### PR TITLE
Film equivalence job uses RT content not PA.

### DIFF
--- a/src/main/java/org/atlasapi/equiv/update/tasks/FilmEquivalenceUpdateTask.java
+++ b/src/main/java/org/atlasapi/equiv/update/tasks/FilmEquivalenceUpdateTask.java
@@ -1,6 +1,6 @@
 package org.atlasapi.equiv.update.tasks;
 
-import static org.atlasapi.media.entity.Publisher.PA;
+import static org.atlasapi.media.entity.Publisher.RADIO_TIMES;
 import static org.atlasapi.persistence.content.ContentCategory.TOP_LEVEL_ITEM;
 import static org.atlasapi.persistence.content.listing.ContentListingCriteria.defaultCriteria;
 
@@ -32,7 +32,7 @@ public class FilmEquivalenceUpdateTask extends AbstractContentEquivalenceUpdateT
 
     @Override
     protected Iterator<Film> getContentIterator(ContentListingProgress progress) {
-        Iterator<Content> lister = contentLister.listContent(defaultCriteria().forContent(TOP_LEVEL_ITEM).forPublisher(PA).startingAt(progress).build());
+        Iterator<Content> lister = contentLister.listContent(defaultCriteria().forContent(TOP_LEVEL_ITEM).forPublisher(RADIO_TIMES).startingAt(progress).build());
         return Iterators.filter(lister, Film.class);
     }
 


### PR DESCRIPTION
Many PN Films are not yet present in PA data since they haven't yet been
broadcast. Previously this wasn't a problem as RT Films were written
where PA Films would appear (i.e. they shared the same URI). This
changes the Film Equivalence job to iterate over RT Films rather than
PA. This will create equivalences from RT -> PN. Equivalences from RT ->
PA already exist through the main equivalence job so the final
transitive equivalent set should be unchanged where all three Films
exist.