### PR TITLE
Change identification and resolution of PA Films.

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/pa/PaHelper.java
+++ b/src/main/java/org/atlasapi/remotesite/pa/PaHelper.java
@@ -6,7 +6,11 @@ public class PaHelper {
     private static final String PA_BASE_URL = "http://pressassociation.com";
     
     public static String getFilmUri(String id) {
-        return PA_BASE_URL + "/films/" + id;
+        return getEpisodeUri(id);
+    }
+    
+    public static String getFilmRtAlias(String rtFilmNumber) {
+        return PA_BASE_URL + "/films/" + rtFilmNumber;
     }
     
     public static String getEpisodeUri(String id) {
@@ -21,8 +25,8 @@ public class PaHelper {
         return PA_BASE_URL + "/series/" + id + "-" + seriesNumber;
     }
     
-    public static String getFilmCurie(String id) {
-        return "pa:f-" + id;
+    public static String getEpisodeCurie(String id) {
+        return "pa:e-" + id;
     }
     
     public static String getBroadcastId(String slotId) {

--- a/src/main/java/org/atlasapi/remotesite/pa/PaProgrammeProcessor.java
+++ b/src/main/java/org/atlasapi/remotesite/pa/PaProgrammeProcessor.java
@@ -12,6 +12,7 @@ import org.atlasapi.media.channel.ChannelResolver;
 import org.atlasapi.media.entity.Actor;
 import org.atlasapi.media.entity.Brand;
 import org.atlasapi.media.entity.Broadcast;
+import org.atlasapi.media.entity.Certificate;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.CrewMember;
 import org.atlasapi.media.entity.Episode;
@@ -27,6 +28,7 @@ import org.atlasapi.media.entity.Version;
 import org.atlasapi.media.util.ItemAndBroadcast;
 import org.atlasapi.persistence.content.ContentResolver;
 import org.atlasapi.persistence.content.ContentWriter;
+import org.atlasapi.persistence.content.ResolvedContent;
 import org.atlasapi.persistence.content.people.ItemsPeopleWriter;
 import org.atlasapi.persistence.logging.AdapterLog;
 import org.atlasapi.persistence.logging.AdapterLogEntry;
@@ -52,6 +54,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.inject.internal.Sets;
 import com.metabroadcast.common.base.Maybe;
+import com.metabroadcast.common.intl.Countries;
 import com.metabroadcast.common.text.MoreStrings;
 import com.metabroadcast.common.time.Timestamp;
 
@@ -320,12 +323,15 @@ public class PaProgrammeProcessor implements PaProgDataProcessor {
     }
     
     private Maybe<ItemAndBroadcast> getFilm(ProgData progData, Channel channel, DateTimeZone zone, Timestamp updatedAt) {
+        String rtFilmAlias = PaHelper.getFilmRtAlias(progData.getRtFilmnumber());
         String filmUri = PaHelper.getFilmUri(programmeId(progData));
-        Maybe<Identified> possiblePreviousData = contentResolver.findByCanonicalUris(ImmutableList.of(filmUri)).getFirstValue();
+        ResolvedContent possiblePreviousData = contentResolver.findByCanonicalUris(ImmutableList.of(rtFilmAlias, filmUri));
         
         Film film;
-        if (possiblePreviousData.hasValue()) {
-        	Identified previous = possiblePreviousData.requireValue();
+        Maybe<Identified> oldFilm = possiblePreviousData.get(rtFilmAlias);
+        Maybe<Identified> newFilm = possiblePreviousData.get(filmUri);
+        if (oldFilm.hasValue()) {
+        	Identified previous = oldFilm.requireValue();
             if (previous instanceof Film) {
                 film = (Film) previous;
             }
@@ -333,8 +339,25 @@ public class PaProgrammeProcessor implements PaProgDataProcessor {
                 film = new Film();
                 Item.copyTo((Episode) previous, film);
             }
+            film.addAlias(filmUri);
+        } else if (newFilm.hasValue()) {
+            Identified previous = newFilm.requireValue();
+            if (previous instanceof Film) {
+                film = (Film) previous;
+            }
+            else {
+                film = new Film();
+                Item.copyTo((Episode) previous, film);
+            }
+            film.addAlias(rtFilmAlias);
         } else {
             film = getBasicFilm(progData);
+        }
+
+        String certificateValue = progData.getCertificate();
+        if (!Strings.isNullOrEmpty(certificateValue)) {
+            Certificate certificate = new Certificate(certificateValue, Countries.GB);
+            film.setCertificates(ImmutableSet.of(certificate));
         }
         
         Broadcast broadcast = setCommonDetails(progData, channel, zone, film, updatedAt);
@@ -403,7 +426,7 @@ public class PaProgrammeProcessor implements PaProgDataProcessor {
         episode.setPeople(people(progData));
 
         Version version = findBestVersion(episode.getVersions());
-
+        
         Broadcast broadcast = broadcast(progData, channel, zone, updatedAt);
         addBroadcast(version, broadcast);
         return broadcast;
@@ -582,7 +605,8 @@ public class PaProgrammeProcessor implements PaProgDataProcessor {
     }
     
     private Film getBasicFilm(ProgData progData) {
-        Film film = new Film(PaHelper.getFilmUri(programmeId(progData)), PaHelper.getFilmCurie(programmeId(progData)), Publisher.PA);
+        Film film = new Film(PaHelper.getFilmUri(programmeId(progData)), PaHelper.getEpisodeCurie(programmeId(progData)), Publisher.PA);
+        film.addAlias(PaHelper.getFilmRtAlias(progData.getRtFilmnumber()));
         
         setBasicDetails(progData, film);
         
@@ -622,7 +646,7 @@ public class PaProgrammeProcessor implements PaProgDataProcessor {
     }
     
     protected static String programmeId(ProgData progData) {
-        return ! Strings.isNullOrEmpty(progData.getRtFilmnumber()) ? progData.getRtFilmnumber() : progData.getProgId();
+        return progData.getProgId();
     }
     
     private static Boolean getBooleanValue(String value) {

--- a/src/test/java/org/atlasapi/remotesite/pa/PaProgrammeProcessorTest.java
+++ b/src/test/java/org/atlasapi/remotesite/pa/PaProgrammeProcessorTest.java
@@ -1,0 +1,158 @@
+package org.atlasapi.remotesite.pa;
+
+import static com.metabroadcast.common.time.DateTimeZones.UTC;
+import static org.atlasapi.media.entity.MediaType.VIDEO;
+import static org.atlasapi.media.entity.Publisher.METABROADCAST;
+import static org.hamcrest.Matchers.any;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.atlasapi.media.channel.Channel;
+import org.atlasapi.media.channel.ChannelResolver;
+import org.atlasapi.media.entity.Film;
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Publisher;
+import org.atlasapi.media.entity.Version;
+import org.atlasapi.persistence.content.ContentResolver;
+import org.atlasapi.persistence.content.ContentWriter;
+import org.atlasapi.persistence.content.ResolvedContent;
+import org.atlasapi.persistence.content.people.ItemsPeopleWriter;
+import org.atlasapi.persistence.logging.AdapterLog;
+import org.atlasapi.persistence.logging.NullAdapterLog;
+import org.atlasapi.remotesite.pa.bindings.ProgData;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+import com.google.common.collect.ImmutableList;
+import com.metabroadcast.common.base.Maybe;
+import com.metabroadcast.common.time.Timestamp;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PaProgrammeProcessorTest {
+
+    private final ContentWriter contentWriter = mock(ContentWriter.class);
+    private final ContentResolver contentResolver = mock(ContentResolver.class);
+    private final ChannelResolver channelResolver = mock(ChannelResolver.class);
+    private final ItemsPeopleWriter itemsPeopleWriter = mock(ItemsPeopleWriter.class);
+    private final AdapterLog log = new NullAdapterLog();
+    
+    private PaProgrammeProcessor progProcessor;
+    
+    @Before
+    public void setup() {
+        when(channelResolver.fromUri(argThat(any(String.class)))).then(new Answer<Maybe<Channel>>() {
+            @Override
+            public Maybe<Channel> answer(InvocationOnMock invocation) throws Throwable {
+                String input = (String)invocation.getArguments()[0];
+                return Maybe.just(new Channel(METABROADCAST, input, input, VIDEO, input));
+            }
+        });
+        progProcessor = new PaProgrammeProcessor(contentWriter, contentResolver, channelResolver, itemsPeopleWriter, log);
+    }
+    
+    @Test
+    public void testExtractsNewFilmWithEpisodeUri() {
+        Channel channel = new Channel(METABROADCAST, "c", "c", VIDEO, "c");
+        ProgData progData = new ProgData();
+        progData.setProgId("1");
+        progData.setRtFilmnumber("5");
+        progData.setDuration("1");
+        progData.setDate("06/08/2012");
+        progData.setTime("11:40");
+        when(contentResolver.findByCanonicalUris(ImmutableList.of(
+            "http://pressassociation.com/films/5",
+            "http://pressassociation.com/episodes/1"
+        ))).thenReturn(ResolvedContent.builder().build());
+        
+        progProcessor.process(progData, channel, UTC, Timestamp.of(0));
+
+        ArgumentCaptor<Item> argCaptor = ArgumentCaptor.forClass(Item.class);
+        verify(contentWriter).createOrUpdate(argCaptor.capture());
+        
+        Item written = argCaptor.getValue();
+        
+        assertThat(written.getCanonicalUri(), is("http://pressassociation.com/episodes/1"));
+        assertThat(written.getCurie(), is("pa:e-1"));
+        assertThat(written.getAliases(), hasItem("http://pressassociation.com/films/5"));
+        
+    }
+    
+    @Test
+    public void testAddsEpisodesAliasForFilmWithRtFilmNumberUri() {
+        Channel channel = new Channel(METABROADCAST, "c", "c", VIDEO, "c");
+        ProgData progData = new ProgData();
+        progData.setProgId("1");
+        progData.setRtFilmnumber("5");
+        progData.setDuration("1");
+        progData.setDate("06/08/2012");
+        progData.setTime("11:40");
+        
+        Film film = new Film("http://pressassociation.com/films/5", "pa:f-5", Publisher.PA);
+        Version version = new Version();
+        version.setProvider(Publisher.PA);
+        film.addVersion(version);
+        
+        when(contentResolver.findByCanonicalUris(ImmutableList.of(
+            "http://pressassociation.com/films/5",
+            "http://pressassociation.com/episodes/1"
+        ))).thenReturn(ResolvedContent.builder()
+            .put("http://pressassociation.com/films/5", film)
+            .build() 
+        );
+        
+        progProcessor.process(progData, channel, UTC, Timestamp.of(0));
+
+        ArgumentCaptor<Item> argCaptor = ArgumentCaptor.forClass(Item.class);
+        verify(contentWriter).createOrUpdate(argCaptor.capture());
+        
+        Item written = argCaptor.getValue();
+        
+        assertThat(written.getAliases(), hasItem("http://pressassociation.com/episodes/1"));
+        
+    }
+
+    @Test
+    public void testAddsRtFilmNumberAliasForFilmWithEpisodesUri() {
+        Channel channel = new Channel(METABROADCAST, "c", "c", VIDEO, "c");
+        ProgData progData = new ProgData();
+        progData.setProgId("1");
+        progData.setRtFilmnumber("5");
+        progData.setDuration("1");
+        progData.setDate("06/08/2012");
+        progData.setTime("11:40");
+        
+        Film film = new Film("http://pressassociation.com/episodes/1", "pa:e-1", Publisher.PA);
+        Version version = new Version();
+        version.setProvider(Publisher.PA);
+        film.addVersion(version);
+        
+        when(contentResolver.findByCanonicalUris(ImmutableList.of(
+            "http://pressassociation.com/films/5",
+            "http://pressassociation.com/episodes/1"
+        ))).thenReturn(ResolvedContent.builder()
+            .put("http://pressassociation.com/episodes/1", film)
+            .build() 
+        );
+        
+        progProcessor.process(progData, channel, UTC, Timestamp.of(0));
+
+        ArgumentCaptor<Item> argCaptor = ArgumentCaptor.forClass(Item.class);
+        verify(contentWriter).createOrUpdate(argCaptor.capture());
+        
+        Item written = argCaptor.getValue();
+        
+        assertThat(written.getAliases(), hasItem("http://pressassociation.com/films/5"));
+        
+    }
+
+}


### PR DESCRIPTION
Create canonical URIs for Films based on their prodId rather than RT
film number. Resolving existing content uses both URI styles to avoid
creating duplicate content. Aliases of the alternate style is added to
the content.