### PR TITLE
Improve ScheduleController error message when key and source missing

### DIFF
--- a/src/main/java/org/atlasapi/query/v2/ScheduleController.java
+++ b/src/main/java/org/atlasapi/query/v2/ScheduleController.java
@@ -98,6 +98,10 @@ public class ScheduleController extends BaseController<Iterable<ScheduleChannel>
             ApplicationConfiguration appConfig = requestedConfig.valueOrDefault(defaultConfig);
             
             boolean publishersSupplied = !Strings.isNullOrEmpty(publisher);
+            
+            if (!(publishersSupplied || apiKeySupplied)) {
+                throw new IllegalArgumentException("You must supply a publisher or API key");
+            }
 
             Set<Publisher> publishers = getPublishers(publisher, appConfig);
             


### PR DESCRIPTION
It's an error not to provide a publisher or API key to /schedule but
resulting message was "Need precedence enabled" didn't described that
very well. If neither param is supplied then "You must supply a
publisher or API key" is displayed.

If an API key without precedence is supplied without a publishers then
the original message is displayed.