### PR TITLE
Treat a 404 as no content

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodContentGroupUpdater.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodContentGroupUpdater.java
@@ -204,7 +204,7 @@ public class BtVodContentGroupUpdater implements BtVodContentListener {
             
             @Override
             public void init() {
-                ids = portalClient.getProductIdsForGroup(groupId);
+                ids = portalClient.getProductIdsForGroup(groupId).or(ImmutableSet.<String>of());
             }
         };
     }

--- a/src/main/java/org/atlasapi/remotesite/btvod/portal/PortalClient.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/portal/PortalClient.java
@@ -2,8 +2,21 @@ package org.atlasapi.remotesite.btvod.portal;
 
 import java.util.Set;
 
+import com.google.common.base.Optional;
+
 
 public interface PortalClient {
 
-    Set<String> getProductIdsForGroup(String groupId);
+    /**
+     * Provide the members of a given groupId. Will return 
+     * {@link Optional.absent()} in the case of the group not 
+     * being present. The group will not be present in two cases:
+     * 
+     *  1) If the group is not set up
+     *  2) If there are no entries in a valid group
+     * 
+     * @param groupId
+     * @return
+     */
+    Optional<Set<String>> getProductIdsForGroup(String groupId);
 }

--- a/src/test/java/org/atlasapi/remotesite/btvod/portal/XmlPortalClientTest.java
+++ b/src/test/java/org/atlasapi/remotesite/btvod/portal/XmlPortalClientTest.java
@@ -1,5 +1,6 @@
 package org.atlasapi.remotesite.btvod.portal;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -40,7 +41,16 @@ public class XmlPortalClientTest {
     
     @Test
     public void testParseAndPaginate() throws HttpException, Exception {
-        Set<String> productIdsForGroup = client.getProductIdsForGroup("test/all");
+        Set<String> productIdsForGroup = client.getProductIdsForGroup("test/all").get();
         assertTrue(productIdsForGroup.contains("C4_55809"));
+    }
+    
+    @Test
+    // The BT API cannot return an emptyset for a group without 
+    // any content. Instead it returns an HTTP 404 response. We consider
+    // this an expected case, so should return Optional.absent() rather 
+    // than throw an exception due to the group not being found.
+    public void testNotFoundResponse() throws HttpException, Exception {
+        assertFalse(client.getProductIdsForGroup("test/nonexistent").isPresent());
     }
 }


### PR DESCRIPTION
The BT API cannot return an emptyset for a valid,
but empty, group. Therefore we will catch that case
and interpret any 404 as an empty group.