### PR TITLE
Store youview items by pcrid, where available

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/ContentMerger.java
+++ b/src/main/java/org/atlasapi/remotesite/ContentMerger.java
@@ -1,5 +1,7 @@
 package org.atlasapi.remotesite;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -31,6 +33,10 @@ public class ContentMerger {
     private static interface VersionMergeStrategy {
         Item mergeVersions(Item current, Item extracted);
     }
+    
+    static interface AliasMergeStrategy {
+        Item mergeAliases(Item current, Item extracted);
+    }
 
     public static abstract class MergeStrategy {
         private MergeStrategy(){}
@@ -47,16 +53,20 @@ public class ContentMerger {
 
     private final VersionMergeStrategy versionMergeStrategy;
     private final TopicMergeStrategy topicsMergeStrategy;
+    private final AliasMergeStrategy aliasMergeStrategy;
 
-    public ContentMerger(VersionMergeStrategy versionMergeStrategy, TopicMergeStrategy topicsMergeStrategy) {
-        this.versionMergeStrategy = versionMergeStrategy;
-        this.topicsMergeStrategy = topicsMergeStrategy;
+    public ContentMerger(VersionMergeStrategy versionMergeStrategy, TopicMergeStrategy topicsMergeStrategy, 
+            AliasMergeStrategy aliasMergeStrategy) {
+        this.versionMergeStrategy = checkNotNull(versionMergeStrategy);
+        this.topicsMergeStrategy = checkNotNull(topicsMergeStrategy);
+        this.aliasMergeStrategy = checkNotNull(aliasMergeStrategy);
     }
 
     public Item merge(Item current, Item extracted) {
 
         current = versionMergeStrategy.mergeVersions(current, extracted);
         current = topicsMergeStrategy.mergeTopics(current, extracted);
+        current = aliasMergeStrategy.mergeAliases(current, extracted);
         current = mergeContents(current, extracted);
 
         if ( current.getContainer() == null
@@ -122,8 +132,6 @@ public class ContentMerger {
 
     private <C extends Content> C mergeContents(C current, C extracted) {
         current.setActivelyPublished(extracted.isActivelyPublished());
-        current.setAliasUrls(extracted.getAliasUrls());
-        current.setAliases(extracted.getAliases());
         current.setTitle(extracted.getTitle());
         current.setDescription(extracted.getDescription());
         current.setShortDescription(extracted.getShortDescription());
@@ -170,7 +178,7 @@ public class ContentMerger {
         }
     }
 
-    private static class LeaveEverythingAlone extends MergeStrategy implements TopicMergeStrategy, VersionMergeStrategy {
+    private static class LeaveEverythingAlone extends MergeStrategy implements TopicMergeStrategy, VersionMergeStrategy, AliasMergeStrategy {
         @Override
         public Item mergeTopics(Item current, Item extracted) {
             return current;
@@ -180,9 +188,15 @@ public class ContentMerger {
         public Item mergeVersions(Item current, Item extracted) {
             return current;
         }
+
+        @Override
+        public Item mergeAliases(Item current, Item extracted) {
+            return current;
+        }
+        
     }
 
-    private static class ReplaceEverything extends MergeStrategy implements TopicMergeStrategy, VersionMergeStrategy {
+    private static class ReplaceEverything extends MergeStrategy implements TopicMergeStrategy, VersionMergeStrategy, AliasMergeStrategy {
         @Override
         public Item mergeTopics(Item current, Item extracted) {
             current.setTopicRefs(extracted.getTopicRefs());
@@ -194,9 +208,16 @@ public class ContentMerger {
             current.setVersions(extracted.getVersions());
             return current;
         }
+
+        @Override
+        public Item mergeAliases(Item current, Item extracted) {
+            current.setAliases(extracted.getAliases());
+            current.setAliasUrls(extracted.getAliasUrls());
+            return current;
+        }
     }
 
-    private static class StandardMerge extends MergeStrategy implements VersionMergeStrategy {
+    private static class StandardMerge extends MergeStrategy implements VersionMergeStrategy, AliasMergeStrategy {
         @Override
         public Item mergeVersions(Item current, Item extracted) {
             Map<String, Version> mergedVersions = Maps.newHashMap();
@@ -220,6 +241,13 @@ public class ContentMerger {
                 }
             }
             current.setVersions(Sets.newHashSet(mergedVersions.values()));
+            return current;
+        }
+
+        @Override
+        public Item mergeAliases(Item current, Item extracted) {
+            current.setAliases(Sets.union(current.getAliases(), extracted.getAliases()));
+            current.setAliasUrls(Sets.union(current.getAliasUrls(), extracted.getAliasUrls()));
             return current;
         }
     }

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/LocalOrRemoteNitroFetcher.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/LocalOrRemoteNitroFetcher.java
@@ -51,7 +51,7 @@ public class LocalOrRemoteNitroFetcher {
 
     public LocalOrRemoteNitroFetcher(ContentResolver resolver, NitroContentAdapter contentAdapter, final Clock clock) {
         this(resolver, contentAdapter, 
-                new ContentMerger(MergeStrategy.MERGE, MergeStrategy.KEEP),
+                new ContentMerger(MergeStrategy.MERGE, MergeStrategy.KEEP, MergeStrategy.REPLACE),
                 new Predicate<Item>() {
 
                     @Override
@@ -104,7 +104,7 @@ public class LocalOrRemoteNitroFetcher {
     
     public LocalOrRemoteNitroFetcher(ContentResolver resolver, NitroContentAdapter contentAdapter, 
             Predicate<Item> fullFetchPermitted) {
-        this(resolver, contentAdapter, new ContentMerger(MergeStrategy.MERGE, MergeStrategy.KEEP), fullFetchPermitted);
+        this(resolver, contentAdapter, new ContentMerger(MergeStrategy.MERGE, MergeStrategy.KEEP, MergeStrategy.REPLACE), fullFetchPermitted);
     }
     
     public LocalOrRemoteNitroFetcher(ContentResolver resolver, NitroContentAdapter contentAdapter, 

--- a/src/main/java/org/atlasapi/remotesite/btfeatured/BtFeaturedContentUpdater.java
+++ b/src/main/java/org/atlasapi/remotesite/btfeatured/BtFeaturedContentUpdater.java
@@ -69,7 +69,7 @@ public class BtFeaturedContentUpdater extends ScheduledTask {
         this.contentWriter = contentWriter;
         this.productBaseUri = productBaseUri;
         this.rootDocumentUri = rootDocumentUri;
-        this.contentMerger = new ContentMerger(MergeStrategy.MERGE, MergeStrategy.KEEP);
+        this.contentMerger = new ContentMerger(MergeStrategy.MERGE, MergeStrategy.KEEP, MergeStrategy.REPLACE);
         
     }
     

--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodBrandWriter.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodBrandWriter.java
@@ -64,7 +64,7 @@ public class BtVodBrandWriter implements BtVodDataProcessor<UpdateProgress> {
         this.resolver = checkNotNull(resolver);
         this.publisher = checkNotNull(publisher);
         this.uriPrefix = checkNotNull(uriPrefix);
-        this.contentMerger = new ContentMerger(MergeStrategy.REPLACE, MergeStrategy.KEEP);
+        this.contentMerger = new ContentMerger(MergeStrategy.REPLACE, MergeStrategy.KEEP, MergeStrategy.REPLACE);
         this.processedRows = checkNotNull(processedRows);
     }
     

--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodItemWriter.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodItemWriter.java
@@ -75,7 +75,7 @@ public class BtVodItemWriter implements BtVodDataProcessor<UpdateProgress> {
         this.seriesExtractor = checkNotNull(seriesExtractor);
         this.publisher = checkNotNull(publisher);
         this.uriPrefix = checkNotNull(uriPrefix);
-        this.contentMerger = new ContentMerger(MergeStrategy.REPLACE, MergeStrategy.KEEP);
+        this.contentMerger = new ContentMerger(MergeStrategy.REPLACE, MergeStrategy.KEEP, MergeStrategy.REPLACE);
         this.processedRows = checkNotNull(processedRows);
         
         FORMATTER.setTimeZone(TimeZone.getTimeZone("UTC"));

--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodSeriesWriter.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodSeriesWriter.java
@@ -56,7 +56,7 @@ public class BtVodSeriesWriter implements BtVodDataProcessor<UpdateProgress>{
         this.publisher = checkNotNull(publisher);
         this.uriPrefix = checkNotNull(uriPrefix);
         this.describedFieldsExtractor = checkNotNull(describedFieldsExtractor);
-        this.contentMerger = new ContentMerger(MergeStrategy.REPLACE, MergeStrategy.KEEP);
+        this.contentMerger = new ContentMerger(MergeStrategy.REPLACE, MergeStrategy.KEEP, MergeStrategy.REPLACE);
     }
     
     @Override

--- a/src/main/java/org/atlasapi/remotesite/five/FiveBrandProcessor.java
+++ b/src/main/java/org/atlasapi/remotesite/five/FiveBrandProcessor.java
@@ -64,7 +64,7 @@ public class FiveBrandProcessor {
         this.contentResolver = checkNotNull(contentResolver);
         this.episodeProcessor = new FiveEpisodeProcessor(baseApiUrl, httpClient, 
                 channelMap, locationPolicyIds);
-        this.contentMerger = new ContentMerger(MergeStrategy.REPLACE, MergeStrategy.KEEP);
+        this.contentMerger = new ContentMerger(MergeStrategy.REPLACE, MergeStrategy.KEEP, MergeStrategy.REPLACE);
     }
 
     public void processShow(Element element) {

--- a/src/main/java/org/atlasapi/remotesite/getty/DefaultGettyDataHandler.java
+++ b/src/main/java/org/atlasapi/remotesite/getty/DefaultGettyDataHandler.java
@@ -26,7 +26,7 @@ public class DefaultGettyDataHandler implements GettyDataHandler {
         this.resolver = checkNotNull(resolver);
         this.writer = checkNotNull(writer);
         this.extractor = checkNotNull(extractor);
-        this.contentMerger = new ContentMerger(MergeStrategy.MERGE, MergeStrategy.REPLACE);
+        this.contentMerger = new ContentMerger(MergeStrategy.MERGE, MergeStrategy.REPLACE, MergeStrategy.MERGE);
     }
 
     @Override

--- a/src/main/java/org/atlasapi/remotesite/itv/whatson/ItvWhatsOnEntryProcessor.java
+++ b/src/main/java/org/atlasapi/remotesite/itv/whatson/ItvWhatsOnEntryProcessor.java
@@ -31,7 +31,7 @@ public class ItvWhatsOnEntryProcessor {
                 locationPolicyIds);
         this.contentResolver = contentResolver;
         this.contentWriter = contentWriter;
-        this.contentMerger = new ContentMerger(MergeStrategy.MERGE, MergeStrategy.KEEP);
+        this.contentMerger = new ContentMerger(MergeStrategy.MERGE, MergeStrategy.KEEP, MergeStrategy.REPLACE);
     }
     
     private Content createOrUpdate(Content content) {

--- a/src/main/java/org/atlasapi/remotesite/knowledgemotion/DefaultKnowledgeMotionDataRowHandler.java
+++ b/src/main/java/org/atlasapi/remotesite/knowledgemotion/DefaultKnowledgeMotionDataRowHandler.java
@@ -27,7 +27,7 @@ public class DefaultKnowledgeMotionDataRowHandler implements KnowledgeMotionData
         this.resolver = checkNotNull(resolver);
         this.writer = checkNotNull(writer);
         this.extractor = checkNotNull(extractor);
-        this.contentMerger = new ContentMerger(MergeStrategy.MERGE, MergeStrategy.REPLACE);
+        this.contentMerger = new ContentMerger(MergeStrategy.MERGE, MergeStrategy.REPLACE, MergeStrategy.REPLACE);
     }
 
     @Override

--- a/src/main/java/org/atlasapi/remotesite/lovefilm/DefaultLoveFilmDataRowHandler.java
+++ b/src/main/java/org/atlasapi/remotesite/lovefilm/DefaultLoveFilmDataRowHandler.java
@@ -112,7 +112,7 @@ public class DefaultLoveFilmDataRowHandler implements LoveFilmDataRowHandler {
         this.lister = lister;
         this.extractor = extractor;
         this.missingContentPercentage = missingContentPercentage;
-        this.contentMerger = new ContentMerger(MergeStrategy.MERGE, MergeStrategy.KEEP);
+        this.contentMerger = new ContentMerger(MergeStrategy.MERGE, MergeStrategy.KEEP, MergeStrategy.MERGE);
     }
 
     @Override

--- a/src/main/java/org/atlasapi/remotesite/netflix/DefaultNetflixXmlElementHandler.java
+++ b/src/main/java/org/atlasapi/remotesite/netflix/DefaultNetflixXmlElementHandler.java
@@ -43,7 +43,7 @@ public class DefaultNetflixXmlElementHandler implements NetflixXmlElementHandler
         this.extractor = extractor;
         this.resolver = resolver;
         this.writer = writer;
-        this.contentMerger = new ContentMerger(MergeStrategy.MERGE, MergeStrategy.KEEP);
+        this.contentMerger = new ContentMerger(MergeStrategy.MERGE, MergeStrategy.KEEP, MergeStrategy.REPLACE);
     }
 
     @Override

--- a/src/main/java/org/atlasapi/remotesite/rte/RteModule.java
+++ b/src/main/java/org/atlasapi/remotesite/rte/RteModule.java
@@ -41,7 +41,7 @@ public class RteModule {
     @Bean
     public RteFeedProcessor feedProcessor() {
         return new RteFeedProcessor(contentWriter, contentResolver, new ContentMerger(
-                MergeStrategy.MERGE, MergeStrategy.KEEP), brandExtractor());
+                MergeStrategy.MERGE, MergeStrategy.KEEP, MergeStrategy.REPLACE), brandExtractor());
     }
     
     @Bean

--- a/src/main/java/org/atlasapi/remotesite/talktalk/ContentUpdatingTalkTalkVodEntityProcessor.java
+++ b/src/main/java/org/atlasapi/remotesite/talktalk/ContentUpdatingTalkTalkVodEntityProcessor.java
@@ -57,7 +57,7 @@ public class ContentUpdatingTalkTalkVodEntityProcessor implements
         this.resolver = checkNotNull(resolver);
         this.writer = checkNotNull(writer);
         this.itemExtractor = new TalkTalkItemDetailItemExtractor(resolver);
-        this.contentMerger = new ContentMerger(MergeStrategy.MERGE, MergeStrategy.KEEP);
+        this.contentMerger = new ContentMerger(MergeStrategy.MERGE, MergeStrategy.KEEP, MergeStrategy.REPLACE);
     }
 
     private void logProcessing(VODEntityType entity) {

--- a/src/main/java/org/atlasapi/remotesite/youview/DefaultYouViewElementProcessor.java
+++ b/src/main/java/org/atlasapi/remotesite/youview/DefaultYouViewElementProcessor.java
@@ -1,7 +1,9 @@
 package org.atlasapi.remotesite.youview;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import nu.xom.Element;
 
+import org.atlasapi.media.entity.Alias;
 import org.atlasapi.media.entity.Broadcast;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Identified;
@@ -11,9 +13,14 @@ import org.atlasapi.media.entity.ScheduleEntry.ItemRefAndBroadcast;
 import org.atlasapi.media.entity.Version;
 import org.atlasapi.persistence.content.ContentResolver;
 import org.atlasapi.persistence.content.ContentWriter;
+import org.atlasapi.persistence.lookup.entry.LookupEntry;
+import org.atlasapi.persistence.lookup.entry.LookupEntryStore;
 import org.atlasapi.remotesite.ContentMerger;
 import org.atlasapi.remotesite.ContentMerger.MergeStrategy;
 
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.metabroadcast.common.base.Maybe;
@@ -25,17 +32,31 @@ public class DefaultYouViewElementProcessor implements YouViewElementProcessor {
     private final ContentResolver resolver;
     private final ContentWriter writer;
     private final ContentMerger contentMerger;
+    private final LookupEntryStore lookupEntryStore;
+    private final Predicate<Alias> scheduleEventAliasPredicate;
     
-    public DefaultYouViewElementProcessor(YouViewContentExtractor extractor, ContentResolver resolver, ContentWriter writer) {
-        this.extractor = extractor;
-        this.resolver = resolver;
-        this.writer = writer;
-        this.contentMerger = new ContentMerger(MergeStrategy.MERGE, MergeStrategy.KEEP);
+    public DefaultYouViewElementProcessor(YouViewContentExtractor extractor, ContentResolver resolver, 
+            ContentWriter writer, LookupEntryStore lookupEntryStore) {
+        this.extractor = checkNotNull(extractor);
+        this.resolver = checkNotNull(resolver);
+        this.writer = checkNotNull(writer);
+        this.lookupEntryStore = checkNotNull(lookupEntryStore);
+        this.contentMerger = new ContentMerger(MergeStrategy.MERGE, MergeStrategy.KEEP, MergeStrategy.MERGE);
+        final String scheduleEventAliasNamespace = extractor.getScheduleEventAliasNamespace(); 
+        this.scheduleEventAliasPredicate = new Predicate<Alias>() {
+
+            @Override
+            public boolean apply(Alias input) {
+                return input.getNamespace().equals(scheduleEventAliasNamespace);
+            };
+            
+        };
     }
     
     @Override
     public ItemRefAndBroadcast process(Publisher targetPublisher, Element element) {
         Item item = extractor.extract(targetPublisher, element);
+        removeStaleScheduleEventOnOldItems(item);
         Maybe<Identified> existing = resolve(item.getCanonicalUri());
         if (existing.isNothing()) {
             write(item);
@@ -58,5 +79,21 @@ public class DefaultYouViewElementProcessor implements YouViewElementProcessor {
 
     private void write(Content content) {
         writer.createOrUpdate((Item) content);
+    }
+    
+    private void removeStaleScheduleEventOnOldItems(Item item) {
+        final String scheduleEventAliasNamespace = extractor.getScheduleEventAliasNamespace();
+        Optional<Alias> scheduleEventAlias = Iterables.tryFind(item.getAliases(), scheduleEventAliasPredicate);
+        Iterable<LookupEntry> entries = lookupEntryStore.entriesForAliases(Optional.of(scheduleEventAliasNamespace), 
+                ImmutableSet.of(scheduleEventAlias.get().getValue()));
+        for (LookupEntry entry : entries) {
+            if (entry.uri().equals(item.getCanonicalUri())) {
+                continue;
+            } else {
+                Identified ided = resolver.findByCanonicalUris(ImmutableSet.of(entry.uri())).getFirstValue().requireValue();
+                ided.setAliases(Iterables.filter(ided.getAliases(), Predicates.not(scheduleEventAliasPredicate)));
+                writer.createOrUpdate((Item)ided);
+            }
+        }
     }
 }

--- a/src/main/java/org/atlasapi/remotesite/youview/DefaultYouViewXmlElementHandler.java
+++ b/src/main/java/org/atlasapi/remotesite/youview/DefaultYouViewXmlElementHandler.java
@@ -25,7 +25,7 @@ public class DefaultYouViewXmlElementHandler implements YouViewXmlElementHandler
         this.extractor = extractor;
         this.resolver = resolver;
         this.writer = writer;
-        this.contentMerger = new ContentMerger(MergeStrategy.MERGE, MergeStrategy.KEEP);
+        this.contentMerger = new ContentMerger(MergeStrategy.MERGE, MergeStrategy.KEEP, MergeStrategy.REPLACE);
     }
     
     @Override

--- a/src/test/java/org/atlasapi/remotesite/rte/RteFeedProcessorTest.java
+++ b/src/test/java/org/atlasapi/remotesite/rte/RteFeedProcessorTest.java
@@ -53,7 +53,7 @@ public class RteFeedProcessorTest {
         processor = new RteFeedProcessor(
                 contentWriter,
                 new DummyContentResolver(),
-                new ContentMerger(MergeStrategy.MERGE, MergeStrategy.KEEP),
+                new ContentMerger(MergeStrategy.MERGE, MergeStrategy.KEEP, MergeStrategy.REPLACE),
                 new RteBrandExtractor());
     }
     

--- a/src/test/java/org/atlasapi/remotesite/youview/DefaultYouViewElementProcessorTest.java
+++ b/src/test/java/org/atlasapi/remotesite/youview/DefaultYouViewElementProcessorTest.java
@@ -1,0 +1,104 @@
+package org.atlasapi.remotesite.youview;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import nu.xom.Element;
+
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Publisher;
+import org.atlasapi.media.entity.Alias;
+import org.atlasapi.media.entity.testing.ComplexBroadcastTestDataBuilder;
+import org.atlasapi.media.entity.testing.ComplexItemTestDataBuilder;
+import org.atlasapi.media.entity.testing.VersionTestDataBuilder;
+import org.atlasapi.persistence.content.ContentResolver;
+import org.atlasapi.persistence.content.ContentWriter;
+import org.atlasapi.persistence.content.ResolvedContent.ResolvedContentBuilder;
+import org.atlasapi.persistence.lookup.entry.LookupEntry;
+import org.atlasapi.persistence.lookup.entry.LookupEntryStore;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableSet;
+
+@RunWith( MockitoJUnitRunner.class )
+public class DefaultYouViewElementProcessorTest {
+
+    private static final String ALIAS_NAMESPACE = "namespace";
+    private static final String ALIAS_VALUE = "12345";
+    private @Mock ContentResolver contentResolver;
+    private @Mock ContentWriter contentWriter;
+    private @Mock LookupEntryStore lookupEntryStore;
+    private @Mock YouViewContentExtractor extractor;
+    
+    private DefaultYouViewElementProcessor elementProcessor;
+    
+    @Before
+    public void setUp() {
+        when(extractor.getScheduleEventAliasNamespace())
+            .thenReturn(ALIAS_NAMESPACE);
+        elementProcessor = new DefaultYouViewElementProcessor(extractor, contentResolver, contentWriter, lookupEntryStore);
+    }
+    
+    @Test
+    public void testStaleScheduleEventAliasIsRemoved() {
+        
+        Item extractedItem = ComplexItemTestDataBuilder
+                        .complexItem()
+                        .withUri("http://example.org/a")
+                        .withVersions(
+                                VersionTestDataBuilder
+                                    .version()
+                                    .withBroadcasts(
+                                            ComplexBroadcastTestDataBuilder
+                                                .broadcast()
+                                                .build()
+                                            )
+                                    .build())
+                        .withAliases(new Alias(ALIAS_NAMESPACE, ALIAS_VALUE))
+                        .build();
+        
+        
+        
+        Item itemWithStaleAlias = ComplexItemTestDataBuilder
+                .complexItem()
+                .withUri("http://example.org/b")
+                .withAliases(new Alias(ALIAS_NAMESPACE, ALIAS_VALUE))
+                .build();
+        
+        Item resolvedItem = ComplexItemTestDataBuilder
+                .complexItem()
+                .withUri(extractedItem.getCanonicalUri())
+                .withAliases(new Alias(ALIAS_NAMESPACE, ALIAS_VALUE))
+                .build();
+        
+        when(extractor.extract(any(Publisher.class), any(Element.class)))
+            .thenReturn(extractedItem);
+        
+        when(contentResolver.findByCanonicalUris(ImmutableSet.of(resolvedItem.getCanonicalUri())))
+            .thenReturn(new ResolvedContentBuilder().put(resolvedItem.getCanonicalUri(), resolvedItem).build());
+        
+        when(contentResolver.findByCanonicalUris(ImmutableSet.of(itemWithStaleAlias.getCanonicalUri())))
+            .thenReturn(new ResolvedContentBuilder().put(itemWithStaleAlias.getCanonicalUri(), itemWithStaleAlias).build());
+        
+        when(lookupEntryStore.entriesForAliases(Optional.of(ALIAS_NAMESPACE), ImmutableSet.of(ALIAS_VALUE)))
+            .thenReturn(ImmutableSet.of(LookupEntry.lookupEntryFrom(itemWithStaleAlias)));
+        
+        ArgumentCaptor<Item> itemCaptor = ArgumentCaptor.forClass(Item.class);
+        
+        elementProcessor.process(Publisher.METABROADCAST, new Element("test"));
+        
+        verify(contentWriter, times(2)).createOrUpdate(itemCaptor.capture());
+        
+        Item firstSavedItem = itemCaptor.getAllValues().get(0);
+        assertEquals(itemWithStaleAlias.getCanonicalUri(), firstSavedItem.getCanonicalUri());
+        assertEquals(0, firstSavedItem.getAliases().size());
+    }
+}


### PR DESCRIPTION
This reduces, greatly, the number of items where they're
repeated on regional variants.