### PR TITLE
Create Publisher rather that use the field from result which is not yet ...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -543,7 +543,7 @@
        <dependency>
           <groupId>com.metabroadcast.atlas.glycerin</groupId>
           <artifactId>glycerin</artifactId>
-          <version>0.1.11</version>
+          <version>0.1.12</version>
        </dependency>
        <dependency>
            <groupId>com.google.http-client</groupId>

--- a/src/main/java/org/atlasapi/input/BrandModelTransformer.java
+++ b/src/main/java/org/atlasapi/input/BrandModelTransformer.java
@@ -4,12 +4,11 @@ import org.atlasapi.media.entity.Brand;
 import org.atlasapi.media.entity.simple.Playlist;
 import org.atlasapi.persistence.lookup.entry.LookupEntryStore;
 import org.atlasapi.persistence.topic.TopicStore;
-import org.joda.time.DateTime;
 
 import com.metabroadcast.common.ids.NumberToShortStringCodec;
 import com.metabroadcast.common.time.Clock;
 
-public class BrandModelTransformer extends ContentModelTransformer<org.atlasapi.media.entity.simple.Playlist, Brand> {
+public class BrandModelTransformer extends ContentModelTransformer<Playlist, Brand> {
 
 	public BrandModelTransformer(LookupEntryStore lookupStore, 
 			TopicStore topicStore, NumberToShortStringCodec idCodec, 
@@ -18,8 +17,7 @@ public class BrandModelTransformer extends ContentModelTransformer<org.atlasapi.
 	}
 
 	@Override
-	protected Brand createContentOutput(Playlist input, DateTime now) {
+	protected Brand createOutput(Playlist simple) {
 		return new Brand();
 	}
-
 }

--- a/src/main/java/org/atlasapi/input/ClipModelTransformer.java
+++ b/src/main/java/org/atlasapi/input/ClipModelTransformer.java
@@ -17,9 +17,15 @@ public class ClipModelTransformer extends ItemModelTransformer  {
     }
 
     @Override
-    protected Item createContentOutput(org.atlasapi.media.entity.simple.Item inputItem, DateTime now) {
-        Item item = new Clip();
-        item.setLastUpdated(now);
-        return setItemFields(item, inputItem, now);
+    protected Item createOutput(org.atlasapi.media.entity.simple.Item inputItem) {
+        return new Clip();
+    }
+
+    @Override
+    protected Item setFields(Item result, org.atlasapi.media.entity.simple.Item inputItem) {
+        super.setFields(result, inputItem);
+        DateTime now = this.clock.now();
+        result.setLastUpdated(now);
+        return result;
     }
 }

--- a/src/main/java/org/atlasapi/input/ContentModelTransformer.java
+++ b/src/main/java/org/atlasapi/input/ContentModelTransformer.java
@@ -99,7 +99,13 @@ public abstract class ContentModelTransformer<F extends Description,T extends Co
     protected abstract T createContentOutput(F simple, DateTime now);
 
     private T setContentFields(T result, Description inputContent) {
-        result.setPeople(transformPeople(inputContent.getPeople(), result.getPublisher()));
+        result.setPeople(
+                transformPeople(
+                        inputContent.getPeople(),
+                        this.getPublisher(inputContent.getPublisher()
+                        )
+                )
+        );
         result.setTopicRefs(topicRefs(inputContent.getTopics()));
         result.setKeyPhrases(keyPhrases(inputContent.getKeyPhrases(), inputContent.getPublisher()));
         result.setGenres(inputContent.getGenres());

--- a/src/main/java/org/atlasapi/input/ContentModelTransformer.java
+++ b/src/main/java/org/atlasapi/input/ContentModelTransformer.java
@@ -25,7 +25,6 @@ import org.atlasapi.media.entity.simple.SameAs;
 import org.atlasapi.persistence.lookup.entry.LookupEntry;
 import org.atlasapi.persistence.lookup.entry.LookupEntryStore;
 import org.atlasapi.persistence.topic.TopicStore;
-import org.joda.time.DateTime;
 
 import com.google.common.base.Function;
 import com.google.common.base.Objects;
@@ -90,22 +89,11 @@ public abstract class ContentModelTransformer<F extends Description,T extends Co
         this.idCodec = idCodec;
         this.clock = clock;
     }
-    
-    @Override
-    protected final T createDescribedOutput(F simple, DateTime now) {
-        return setContentFields(createContentOutput(simple, now), simple);
-    }
-    
-    protected abstract T createContentOutput(F simple, DateTime now);
 
-    private T setContentFields(T result, Description inputContent) {
-        result.setPeople(
-                transformPeople(
-                        inputContent.getPeople(),
-                        this.getPublisher(inputContent.getPublisher()
-                        )
-                )
-        );
+    @Override
+    protected T setFields(T result, F inputContent) {
+        super.setFields(result, inputContent);
+        result.setPeople(transformPeople(inputContent.getPeople(), result.getPublisher()));
         result.setTopicRefs(topicRefs(inputContent.getTopics()));
         result.setKeyPhrases(keyPhrases(inputContent.getKeyPhrases(), inputContent.getPublisher()));
         result.setGenres(inputContent.getGenres());

--- a/src/main/java/org/atlasapi/input/DescribedModelTransformer.java
+++ b/src/main/java/org/atlasapi/input/DescribedModelTransformer.java
@@ -34,10 +34,15 @@ public abstract class DescribedModelTransformer<F extends Description,T extends 
 
     @Override
     protected final T createIdentifiedOutput(F simple, DateTime now) {
-        return setDescriptionFields(createDescribedOutput(simple, now), simple);
+        T result = createOutput(simple);
+        return setFields(result, simple);
+
     }
 
-    private T setDescriptionFields(T result, F inputContent) {
+    protected abstract T createOutput(F simple);
+
+
+    protected T setFields(T result, F inputContent) {
         Publisher publisher = getPublisher(inputContent.getPublisher());
         result.setPublisher(publisher);
         result.setTitle(inputContent.getTitle());
@@ -124,7 +129,4 @@ public abstract class DescribedModelTransformer<F extends Description,T extends 
         }
         return possiblePublisher.requireValue();
     }
-
-    protected abstract T createDescribedOutput(F simple, DateTime now);
-
 }

--- a/src/main/java/org/atlasapi/input/ItemModelTransformer.java
+++ b/src/main/java/org/atlasapi/input/ItemModelTransformer.java
@@ -55,7 +55,8 @@ public class ItemModelTransformer extends ContentModelTransformer<org.atlasapi.m
     }
 
     @Override
-    protected Item createContentOutput(org.atlasapi.media.entity.simple.Item inputItem, DateTime now) {
+    protected Item createOutput(org.atlasapi.media.entity.simple.Item inputItem) {
+        DateTime now = this.clock.now();
         String type = inputItem.getType();
         Item item;
         if ("episode".equals(type)) {
@@ -71,7 +72,7 @@ public class ItemModelTransformer extends ContentModelTransformer<org.atlasapi.m
             item = new Item();
         }
         item.setLastUpdated(now);
-        return setItemFields(item, inputItem, now);
+        return item;
     }
 
     private Item createBroadcast(org.atlasapi.media.entity.simple.Item inputItem) {
@@ -104,7 +105,10 @@ public class ItemModelTransformer extends ContentModelTransformer<org.atlasapi.m
         return episode;
     }
 
-    protected Item setItemFields(Item item, org.atlasapi.media.entity.simple.Item inputItem, DateTime now) {
+    @Override
+    protected Item setFields(Item item, org.atlasapi.media.entity.simple.Item inputItem) {
+        super.setFields(item, inputItem);
+        DateTime now = this.clock.now();
         Set<Encoding> encodings = encodingsFrom(inputItem.getLocations(), now);
         if (!encodings.isEmpty()) {
             Version version = new Version();

--- a/src/main/java/org/atlasapi/input/PersonModelTransformer.java
+++ b/src/main/java/org/atlasapi/input/PersonModelTransformer.java
@@ -6,7 +6,6 @@ import org.atlasapi.media.entity.LookupRef;
 import org.atlasapi.media.entity.simple.Person;
 import org.atlasapi.media.entity.simple.SameAs;
 import org.atlasapi.persistence.content.PeopleResolver;
-import org.joda.time.DateTime;
 
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
@@ -24,9 +23,17 @@ public class PersonModelTransformer extends DescribedModelTransformer<Person, or
     }
     
     @Override
-    protected org.atlasapi.media.entity.Person createDescribedOutput(Person simple, DateTime now) {
-        org.atlasapi.media.entity.Person person = new org.atlasapi.media.entity.Person();
+    protected org.atlasapi.media.entity.Person createOutput(Person simple) {
+        return new org.atlasapi.media.entity.Person();
         
+    }
+
+    @Override
+    protected org.atlasapi.media.entity.Person setFields(
+            org.atlasapi.media.entity.Person person,
+            Person simple
+    ) {
+        super.setFields(person, simple);
         person.setGivenName(simple.getGivenName());
         person.setFamilyName(simple.getFamilyName());
         person.withName(simple.getName());
@@ -36,7 +43,7 @@ public class PersonModelTransformer extends DescribedModelTransformer<Person, or
         if (simple.getQuotes() != null) {
             person.setQuotes(simple.getQuotes());
         }
-        
+
         return person;
     }
     

--- a/src/main/java/org/atlasapi/input/SeriesModelTransformer.java
+++ b/src/main/java/org/atlasapi/input/SeriesModelTransformer.java
@@ -21,7 +21,8 @@ public class SeriesModelTransformer extends ContentModelTransformer<Playlist, Se
         super(lookupStore, topicStore, idCodec, clipsModelTransformer, clock);
     }
 
-    @Override protected Series createContentOutput(Playlist simple, DateTime now) {
+    @Override
+    protected Series createOutput(Playlist simple) {
         checkNotNull(simple.getUri(),
                 "Cannot create a Series from simple Item without URI");
         checkNotNull(simple.getPublisher(),
@@ -34,8 +35,15 @@ public class SeriesModelTransformer extends ContentModelTransformer<Playlist, Se
                 simple.getCurie(),
                 Publisher.fromKey(simple.getPublisher().getKey()).requireValue()
         );
-        series.setTotalEpisodes(simple.getTotalEpisodes());
-        series.withSeriesNumber(simple.getSeriesNumber());
         return series;
+
+    }
+
+    @Override
+    protected Series setFields(Series result, Playlist simple) {
+        super.setFields(result, simple);
+        result.setTotalEpisodes(simple.getTotalEpisodes());
+        result.withSeriesNumber(simple.getSeriesNumber());
+        return result;
     }
 }

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/BbcNitroModule.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/BbcNitroModule.java
@@ -14,6 +14,7 @@ import org.atlasapi.media.entity.ScheduleEntry.ItemRefAndBroadcast;
 import org.atlasapi.persistence.content.ContentResolver;
 import org.atlasapi.persistence.content.ContentWriter;
 import org.atlasapi.persistence.content.ScheduleResolver;
+import org.atlasapi.persistence.content.people.QueuingPersonWriter;
 import org.atlasapi.persistence.content.schedule.mongo.ScheduleWriter;
 import org.atlasapi.remotesite.bbc.ion.BbcIonServices;
 import org.atlasapi.remotesite.bbc.nitro.v1.HttpNitroClient;
@@ -68,6 +69,7 @@ public class BbcNitroModule {
     private @Autowired ScheduleResolver scheduleResolver;
     private @Autowired ScheduleWriter scheduleWriter;
     private @Autowired ChannelResolver channelResolver;
+    private @Autowired QueuingPersonWriter peopleWriter;
     
     private final ThreadFactory nitroThreadFactory
         = new ThreadFactoryBuilder().setNameFormat("nitro %s").build();
@@ -150,7 +152,7 @@ public class BbcNitroModule {
     
 
     GlycerinNitroContentAdapter nitroContentAdapter(Glycerin glycerin) {
-        return new GlycerinNitroContentAdapter(glycerin, nitroClient(), new SystemClock(), nitroRequestPageSize);
+        return new GlycerinNitroContentAdapter(glycerin, nitroClient(), peopleWriter, new SystemClock(), nitroRequestPageSize);
     }
 
     private Supplier<Range<LocalDate>> dayRangeSupplier(int back, int forward) {

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/GlycerinNitroContentAdapter.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/GlycerinNitroContentAdapter.java
@@ -2,6 +2,7 @@ package org.atlasapi.remotesite.bbc.nitro;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.metabroadcast.atlas.glycerin.queries.ProgrammesMixin.PEOPLE;
 import static com.metabroadcast.atlas.glycerin.queries.ProgrammesMixin.TITLES;
 
 import java.util.List;
@@ -10,6 +11,7 @@ import org.atlasapi.media.entity.Brand;
 import org.atlasapi.media.entity.Clip;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Series;
+import org.atlasapi.persistence.content.people.QueuingPersonWriter;
 import org.atlasapi.remotesite.bbc.nitro.extract.NitroBrandExtractor;
 import org.atlasapi.remotesite.bbc.nitro.extract.NitroEpisodeExtractor;
 import org.atlasapi.remotesite.bbc.nitro.extract.NitroItemSource;
@@ -61,14 +63,14 @@ public class GlycerinNitroContentAdapter implements NitroContentAdapter {
     private final NitroEpisodeExtractor itemExtractor;
     private final int pageSize;
     
-    public GlycerinNitroContentAdapter(Glycerin glycerin, NitroClient nitroClient, Clock clock, int pageSize) {
+    public GlycerinNitroContentAdapter(Glycerin glycerin, NitroClient nitroClient, QueuingPersonWriter peopleWriter, Clock clock, int pageSize) {
         this.glycerin = checkNotNull(glycerin);
         this.nitroClient = checkNotNull(nitroClient);
         this.pageSize = pageSize;
         this.clipsAdapter = new GlycerinNitroClipsAdapter(glycerin, clock, pageSize);
         this.brandExtractor = new NitroBrandExtractor(clock);
         this.seriesExtractor = new NitroSeriesExtractor(clock);
-        this.itemExtractor = new NitroEpisodeExtractor(clock);
+        this.itemExtractor = new NitroEpisodeExtractor(clock, peopleWriter);
     }
     
     @Override
@@ -192,9 +194,10 @@ public class GlycerinNitroContentAdapter implements NitroContentAdapter {
     private ImmutableList<Programme> fetchProgrammes(Iterable<PidReference> refs) throws GlycerinException {
         ProgrammesQuery query = ProgrammesQuery.builder()
                 .withPid(toStrings(refs))
-                .withMixins(TITLES)
+                .withMixins(TITLES, PEOPLE)
                 .withPageSize(pageSize)
                 .build();
+        
         return exhaust(glycerin.execute(query));
     }
 

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/BaseNitroItemExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/BaseNitroItemExtractor.java
@@ -25,12 +25,14 @@ import org.joda.time.Duration;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.ImmutableSetMultimap.Builder;
 import com.google.common.collect.Iterables;
 import com.metabroadcast.atlas.glycerin.model.Availability;
+import com.metabroadcast.atlas.glycerin.model.Brand;
 import com.metabroadcast.atlas.glycerin.model.PidReference;
 import com.metabroadcast.atlas.glycerin.model.Programme;
 import com.metabroadcast.atlas.glycerin.model.VersionType;

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroBrandExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroBrandExtractor.java
@@ -40,6 +40,11 @@ public class NitroBrandExtractor
     }
 
     @Override
+    protected Brand.People extractPeople(Brand brand) {
+        return brand.getPeople();
+    }
+
+    @Override
     protected Image extractImage(Brand source) {
         return source.getImage();
     }

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroClipExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroClipExtractor.java
@@ -1,8 +1,9 @@
 package org.atlasapi.remotesite.bbc.nitro.extract;
 
-import com.metabroadcast.atlas.glycerin.model.Clip;
+import com.metabroadcast.atlas.glycerin.model.Brand;
 import com.metabroadcast.atlas.glycerin.model.Brand.Image;
 import com.metabroadcast.atlas.glycerin.model.Brand.MasterBrand;
+import com.metabroadcast.atlas.glycerin.model.Clip;
 import com.metabroadcast.atlas.glycerin.model.Synopses;
 import com.metabroadcast.common.time.Clock;
 
@@ -40,6 +41,11 @@ public class NitroClipExtractor
     @Override
     protected Synopses extractSynopses(NitroItemSource<Clip> source) {
         return source.getProgramme().getSynopses();
+    }
+
+    @Override
+    protected Brand.People extractPeople(NitroItemSource<Clip> source) {
+        return source.getProgramme().getPeople();
     }
 
     @Override

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroContentExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroContentExtractor.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import com.google.api.client.repackaged.com.google.common.base.Strings;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
+import com.metabroadcast.atlas.glycerin.model.Brand;
 import com.metabroadcast.atlas.glycerin.model.Brand.MasterBrand;
 import com.metabroadcast.atlas.glycerin.model.Series;
 import com.metabroadcast.atlas.glycerin.model.Synopses;
@@ -137,14 +138,25 @@ public abstract class NitroContentExtractor<SOURCE, CONTENT extends Content>
     protected abstract @Nullable Synopses extractSynopses(SOURCE source);
     
     /**
-     * Projects the {@link com.metabroadcast.atlas.glycerin.model.Image Image}
+     * Projects the {@link com.metabroadcast.atlas.glycerin.model.Brand.People}
      * of the source data.
      * 
      * @param source
      *            - the source data
+     * @return - the people of the source data, or {@code null} if there is none.
+     */
+
+    protected abstract @Nullable Brand.People extractPeople(SOURCE source);
+
+    /**
+     * Projects the {@link com.metabroadcast.atlas.glycerin.model.Image Image}
+     * of the source data.
+     *
+     * @param source
+     *            - the source data
      * @return - the image of the source data, or {@code null} if there is none.
      */
-    protected abstract @Nullable com.metabroadcast.atlas.glycerin.model.Brand.Image extractImage(SOURCE source);
+    protected abstract @Nullable Brand.Image extractImage(SOURCE source);
     
     /**
      * Concrete implementations can override this method to perform additional

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroCrewMemberExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroCrewMemberExtractor.java
@@ -1,0 +1,63 @@
+package org.atlasapi.remotesite.bbc.nitro.extract;
+
+import static org.atlasapi.remotesite.bbc.nitro.extract.NitroUtil.curieFor;
+import static org.atlasapi.remotesite.bbc.nitro.extract.NitroUtil.uriFor;
+
+import org.atlasapi.media.entity.Actor;
+import org.atlasapi.media.entity.CrewMember;
+import org.atlasapi.media.entity.Publisher;
+import org.atlasapi.remotesite.ContentExtractor;
+
+import com.google.api.client.repackaged.com.google.common.base.Joiner;
+import com.google.api.client.repackaged.com.google.common.base.Strings;
+import com.google.common.base.Optional;
+import com.metabroadcast.atlas.glycerin.model.Brand;
+
+public class NitroCrewMemberExtractor implements
+        ContentExtractor<Brand.People.Contribution, Optional<CrewMember>> {
+
+    private static final Publisher PUBLISHER = Publisher.BBC_NITRO;
+
+    @Override
+    public Optional<CrewMember> extract(Brand.People.Contribution contribution) {
+        Optional<CrewMember.Role> role = CrewMember.Role.fromPossibleTvaCode(contribution.getCreditRoleId());
+
+        if (!role.isPresent()) {
+            return Optional.absent();
+        }
+
+        CrewMember crewMember = crewMemberFor(contribution, role.get()).withRole(role.get());
+
+        if (contribution.getContributorName() != null) {
+            crewMember.withName(fullName(contribution.getContributorName()));
+        }
+
+        return Optional.of(crewMember);
+    }
+
+    private static CrewMember crewMemberFor(Brand.People.Contribution contribution, CrewMember.Role role) {
+        CrewMember crewMember;
+        if (CrewMember.Role.ACTOR.equals(role)) {
+            crewMember = createActor(contribution);
+        } else {
+            crewMember = createCrewMember(contribution);
+        }
+        return crewMember;
+    }
+
+    private static CrewMember createCrewMember(Brand.People.Contribution contribution) {
+        return new CrewMember(uriFor(contribution), curieFor(contribution), PUBLISHER);
+    }
+
+    private static CrewMember createActor(Brand.People.Contribution contribution) {
+        return new Actor(uriFor(contribution), curieFor(contribution), PUBLISHER)
+                .withCharacter(contribution.getCharacterName());
+    }
+
+    private static String fullName(Brand.People.Contribution.ContributorName name) {
+        return Joiner.on(" ").skipNulls().join(
+                Strings.emptyToNull(name.getGiven()),
+                Strings.emptyToNull(name.getFamily())
+        );
+    }
+}

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroPersonExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroPersonExtractor.java
@@ -1,0 +1,28 @@
+package org.atlasapi.remotesite.bbc.nitro.extract;
+
+import org.atlasapi.media.entity.Person;
+import org.atlasapi.remotesite.ContentExtractor;
+
+import com.google.common.base.Optional;
+import com.metabroadcast.atlas.glycerin.model.Brand;
+
+public class NitroPersonExtractor implements
+        ContentExtractor<Brand.People.Contribution, Optional<Person>> {
+
+    @Override
+    public Optional<Person> extract(Brand.People.Contribution contribution) {
+        Brand.People.Contribution.ContributorName contributorName = contribution.getContributorName();
+
+        if (contributorName == null) {
+            return Optional.absent();
+        }
+
+        Person person = new Person();
+        person.setCanonicalUri(NitroUtil.uriFor(contribution));
+        person.setCurie(NitroUtil.curieFor(contribution));
+        person.setGivenName(contributorName.getGiven());
+        person.setFamilyName(contributorName.getFamily());
+
+        return Optional.of(person);
+    }
+}

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroPersonExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroPersonExtractor.java
@@ -1,6 +1,7 @@
 package org.atlasapi.remotesite.bbc.nitro.extract;
 
 import org.atlasapi.media.entity.Person;
+import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.remotesite.ContentExtractor;
 
 import com.google.common.base.Optional;
@@ -22,6 +23,7 @@ public class NitroPersonExtractor implements
         person.setCurie(NitroUtil.curieFor(contribution));
         person.setGivenName(contributorName.getGiven());
         person.setFamilyName(contributorName.getFamily());
+        person.setPublisher(Publisher.BBC_NITRO);
 
         return Optional.of(person);
     }

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroSeriesExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroSeriesExtractor.java
@@ -2,10 +2,13 @@ package org.atlasapi.remotesite.bbc.nitro.extract;
 
 import java.math.BigInteger;
 
+import javax.annotation.Nullable;
+
 import org.atlasapi.media.entity.ParentRef;
 import org.atlasapi.remotesite.bbc.BbcFeeds;
 import org.joda.time.DateTime;
 
+import com.metabroadcast.atlas.glycerin.model.Brand;
 import com.metabroadcast.atlas.glycerin.model.Brand.Image;
 import com.metabroadcast.atlas.glycerin.model.Brand.MasterBrand;
 import com.metabroadcast.atlas.glycerin.model.Series;
@@ -43,6 +46,10 @@ public class NitroSeriesExtractor
     @Override
     protected Synopses extractSynopses(Series source) {
         return source.getSynopses();
+    }
+
+    @Override protected Brand.People extractPeople(Series series) {
+        return series.getPeople();
     }
 
     @Override

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroUtil.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroUtil.java
@@ -14,6 +14,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.metabroadcast.atlas.glycerin.model.Availability;
 import com.metabroadcast.atlas.glycerin.model.AvailabilityOf;
+import com.metabroadcast.atlas.glycerin.model.Brand;
 import com.metabroadcast.atlas.glycerin.model.Broadcast;
 import com.metabroadcast.atlas.glycerin.model.PidReference;
 import com.metabroadcast.atlas.glycerin.model.Version;
@@ -24,6 +25,9 @@ import com.metabroadcast.common.time.DateTimeZones;
  *
  */
 public final class NitroUtil {
+
+    private static final String PERSON_URI_PREFIX = "http://nitro.bbc.co.uk/people/";
+    private static final String PERSON_CURIE_PREFIX = "nitro:bbc:person_";
 
     private NitroUtil() {}
     
@@ -135,6 +139,14 @@ public final class NitroUtil {
                 return input.getPid();
             }
         });
+    }
+
+    public static String uriFor(Brand.People.Contribution contribution) {
+        return PERSON_URI_PREFIX + contribution.getContributionBy();
+    }
+
+    public static String curieFor(Brand.People.Contribution contribution) {
+        return PERSON_CURIE_PREFIX + contribution.getContributionBy();
     }
     
 }

--- a/src/main/java/org/atlasapi/remotesite/youview/YouViewEquivalenceBreaker.java
+++ b/src/main/java/org/atlasapi/remotesite/youview/YouViewEquivalenceBreaker.java
@@ -87,7 +87,6 @@ public class YouViewEquivalenceBreaker {
     private void orphan(Item equiv) {
         lookupWriter.writeLookup(ContentRef.valueOf(equiv), 
                 Iterables.transform(ImmutableSet.of(equiv), ContentRef.FROM_CONTENT), Publisher.all());
-        
     }
 
     private boolean shouldOrphan(Identified identified) {

--- a/src/main/java/org/atlasapi/remotesite/youview/YouViewModule.java
+++ b/src/main/java/org/atlasapi/remotesite/youview/YouViewModule.java
@@ -86,7 +86,7 @@ public class YouViewModule {
     }
     
     @Bean
-    private YouViewEquivalanceBreakerController youViewEquivalenceBreakerController() {
+    public YouViewEquivalanceBreakerController youViewEquivalenceBreakerController() {
         return new YouViewEquivalanceBreakerController(youViewEquivalenceBreaker());
     }
     

--- a/src/test/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroCrewMemberExtractorTest.java
+++ b/src/test/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroCrewMemberExtractorTest.java
@@ -1,0 +1,71 @@
+package org.atlasapi.remotesite.bbc.nitro.extract;
+
+import static org.atlasapi.media.entity.CrewMember.Role.ACTOR;
+import static org.atlasapi.media.entity.CrewMember.Role.PRODUCTION_COMPANY;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import org.atlasapi.media.entity.Actor;
+import org.atlasapi.media.entity.CrewMember;
+import org.junit.Test;
+
+import com.metabroadcast.atlas.glycerin.model.Brand;
+
+public class NitroCrewMemberExtractorTest {
+
+    private NitroCrewMemberExtractor extractor = new NitroCrewMemberExtractor();
+
+    @Test
+    public void testNonActorExtraction() {
+        Brand.People.Contribution contribution = companyContribution();
+
+        CrewMember crewMember = extractor.extract(contribution).get();
+
+        assertThat(crewMember, not(instanceOf(Actor.class)));
+        assertEquals(PRODUCTION_COMPANY, crewMember.role());
+        assertEquals("So Television", crewMember.name());
+    }
+
+    @Test
+    public void testActorExtraction() {
+        Brand.People.Contribution contribution = actorContribution();
+
+        CrewMember crewMember = extractor.extract(contribution).get();
+
+        assertThat(crewMember, is(instanceOf(Actor.class)));
+        assertEquals(ACTOR, crewMember.role());
+        assertEquals("Carey Mulligan", crewMember.name());
+    }
+
+    private Brand.People.Contribution companyContribution() {
+        Brand.People.Contribution contribution = new Brand.People.Contribution();
+        contribution.setContributionBy("p029hdv9");
+        contribution.setCreditRole("Production Company");
+        contribution.setCreditRoleId("V20");
+
+        Brand.People.Contribution.ContributorName name = new Brand.People.Contribution.ContributorName();
+        name.setFamily("So Television");
+        contribution.setContributorName(name);
+
+        return contribution;
+    }
+
+    private Brand.People.Contribution actorContribution() {
+        Brand.People.Contribution contribution = new Brand.People.Contribution();
+        contribution.setContributionBy("p01fvgrh");
+        contribution.setCharacterName("Irene");
+        contribution.setCreditRole("Actor");
+        contribution.setCreditRoleId("ACTOR");
+
+        Brand.People.Contribution.ContributorName name = new Brand.People.Contribution.ContributorName();
+        name.setGiven("Carey");
+        name.setFamily("Mulligan");
+        contribution.setContributorName(name);
+
+        return contribution;
+    }
+
+}

--- a/src/test/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroEpisodeExtractorTest.java
+++ b/src/test/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroEpisodeExtractorTest.java
@@ -21,11 +21,13 @@ import org.atlasapi.media.entity.Film;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.MediaType;
 import org.atlasapi.media.entity.Restriction;
+import org.atlasapi.persistence.content.people.QueuingPersonWriter;
 import org.atlasapi.remotesite.bbc.nitro.v1.NitroGenreGroup;
 import org.hamcrest.Matchers;
 import org.joda.time.Duration;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -57,7 +59,8 @@ public class NitroEpisodeExtractorTest {
 
     private static final String EPISODE_PID = "p01mv8m3";
     private static final ImmutableList<Availability> noAvailability = ImmutableList.<Availability>of();
-    private final NitroEpisodeExtractor extractor = new NitroEpisodeExtractor(new SystemClock());
+    private final NitroEpisodeExtractor extractor = new NitroEpisodeExtractor(new SystemClock(),
+            Mockito.mock(QueuingPersonWriter.class));
 
     @Test
     public void testParentRefsForExtractedTopLevelItemAreEmpty() {

--- a/src/test/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroPersonExtractorTest.java
+++ b/src/test/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroPersonExtractorTest.java
@@ -1,0 +1,38 @@
+package org.atlasapi.remotesite.bbc.nitro.extract;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.atlasapi.media.entity.Person;
+import org.junit.Test;
+
+import com.google.common.base.Optional;
+import com.metabroadcast.atlas.glycerin.model.Brand;
+
+public class NitroPersonExtractorTest {
+
+    private NitroPersonExtractor extractor = new NitroPersonExtractor();
+
+    @Test
+    public void testPersonExtraction() {
+        Brand.People.Contribution contribution = new Brand.People.Contribution();
+        contribution.setContributionBy("p01fvgrh");
+        contribution.setCharacterName("Irene");
+
+        Brand.People.Contribution.ContributorName name = new Brand.People.Contribution.ContributorName();
+        name.setGiven("Carey");
+        name.setFamily("Mulligan");
+
+        contribution.setContributorName(name);
+
+        Optional<Person> optionalPerson = extractor.extract(contribution);
+        assertTrue(optionalPerson.isPresent());
+
+        Person person = optionalPerson.get();
+        assertEquals(name.getGiven(), person.getGivenName());
+        assertEquals(name.getFamily(), person.getFamilyName());
+        assertEquals("http://nitro.bbc.co.uk/people/p01fvgrh", person.getCanonicalUri());
+        assertEquals("nitro:bbc:person_p01fvgrh", person.getCurie());
+    }
+
+}

--- a/src/test/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroPersonExtractorTest.java
+++ b/src/test/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroPersonExtractorTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.atlasapi.media.entity.Person;
+import org.atlasapi.media.entity.Publisher;
 import org.junit.Test;
 
 import com.google.common.base.Optional;
@@ -33,6 +34,7 @@ public class NitroPersonExtractorTest {
         assertEquals(name.getFamily(), person.getFamilyName());
         assertEquals("http://nitro.bbc.co.uk/people/p01fvgrh", person.getCanonicalUri());
         assertEquals("nitro:bbc:person_p01fvgrh", person.getCurie());
+        assertEquals(Publisher.BBC_NITRO, person.getPublisher());
     }
 
 }


### PR DESCRIPTION
At the moment when result.getPublisher() is called, publisher has not been yet set.

This is a fix which doens't solve the underlying problem, which is the more specific fields should be written after more general fields and possibly override them, rather than the other way round as it is now.

