### PR TITLE
Use LookupEntryStore directly to orphan items

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/youview/YouViewEquivalenceBreaker.java
+++ b/src/main/java/org/atlasapi/remotesite/youview/YouViewEquivalenceBreaker.java
@@ -2,7 +2,8 @@ package org.atlasapi.remotesite.youview;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import org.atlasapi.equiv.ContentRef;
+import java.util.Set;
+
 import org.atlasapi.media.entity.Alias;
 import org.atlasapi.media.entity.Broadcast;
 import org.atlasapi.media.entity.Identified;
@@ -13,14 +14,15 @@ import org.atlasapi.media.entity.Schedule;
 import org.atlasapi.media.entity.Version;
 import org.atlasapi.persistence.content.ContentResolver;
 import org.atlasapi.persistence.content.ScheduleResolver;
-import org.atlasapi.persistence.lookup.LookupWriter;
 import org.atlasapi.persistence.lookup.entry.LookupEntry;
 import org.atlasapi.persistence.lookup.entry.LookupEntryStore;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 
+import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
 
 
 /**
@@ -43,18 +45,16 @@ public class YouViewEquivalenceBreaker {
     private final YouViewChannelResolver youViewChannelResolver;
     private final LookupEntryStore lookupEntryStore;
     private final ContentResolver contentResolver;
-    private final LookupWriter lookupWriter;
     private final ImmutableSet<Publisher> publishersToOrphan;
     private final Publisher referenceSchedulePublisher;
 
     public YouViewEquivalenceBreaker(ScheduleResolver scheduleResolver, YouViewChannelResolver youViewChannelResolver,
-            LookupEntryStore lookupEntryStore, ContentResolver contentResolver, LookupWriter lookupWriter,
-            Publisher referenceSchedulePublisher, Iterable<Publisher> publishersToOrphan) {
+            LookupEntryStore lookupEntryStore, ContentResolver contentResolver, Publisher referenceSchedulePublisher, 
+            Iterable<Publisher> publishersToOrphan) {
         this.youViewChannelResolver = checkNotNull(youViewChannelResolver);
         this.scheduleResolver = checkNotNull(scheduleResolver);
         this.lookupEntryStore = checkNotNull(lookupEntryStore);
         this.contentResolver = checkNotNull(contentResolver);
-        this.lookupWriter = checkNotNull(lookupWriter);
         this.referenceSchedulePublisher = checkNotNull(referenceSchedulePublisher);
         this.publishersToOrphan = ImmutableSet.copyOf(publishersToOrphan);
     }
@@ -71,25 +71,59 @@ public class YouViewEquivalenceBreaker {
     private void process(Schedule schedule) {
         for (Item item : Iterables.getOnlyElement(schedule.scheduleChannels()).items()) {
             LookupEntry lookupEntry = Iterables.getOnlyElement(lookupEntryStore.entriesForCanonicalUris(ImmutableSet.of(item.getCanonicalUri())));
+            Set<String> toOrphan = Sets.newHashSet();
             for (LookupRef lookupRef : lookupEntry.equivalents()) {
                 if (publishersToOrphan.contains(lookupRef.publisher())
                         && !lookupRef.uri().equals(item.getCanonicalUri())) {
                     Item equiv = (Item) contentResolver.findByCanonicalUris(ImmutableSet.of(lookupRef.uri())).getFirstValue().requireValue();
                     if (shouldOrphan(equiv)) {
+                        toOrphan.add(equiv.getCanonicalUri());
                         log.trace("Orphaning item {}", equiv.getCanonicalUri());
-                        orphan(equiv);
                     } else {
                         log.trace("Not orphaning item {}", equiv.getCanonicalUri());
                     }
                 }
             }
+            if (!toOrphan.isEmpty()) {
+                orphanFromEquivalentSet(lookupEntry, toOrphan);
+            }
         }
         
     }
 
-    private void orphan(Item equiv) {
-        lookupWriter.writeLookup(ContentRef.valueOf(equiv), 
-                Iterables.transform(ImmutableSet.of(equiv), ContentRef.FROM_CONTENT), Publisher.all());
+    private void orphanFromEquivalentSet(LookupEntry lookupEntry, Set<String> toOrphan) {
+        Predicate<LookupRef> shouldRetainLookupRef = createShouldRetainLookupRefPredicate(toOrphan);
+        for (LookupRef equivalentLookupRef : Sets.union(Sets.union(lookupEntry.equivalents(), lookupEntry.directEquivalents()), lookupEntry.explicitEquivalents())) {
+            LookupEntry entry = Iterables.getOnlyElement(lookupEntryStore.entriesForCanonicalUris(ImmutableSet.of(equivalentLookupRef.uri())));
+            if (toOrphan.contains(entry.uri())) {
+                lookupEntryStore.store(createOrphanedLookupEntry(entry));
+            } else {
+                lookupEntryStore.store(createFilteredLookupEntry(entry, shouldRetainLookupRef));
+            }
+        }
+    }
+
+    private LookupEntry createOrphanedLookupEntry(LookupEntry entry) {
+        return entry.copyWithDirectEquivalents(ImmutableSet.<LookupRef>of())
+                    .copyWithEquivalents(ImmutableSet.<LookupRef>of())
+                    .copyWithExplicitEquivalents(ImmutableSet.<LookupRef>of());
+    }
+
+    private LookupEntry createFilteredLookupEntry(LookupEntry entry, Predicate<LookupRef> shouldRetainLookupRef) {
+        return entry.copyWithDirectEquivalents(Iterables.filter(entry.directEquivalents(), shouldRetainLookupRef))
+                    .copyWithEquivalents(Iterables.filter(entry.equivalents(), shouldRetainLookupRef))
+                    .copyWithExplicitEquivalents(Iterables.filter(entry.explicitEquivalents(), shouldRetainLookupRef));
+        
+    }
+
+    private Predicate<LookupRef> createShouldRetainLookupRefPredicate(final Set<String> toOrphan) {
+        return new Predicate<LookupRef>() {
+
+            @Override
+            public boolean apply(LookupRef input) {
+                return !toOrphan.contains(input.uri());
+            }
+        };
     }
 
     private boolean shouldOrphan(Identified identified) {

--- a/src/main/java/org/atlasapi/remotesite/youview/YouViewModule.java
+++ b/src/main/java/org/atlasapi/remotesite/youview/YouViewModule.java
@@ -92,7 +92,7 @@ public class YouViewModule {
     
     private YouViewEquivalenceBreaker youViewEquivalenceBreaker() {
         return new YouViewEquivalenceBreaker(scheduleResolver, youviewChannelResolver, 
-                lookupEntryStore, contentResolver, lookupWriter, Publisher.PA, 
+                lookupEntryStore, contentResolver, Publisher.PA, 
                 ImmutableSet.of(Publisher.YOUVIEW, Publisher.YOUVIEW_BT, 
                                 Publisher.YOUVIEW_STAGE, Publisher.YOUVIEW_BT_STAGE,
                                 Publisher.YOUVIEW_SCOTLAND_RADIO, Publisher.YOUVIEW_SCOTLAND_RADIO_STAGE));


### PR DESCRIPTION
This should see a much better throughput, as we'll reduce the number of writes greatly. We're now
writing one entry per item in the equivalent set, rather than detaching each separately, which each would cause one write per item in the set.