### PR TITLE
Remove leading character from opta ID

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/opta/events/OptaEventsUtility.java
+++ b/src/main/java/org/atlasapi/remotesite/opta/events/OptaEventsUtility.java
@@ -131,7 +131,22 @@ public class OptaEventsUtility extends EventsUtility<OptaSportType> {
 
     @Override
     public String createTeamUri(String id) {
-        return TEAM_URI_BASE + id;
+        
+        return TEAM_URI_BASE + normalizeTeamId(id);
+    }
+    
+    /**
+     * Previously we received numeric IDs in the feed. However, when
+     * we switched to the opta API from a file, the IDs were prefixed
+     * with a leading "t". So as to reference the previously-created
+     * teams, we'll strip the leading "t", if present.
+     */
+    private String normalizeTeamId(String id) {
+        if (id.startsWith("t")) {
+            return id.substring(1);
+        } else {
+            return id;
+        }
     }
 
     @Override

--- a/src/test/java/org/atlasapi/remotesite/opta/events/sports/OptaEventsUtilityTest.java
+++ b/src/test/java/org/atlasapi/remotesite/opta/events/sports/OptaEventsUtilityTest.java
@@ -31,4 +31,11 @@ public class OptaEventsUtilityTest {
         
         assertFalse(fetched.isPresent());
     }
+    
+    @Test
+    public void testRemovesLeadingTFromId() {
+        assertEquals("http://optasports.com/teams/12345", utility.createTeamUri("t12345"));
+        assertEquals("http://optasports.com/teams/r12345", utility.createTeamUri("r12345"));
+    }
+    
 }


### PR DESCRIPTION
This makes it consistent with the former feed, where there
was not a leading t.