### PR TITLE
Make Opta ID parsing sport-specific

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/bt/events/BtEventsDataHandler.java
+++ b/src/main/java/org/atlasapi/remotesite/bt/events/BtEventsDataHandler.java
@@ -17,6 +17,7 @@ import org.atlasapi.persistence.content.organisation.OrganisationStore;
 import org.atlasapi.persistence.event.EventStore;
 import org.atlasapi.remotesite.bt.events.model.BtEvent;
 import org.atlasapi.remotesite.events.EventParsingDataHandler;
+import org.atlasapi.remotesite.opta.events.model.OptaSportType;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeFieldType;
 import org.joda.time.DateTimeZone;
@@ -62,7 +63,7 @@ public final class BtEventsDataHandler extends EventParsingDataHandler<BtSportTy
     }
 
     @Override
-    public Optional<Organisation> parseOrganisation(BtTeam team) {
+    public Optional<Organisation> parseOrganisation(BtTeam team, OptaSportType sportType) {
         // no-op: BT has no event modelling currently
         return Optional.absent();
     }

--- a/src/main/java/org/atlasapi/remotesite/bt/events/BtEventsUtility.java
+++ b/src/main/java/org/atlasapi/remotesite/bt/events/BtEventsUtility.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import org.atlasapi.persistence.topic.TopicStore;
 import org.atlasapi.remotesite.events.EventsUtility;
+import org.atlasapi.remotesite.opta.events.model.OptaSportType;
 import org.joda.time.DateTime;
 
 import com.google.common.base.Optional;
@@ -75,7 +76,7 @@ public final class BtEventsUtility extends EventsUtility<BtSportType> {
      * BT currently don't provide Team information
      */
     @Override
-    public String createTeamUri(String id) {
+    public String createTeamUri(OptaSportType sportType, String id) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/org/atlasapi/remotesite/events/DataHandler.java
+++ b/src/main/java/org/atlasapi/remotesite/events/DataHandler.java
@@ -3,6 +3,6 @@ package org.atlasapi.remotesite.events;
 
 public interface DataHandler<S, T, M> {
 
-    void handle(T team);
-    void handle(M match, S sport);
+    void handleTeam(T team, S sport);
+    void handleMatch(M match, S sport);
 }

--- a/src/main/java/org/atlasapi/remotesite/events/EventParsingDataHandler.java
+++ b/src/main/java/org/atlasapi/remotesite/events/EventParsingDataHandler.java
@@ -8,6 +8,7 @@ import org.atlasapi.media.entity.Event;
 import org.atlasapi.media.entity.Organisation;
 import org.atlasapi.persistence.content.organisation.OrganisationStore;
 import org.atlasapi.persistence.event.EventStore;
+import org.atlasapi.remotesite.opta.events.model.OptaSportType;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.Maps;
@@ -26,22 +27,22 @@ public abstract class EventParsingDataHandler<S, T, M> implements DataHandler<S,
     }
     
     @Override
-    public void handle(T team) {
-        Optional<Organisation> organisation = parseOrganisation(team);
+    public void handleTeam(T team, S sport) {
+        Optional<Organisation> organisation = parseOrganisation(team, sport);
         if (organisation.isPresent()) {
             createOrMerge(organisation.get());
         }
     }
 
     @Override
-    public void handle(M match, S sport) {
+    public void handleMatch(M match, S sport) {
         Optional<Event> event = parseEvent(match, sport);
         if (event.isPresent()) {
             createOrMerge(event.get());
         }
     }
 
-    public abstract Optional<Organisation> parseOrganisation(T team);
+    public abstract Optional<Organisation> parseOrganisation(T team, S sport);
     
     public abstract Optional<Event> parseEvent(M match, S sport);
 

--- a/src/main/java/org/atlasapi/remotesite/events/EventsIngestTask.java
+++ b/src/main/java/org/atlasapi/remotesite/events/EventsIngestTask.java
@@ -38,7 +38,7 @@ public abstract class EventsIngestTask<S, T, M> extends ScheduledTask {
     }
 
     private UpdateProgress processData(S sport, EventsData<T, M> data) {
-        DataProcessor<T> teamProcessor = teamProcessor();
+        DataProcessor<T> teamProcessor = teamProcessor(sport);
         for (T team : data.teams()) {
             teamProcessor.process(team);
         }
@@ -56,7 +56,7 @@ public abstract class EventsIngestTask<S, T, M> extends ScheduledTask {
         return teamProcessor.getResult().reduce(matchProcessor.getResult());
     }
 
-    private DataProcessor<T> teamProcessor() {
+    private DataProcessor<T> teamProcessor(final S sport) {
         return new DataProcessor<T>() {
             
             UpdateProgress progress = UpdateProgress.START;
@@ -64,7 +64,7 @@ public abstract class EventsIngestTask<S, T, M> extends ScheduledTask {
             @Override
             public boolean process(T team) {
                 try {
-                    dataHandler.handle(team);
+                    dataHandler.handleTeam(team, sport);
                     progress = progress.reduce(UpdateProgress.SUCCESS);
                 } catch (Exception e) {
                     log.warn("Error processing team: " + team, e);
@@ -89,7 +89,7 @@ public abstract class EventsIngestTask<S, T, M> extends ScheduledTask {
             @Override
             public boolean process(M match) {
                 try {
-                    dataHandler.handle(match, sport);
+                    dataHandler.handleMatch(match, sport);
                     progress = progress.reduce(UpdateProgress.SUCCESS);
                 } catch (Exception e) {
                     log.warn("Error processing team: " + match, e);

--- a/src/main/java/org/atlasapi/remotesite/events/EventsUtility.java
+++ b/src/main/java/org/atlasapi/remotesite/events/EventsUtility.java
@@ -9,6 +9,7 @@ import java.util.Set;
 
 import org.atlasapi.media.entity.Topic;
 import org.atlasapi.persistence.topic.TopicStore;
+import org.atlasapi.remotesite.opta.events.model.OptaSportType;
 import org.joda.time.DateTime;
 
 import com.google.common.base.Function;
@@ -36,7 +37,7 @@ public abstract class EventsUtility<S> {
     
     public abstract String createEventUri(String id);
     
-    public abstract String createTeamUri(String id);
+    public abstract String createTeamUri(OptaSportType sportType, String id);
     
     /**
      * Where an end time has not been provided for an {@link org.atlasapi.media.entity.Event},
@@ -103,4 +104,5 @@ public abstract class EventsUtility<S> {
                 value
         ));
     }
+
 }

--- a/src/main/java/org/atlasapi/remotesite/opta/events/OptaSportConfiguration.java
+++ b/src/main/java/org/atlasapi/remotesite/opta/events/OptaSportConfiguration.java
@@ -2,6 +2,8 @@ package org.atlasapi.remotesite.opta.events;
 
 import static com.google.api.client.util.Preconditions.checkNotNull;
 
+import com.google.common.base.Optional;
+
 
 /**
  * Wraps the three parameters that uniquely define a sports feed from Opta.
@@ -14,15 +16,18 @@ public class OptaSportConfiguration {
     private final String feedType;
     private final String competition;
     private final String seasonId;
+    private Optional<String> prefixToStripFromId;
     
     public static Builder builder() {
         return new Builder();
     }
     
-    private OptaSportConfiguration(String feedType, String competition, String seasonId) {
+    private OptaSportConfiguration(String feedType, String competition, 
+            String seasonId, String prefixToStripFromOptaId) {
         this.feedType = checkNotNull(feedType);
         this.competition = checkNotNull(competition);
         this.seasonId = checkNotNull(seasonId);
+        this.prefixToStripFromId = Optional.fromNullable(prefixToStripFromOptaId);
     }
     
     public String feedType() {
@@ -36,15 +41,20 @@ public class OptaSportConfiguration {
     public String seasonId() {
         return seasonId;
     }
+    
+    public Optional<String> prefixToStripFromId() {
+        return prefixToStripFromId;
+    };
 
     public static class Builder {
         
         private String feedType;
         private String competition;
         private String seasonId;
+        private String prefixToStripFromId;
         
         public OptaSportConfiguration build() {
-            return new OptaSportConfiguration(feedType, competition, seasonId);
+            return new OptaSportConfiguration(feedType, competition, seasonId, prefixToStripFromId);
         }
         
         private Builder() { }
@@ -61,6 +71,11 @@ public class OptaSportConfiguration {
         
         public Builder withSeasonId(String seasonId) {
             this.seasonId = seasonId;
+            return this;
+        }
+
+        public Builder withPrefixToStripFromId(String prefixToStripFromId) {
+            this.prefixToStripFromId = prefixToStripFromId;
             return this;
         }
     }

--- a/src/main/resources/config/environment.properties
+++ b/src/main/resources/config/environment.properties
@@ -356,10 +356,11 @@ bt.events.s3.bucket=
 opta.events.http.baseUrl=omo.akamai.opta.net
 opta.events.http.username=
 opta.events.http.password=
+# This format is described in the JavaDoc of OptaEvents.sportConfig
 opta.events.http.sports.soccer.football_premier_league=f1|8|2014
 opta.events.http.sports.soccer.football_scottish_premier_league=f1|14|2014
 opta.events.http.sports.soccer.football_german_bundesliga=f1|22|2014
-opta.events.http.sports.rugby.rugby_aviva_premiership=ruf1|201|2015
+opta.events.http.sports.rugby.rugby_aviva_premiership=ruf1|201|2015|t
 
 events.whitelist.ids=
 

--- a/src/test/java/org/atlasapi/remotesite/events/EventParsingDataHandlerTest.java
+++ b/src/test/java/org/atlasapi/remotesite/events/EventParsingDataHandlerTest.java
@@ -38,7 +38,7 @@ public class EventParsingDataHandlerTest {
         Mockito.when(testTeam.getCanonicalUri()).thenReturn("teamUri");
         Mockito.when(organisationStore.organisation("teamUri")).thenReturn(Optional.<Organisation>absent());
         
-        handler.handle(teamData);
+        handler.handleTeam(teamData);
         
         Mockito.verify(organisationStore).createOrUpdateOrganisation(testTeam);
     }
@@ -49,7 +49,7 @@ public class EventParsingDataHandlerTest {
         Mockito.when(testEvent.getCanonicalUri()).thenReturn("eventUri");
         Mockito.when(eventStore.fetch("eventUri")).thenReturn(Optional.<Event>absent());
         
-        handler.handle(matchData, OptaSportType.RUGBY_AVIVA_PREMIERSHIP);
+        handler.handleMatch(matchData, OptaSportType.RUGBY_AVIVA_PREMIERSHIP);
         
         Mockito.verify(eventStore).createOrUpdate(testEvent);
     }

--- a/src/test/java/org/atlasapi/remotesite/opta/events/sports/OptaEventsUtilityTest.java
+++ b/src/test/java/org/atlasapi/remotesite/opta/events/sports/OptaEventsUtilityTest.java
@@ -3,20 +3,43 @@ package org.atlasapi.remotesite.opta.events.sports;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
+import java.util.Map;
+
 import org.atlasapi.persistence.topic.TopicStore;
 import org.atlasapi.remotesite.opta.events.OptaEventsUtility;
+import org.atlasapi.remotesite.opta.events.OptaSportConfiguration;
 import org.atlasapi.remotesite.opta.events.model.OptaSportType;
 import org.joda.time.DateTimeZone;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 
 
 public class OptaEventsUtilityTest {
     
+    private final OptaSportConfiguration rugbyConfig = 
+            OptaSportConfiguration.builder()
+                                  .withCompetition("competition")
+                                  .withFeedType("feedType")
+                                  .withSeasonId("season")
+                                  .withPrefixToStripFromId("t")
+                                  .build();
+    
+    private final OptaSportConfiguration soccerConfig = 
+            OptaSportConfiguration.builder()
+                                  .withCompetition("competition")
+                                  .withFeedType("feedType")
+                                  .withSeasonId("season")
+                                  .build();
+    
+    private final Map<OptaSportType, OptaSportConfiguration> config = ImmutableMap.of(
+            OptaSportType.RUGBY_AVIVA_PREMIERSHIP, rugbyConfig,
+            OptaSportType.FOOTBALL_PREMIER_LEAGUE, soccerConfig);
+            
     private TopicStore topicStore = Mockito.mock(TopicStore.class);
-    private final OptaEventsUtility utility = new OptaEventsUtility(topicStore );
+    private final OptaEventsUtility utility = new OptaEventsUtility(topicStore, config);
 
     @Test
     public void testTimeZoneMapping() {
@@ -33,9 +56,14 @@ public class OptaEventsUtilityTest {
     }
     
     @Test
-    public void testRemovesLeadingTFromId() {
-        assertEquals("http://optasports.com/teams/12345", utility.createTeamUri("t12345"));
-        assertEquals("http://optasports.com/teams/r12345", utility.createTeamUri("r12345"));
+    public void testRemovesConfiguredLeadingCharacterFromId() {
+        assertEquals("http://optasports.com/teams/12345", 
+                utility.createTeamUri(OptaSportType.RUGBY_AVIVA_PREMIERSHIP, "t12345"));
+        assertEquals("http://optasports.com/teams/r12345", 
+                utility.createTeamUri(OptaSportType.RUGBY_AVIVA_PREMIERSHIP, "r12345"));
+        
+        assertEquals("http://optasports.com/teams/t12345", 
+                utility.createTeamUri(OptaSportType.FOOTBALL_PREMIER_LEAGUE, "t12345"));
     }
     
 }

--- a/src/test/java/org/atlasapi/remotesite/opta/events/sports/OptaSportsDataHandlerTest.java
+++ b/src/test/java/org/atlasapi/remotesite/opta/events/sports/OptaSportsDataHandlerTest.java
@@ -127,7 +127,7 @@ public class OptaSportsDataHandlerTest {
 
     private void parseTeams() {
         for (SportsTeam team : feedData.teams()) {
-            handler.handle(team);
+            handler.handleTeam(team);
         }
     }
 


### PR DESCRIPTION
The original Opta feed that was used was had IDs that
differ from the new one we're using. We therefore had
had to remove the prefix 't'. However, it transpired
that we should only do this removal for rugby, since
for other sports the IDs were consistent between the
two feeds.