### PR TITLE
Batch and parallelise requestes to Nitro

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/BbcNitroModule.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/BbcNitroModule.java
@@ -87,9 +87,9 @@ public class BbcNitroModule {
             scheduler.schedule(nitroScheduleUpdateTask(0, 0, nitroTodayThreadCount, nitroTodayRateLimit, Optional.of(Predicates.<Item>alwaysTrue()))
                     .withName("Nitro full fetch 15 day updater"), RepetitionRules.NEVER);
             scheduler.schedule(nitroScheduleUpdateTask(30, -8, nitroThreeWeekThreadCount, nitroThreeWeekRateLimit, Optional.of(Predicates.<Item>alwaysTrue()))
-                    .withName("Nitro full fetch -8 to -30 day updater"), RepetitionRules.NEVER);
+                    .withName("Nitro full fetch -8 to -30 day updater"), RepetitionRules.every(Duration.standardHours(12)));
             scheduler.schedule(nitroScheduleUpdateTask(7, 3, nitroAroundTodayThreadCount, nitroAroundTodayRateLimit, Optional.of(Predicates.<Item>alwaysTrue()))
-                    .withName("Nitro full fetch -7 to +3 day updater"), RepetitionRules.NEVER);
+                    .withName("Nitro full fetch -7 to +3 day updater"), RepetitionRules.every(Duration.standardHours(4)));
         }
     }
 

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/GlycerinNitroClipsAdapter.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/GlycerinNitroClipsAdapter.java
@@ -1,8 +1,12 @@
 package org.atlasapi.remotesite.bbc.nitro;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.metabroadcast.atlas.glycerin.queries.ProgrammesMixin.TITLES;
 
 import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 
 import javax.annotation.Nullable;
 
@@ -13,6 +17,7 @@ import org.atlasapi.remotesite.bbc.nitro.extract.NitroUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.api.client.repackaged.com.google.common.base.Throwables;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
@@ -23,6 +28,10 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.metabroadcast.atlas.glycerin.Glycerin;
 import com.metabroadcast.atlas.glycerin.GlycerinException;
 import com.metabroadcast.atlas.glycerin.GlycerinResponse;
@@ -64,10 +73,13 @@ public class GlycerinNitroClipsAdapter {
     private final NitroClipExtractor clipExtractor;
     private final int pageSize;
 
+    private final ListeningExecutorService executor;
+
     public GlycerinNitroClipsAdapter(Glycerin glycerin, Clock clock, int pageSize) {
         this.glycerin = glycerin;
         this.clipExtractor = new NitroClipExtractor(clock);
         this.pageSize = pageSize;
+        this.executor = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(15));
     }
     
     public Multimap<String, org.atlasapi.media.entity.Clip> clipsFor(Iterable<PidReference> refs) throws NitroException {
@@ -142,16 +154,44 @@ public class GlycerinNitroClipsAdapter {
             }
         });
     }
-
+    
     private ImmutableList<Programme> getNitroClips(Iterable<PidReference> refs) throws GlycerinException {
-        ProgrammesQuery query = ProgrammesQuery.builder()
-                .withEntityType(EntityTypeOption.CLIP)
-                .withChildrenOf(NitroUtil.toPids(refs))
-                .withPageSize(pageSize)
-                .build();
-        return exhaust(glycerin.execute(query));
+        
+        List<ListenableFuture<ImmutableList<Programme>>> futures = Lists.newArrayList();
+        
+        for (List<PidReference> ref : Iterables.partition(refs, 5)) {
+            ProgrammesQuery query = ProgrammesQuery.builder()
+                    .withEntityType(EntityTypeOption.CLIP)
+                    .withChildrenOf(NitroUtil.toPids(ref))
+                    .withPageSize(pageSize)
+                    .build();
+            
+            futures.add(executor.submit(exhaustingProgrammeCallable(query)));
+        }
+        
+        ListenableFuture<List<ImmutableList<Programme>>> all = Futures.allAsList(futures);
+        
+        try {
+            return ImmutableList.copyOf(Iterables.concat(all.get()));
+        } catch (InterruptedException | ExecutionException e) {
+            if (e.getCause() instanceof GlycerinException) {
+                throw (GlycerinException) e.getCause();
+            }
+            throw Throwables.propagate(e);
+        }
     }
     
+    private Callable<ImmutableList<Programme>> exhaustingProgrammeCallable(final ProgrammesQuery query) {
+        
+        return new Callable<ImmutableList<Programme>>() {
+
+            @Override
+            public ImmutableList<Programme> call() throws Exception {
+                return exhaust(glycerin.execute(query));
+            }
+        };
+    }
+
     private <T> ImmutableList<T> exhaust(GlycerinResponse<T> resp) throws GlycerinException {
         ImmutableList.Builder<T> programmes = ImmutableList.builder(); 
         programmes.addAll(resp.getResults());

--- a/src/main/resources/config/environment.properties
+++ b/src/main/resources/config/environment.properties
@@ -288,16 +288,16 @@ bbc.nitro.apiKey=
 bbc.nitro.requestsPerSecond.today=5
 #Max Requests per second, fortnight
 bbc.nitro.requestsPerSecond.fortnight=2
-bbc.nitro.requestsPerSecond.threeweek=5
-bbc.nitro.requestsPerSecond.aroundtoday=14
+bbc.nitro.requestsPerSecond.threeweek=50
+bbc.nitro.requestsPerSecond.aroundtoday=50
 #Nitro thread count for task updating today only
 bbc.nitro.threadCount.today=10
 #Nitro thread count for task updating fortnight round today
 bbc.nitro.threadCount.fortnight=10
-bbc.nitro.threadCount.threeweek=20
-bbc.nitro.threadCount.aroundtoday=20
+bbc.nitro.threadCount.threeweek=60
+bbc.nitro.threadCount.aroundtoday=60
 #Page size for requests to nitro
-bbc.nitro.requestPageSize=30
+bbc.nitro.requestPageSize=50
 #Percentage of tasks that need to fail to mark ingest job as failure
 bbc.nitro.jobFailureThresholdPercent=10
 bbc.audience-data.filename=


### PR DESCRIPTION
Instead of requesting all programmes/availabilities/versions
for a schedule day in one go, batch them to improve throughput