### PR TITLE
Ingest images from MPX

### DIFF
--- a/src/main/java/org/atlasapi/equiv/EquivModule.java
+++ b/src/main/java/org/atlasapi/equiv/EquivModule.java
@@ -23,6 +23,7 @@ import static org.atlasapi.media.entity.Publisher.BBC;
 import static org.atlasapi.media.entity.Publisher.BBC_MUSIC;
 import static org.atlasapi.media.entity.Publisher.BBC_REDUX;
 import static org.atlasapi.media.entity.Publisher.BETTY;
+import static org.atlasapi.media.entity.Publisher.BT_TVE_VOD;
 import static org.atlasapi.media.entity.Publisher.BT_VOD;
 import static org.atlasapi.media.entity.Publisher.FACEBOOK;
 import static org.atlasapi.media.entity.Publisher.ITUNES;
@@ -290,7 +291,7 @@ public class EquivModule {
         EquivalenceUpdater<Container> topLevelContainerUpdater = topLevelContainerUpdater(MoreSets.add(acceptablePublishers, LOVEFILM));
 
         Set<Publisher> nonStandardPublishers = ImmutableSet.copyOf(Sets.union(
-            ImmutableSet.of(ITUNES, BBC_REDUX, RADIO_TIMES, FACEBOOK, LOVEFILM, NETFLIX, RTE, YOUVIEW, YOUVIEW_STAGE, YOUVIEW_BT, YOUVIEW_BT_STAGE, TALK_TALK, PA, BT_VOD, BETTY), 
+            ImmutableSet.of(ITUNES, BBC_REDUX, RADIO_TIMES, FACEBOOK, LOVEFILM, NETFLIX, RTE, YOUVIEW, YOUVIEW_STAGE, YOUVIEW_BT, YOUVIEW_BT_STAGE, TALK_TALK, PA, BT_VOD, BT_TVE_VOD, BETTY), 
             Sets.union(musicPublishers, roviPublishers)
         ));
         final EquivalenceUpdaters updaters = new EquivalenceUpdaters();
@@ -408,6 +409,14 @@ public class EquivModule {
                         .withScorer(new SeriesSequenceItemScorer()).build())
                 .withTopLevelContainerUpdater(vodContainerUpdater(btVodPublishers))
                 .withNonTopLevelContainerUpdater(vodSeriesUpdater(btVodPublishers))
+                .build());
+        
+        Set<Publisher> btTveVodPublishers = ImmutableSet.of(PA);
+        updaters.register(BT_TVE_VOD, SourceSpecificEquivalenceUpdater.builder(BT_TVE_VOD)
+                .withItemUpdater(vodItemUpdater(btTveVodPublishers)
+                        .withScorer(new SeriesSequenceItemScorer()).build())
+                .withTopLevelContainerUpdater(vodContainerUpdater(btTveVodPublishers))
+                .withNonTopLevelContainerUpdater(vodSeriesUpdater(btTveVodPublishers))
                 .build());
                 
         Set<Publisher> itunesAndMusicPublishers = Sets.union(musicPublishers, ImmutableSet.of(ITUNES));

--- a/src/main/java/org/atlasapi/equiv/EquivTaskModule.java
+++ b/src/main/java/org/atlasapi/equiv/EquivTaskModule.java
@@ -5,6 +5,7 @@ import static org.atlasapi.media.entity.Publisher.BBC;
 import static org.atlasapi.media.entity.Publisher.BBC_REDUX;
 import static org.atlasapi.media.entity.Publisher.BETTY;
 import static org.atlasapi.media.entity.Publisher.BT_VOD;
+import static org.atlasapi.media.entity.Publisher.BT_TVE_VOD;
 import static org.atlasapi.media.entity.Publisher.C4;
 import static org.atlasapi.media.entity.Publisher.C4_PMLSD;
 import static org.atlasapi.media.entity.Publisher.FIVE;
@@ -158,6 +159,7 @@ public class EquivTaskModule {
             taskScheduler.schedule(publisherUpdateTask(ROVI_EN).withName("Rovi EN Equivalence Updater"), ROVI_EN_EQUIVALENCE_REPETITION);
             taskScheduler.schedule(publisherUpdateTask(RTE).withName("RTE Equivalence Updater"), RTE_EQUIVALENCE_REPETITION);
             taskScheduler.schedule(publisherUpdateTask(BT_VOD).withName("BT VOD Equivalence Updater"), BT_VOD_EQUIVALENCE_REPETITION);
+            taskScheduler.schedule(publisherUpdateTask(BT_TVE_VOD).withName("BT VOD TVE Equivalence Updater"), BT_VOD_EQUIVALENCE_REPETITION);
             taskScheduler.schedule(publisherUpdateTask(AMAZON_UNBOX).withName("Amazon Unbox Equivalence Updater"), AMAZON_EQUIVALENCE_REPETITION);
             
             taskScheduler.schedule(publisherUpdateTask(Publisher.BBC_MUSIC).withName("Music Equivalence Updater"), RepetitionRules.every(Duration.standardHours(6)));

--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodDescribedFieldsExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodDescribedFieldsExtractor.java
@@ -150,7 +150,6 @@ public class BtVodDescribedFieldsExtractor {
     public void setDescribedFieldsFrom(BtVodEntry row, Described described) {
         described.setDescription(row.getDescription());
         described.setLongDescription(row.getProductLongDescription());
-        described.setImages(createImages(row));
         if (row.getProductPriority() != null) {
             described.setPriority(Double.valueOf(row.getProductPriority()));
         }
@@ -176,7 +175,8 @@ public class BtVodDescribedFieldsExtractor {
             described.setGenres(genres.build());
         }
 
-        if (!described.getImages().isEmpty()) {
+        if (described.getImages() != null 
+                && !described.getImages().isEmpty()) {
             described.setImage(Iterables.getFirst(described.getImages(), null).getCanonicalUri());
         }
         

--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodMpxImageExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodMpxImageExtractor.java
@@ -1,8 +1,10 @@
 package org.atlasapi.remotesite.btvod;
 
 import com.google.common.collect.ImmutableSet;
+
 import org.atlasapi.media.entity.Image;
 import org.atlasapi.media.entity.ImageType;
+import org.atlasapi.remotesite.btvod.model.BtVodEntry;
 import org.atlasapi.remotesite.btvod.model.BtVodImage;
 import org.atlasapi.remotesite.btvod.model.BtVodPlproductImages;
 
@@ -19,7 +21,8 @@ public class BtVodMpxImageExtractor implements ImageExtractor {
     }
 
     @Override
-    public Set<Image> extractImages(BtVodPlproductImages btVodPlproductImages) {
+    public Set<Image> extractImages(BtVodEntry entry) {
+        BtVodPlproductImages btVodPlproductImages = entry.getProductImages();
         ImmutableSet.Builder<Image> extractedImages = ImmutableSet.builder();
 
         for (BtVodImage packshotImage : btVodPlproductImages.getPackshotImages()) {
@@ -52,5 +55,10 @@ public class BtVodMpxImageExtractor implements ImageExtractor {
                 baseUrl,
                 image.getPlproduct$url()
         );
+    }
+
+    @Override
+    public void start() {
+        
     }
 }

--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodSeriesWriter.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodSeriesWriter.java
@@ -135,7 +135,7 @@ public class BtVodSeriesWriter implements BtVodDataProcessor<UpdateProgress>{
         return series;
     }
 
-    public Optional<Integer> extractSeriesNumber(String title) {
+    public static Optional<Integer> extractSeriesNumber(String title) {
         if (title == null) {
             return Optional.absent();
         }
@@ -148,13 +148,11 @@ public class BtVodSeriesWriter implements BtVodDataProcessor<UpdateProgress>{
 
         }
 
-
-
         return Optional.absent();
     }
 
     public Optional<String> uriFor(BtVodEntry row) {
-        Optional<String> brandUri = brandExtractor.uriFor(row);
+        Optional<String> brandUri = brandExtractor.brandUriFor(row);
         if(!brandUri.isPresent()) {
             return Optional.absent();
         }

--- a/src/main/java/org/atlasapi/remotesite/btvod/DerivingFromItemBrandImageExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/DerivingFromItemBrandImageExtractor.java
@@ -1,0 +1,151 @@
+package org.atlasapi.remotesite.btvod;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.atlasapi.media.entity.Image;
+import org.atlasapi.media.entity.ImageType;
+import org.atlasapi.remotesite.btvod.model.BtVodEntry;
+import org.atlasapi.remotesite.btvod.model.BtVodImage;
+
+import com.google.api.client.util.Maps;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+
+/**
+ * Extract low-resolution brand images from MPX feed.
+ * 
+ * Images aren't provided at the brand level, however. we
+ * must find the images from the first episode, ordered editorially.
+ * 
+ * To do this in an efficient manner during ingest, and avoid writing a
+ * brand many times, users of this class are expected to pre-process the
+ * feed so the correct images for each brand can be computed before
+ * brands are written.
+ *
+ */
+public class DerivingFromItemBrandImageExtractor implements BrandImageExtractor, BtVodDataProcessor<Void> {
+
+    private final String baseUrl;
+    private final Map<String, BrandImage> backgroundImages = Maps.newHashMap();
+    private final Map<String, BrandImage> packshotImages = Maps.newHashMap();
+    private final BrandUriExtractor brandUriExtractor;
+
+    public DerivingFromItemBrandImageExtractor(BrandUriExtractor brandUriExtractor, String baseUrl) {
+        this.baseUrl = checkNotNull(baseUrl);
+        this.brandUriExtractor = checkNotNull(brandUriExtractor);
+    }
+    
+    @Override
+    public Set<Image> extractImages(BtVodEntry entry) {
+        Optional<String> brandUri = brandUriExtractor.extractBrandUri(entry);
+        if (!brandUri.isPresent()) {
+            return ImmutableSet.of();
+        }
+        
+        ImmutableSet.Builder<Image> images = ImmutableSet.builder();
+        BrandImage backgroundImage = backgroundImages.get(brandUri.get());
+        
+        if (backgroundImage != null) {
+            images.add(buildImage(backgroundImage.image, ImageType.ADDITIONAL, false));
+        }
+        
+        BrandImage packshotImage = packshotImages.get(brandUri.get());
+        if (packshotImage != null) {
+            images.add(buildImage(packshotImage.image, ImageType.PRIMARY, true));
+        }
+        
+        return images.build();
+    }
+
+    @Override
+    public boolean process(BtVodEntry entry) {
+        Optional<String> brandUri = brandUriExtractor.extractBrandUri(entry);
+        if (!brandUri.isPresent()) {
+            return true;
+        }
+        Integer seriesNumber = BtVodSeriesWriter.extractSeriesNumber(entry.getTitle()).orNull();
+        Integer episodeNumber = BtVodItemWriter.extractEpisodeNumber(entry);
+        if (episodeNumber != null && seriesNumber != null) {
+            retainIfBestImage(brandUri.get(), backgroundImages, getBackgroundImage(entry), seriesNumber, episodeNumber);
+            retainIfBestImage(brandUri.get(), packshotImages, getPackshotDoubleImage(entry), seriesNumber, episodeNumber);
+        }
+        return true;
+    }
+    
+    private void retainIfBestImage(String brandUri, Map<String, BrandImage> images,
+            BtVodImage image, Integer seriesNumber, Integer episodeNumber) {
+        
+        if (image == null) {
+            return;
+        }
+        
+        BrandImage current = images.get(brandUri);
+        
+        if (current == null 
+                || newImageIsForEarlierEpisode(current, seriesNumber, episodeNumber)) {
+            images.put(brandUri, 
+                        new BrandImage(seriesNumber, 
+                                       episodeNumber, 
+                                       image));
+        }
+    }
+
+    private boolean newImageIsForEarlierEpisode(BrandImage current, Integer seriesNumber,
+            Integer episodeNumber) {
+        
+        return (seriesNumber < current.seriesNumber)
+                || (seriesNumber == current.seriesNumber && episodeNumber < current.episodeNumber);
+    }
+
+    private BtVodImage getBackgroundImage(BtVodEntry row) {
+        return Iterables.getFirst(row.getProductImages().getBackgroundImages(), null);
+    }
+    
+    private BtVodImage getPackshotDoubleImage(BtVodEntry row) {
+        return Iterables.getFirst(row.getProductImages().getPackshotDoubleImages(), null);
+    }
+
+    @Override
+    public Void getResult() {
+        return null;
+    }
+    
+    private static class BrandImage {
+        private int seriesNumber;
+        private int episodeNumber;
+        private BtVodImage image;
+        
+        public BrandImage(int seriesNumber, int episodeNumber, BtVodImage image) {
+            this.seriesNumber = seriesNumber;
+            this.episodeNumber = episodeNumber;
+            this.image = image;
+        }
+    }
+    
+    private Image buildImage(BtVodImage btVodImage, ImageType imageType, boolean hasTitleArt) {
+        return Image.builder(uriFor(btVodImage))
+                .withHeight(btVodImage.getPlproduct$height())
+                .withWidth(btVodImage.getPlproduct$width())
+                .withType(imageType)
+                .withHasTitleArt(hasTitleArt)
+                .build();
+    }
+
+    private String uriFor(BtVodImage image) {
+        return String.format(
+                "%s%s",
+                baseUrl,
+                image.getPlproduct$url()
+        );
+    }
+
+    @Override
+    public void start() {
+        backgroundImages.clear();
+        packshotImages.clear();
+    }
+}

--- a/src/main/java/org/atlasapi/remotesite/btvod/ImageExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/ImageExtractor.java
@@ -1,11 +1,12 @@
 package org.atlasapi.remotesite.btvod;
 
 import org.atlasapi.media.entity.Image;
-import org.atlasapi.remotesite.btvod.model.BtVodPlproductImages;
+import org.atlasapi.remotesite.btvod.model.BtVodEntry;
 
 import java.util.Set;
 
 public interface ImageExtractor {
 
-    Set<Image> extractImages(BtVodPlproductImages btVodPlproductImages);
+    Set<Image> extractImages(BtVodEntry btVodPlproductImages);
+    void start();
 }

--- a/src/main/java/org/atlasapi/remotesite/btvod/model/BtVodPlproductImages.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/model/BtVodPlproductImages.java
@@ -13,6 +13,9 @@ public class BtVodPlproductImages {
     @SerializedName("image-single-packshot")
     private List<BtVodImage> packshotImages;
 
+    @SerializedName("image-double-packshot")
+    private List<BtVodImage> packshotDoubleImages;
+    
     public BtVodPlproductImages() {
     }
 
@@ -33,9 +36,20 @@ public class BtVodPlproductImages {
         }
         return packshotImages;
     }
+    
+    public List<BtVodImage> getPackshotDoubleImages() {
+        if (packshotDoubleImages == null) {
+            return ImmutableList.of();
+        }
+        return ImmutableList.copyOf(packshotDoubleImages);
+    }
 
     public void setPackshotImages(List<BtVodImage> packshotImages) {
         this.packshotImages = packshotImages;
+    }
+    
+    public void setPackshotDoubleImages(List<BtVodImage> packshotDoubleImages) {
+        this.packshotDoubleImages = packshotDoubleImages;
     }
 
     @Override

--- a/src/test/java/org/atlasapi/remotesite/btvod/BtVodItemWriterTest.java
+++ b/src/test/java/org/atlasapi/remotesite/btvod/BtVodItemWriterTest.java
@@ -85,7 +85,8 @@ public class BtVodItemWriterTest {
                                 new BtVodDescribedFieldsExtractor(imageExtractor, topicResolver, topicWriter),
                                 Sets.<String>newHashSet(),
                                 new BtVodPricingAvailabilityGrouper(),
-                                new TitleSanitiser());
+                                new TitleSanitiser(),
+                                new NoImageExtractor());
     
     @Test
     public void testExtractsEpisode() {
@@ -95,9 +96,8 @@ public class BtVodItemWriterTest {
 
         when(contentResolver.findByCanonicalUris(ImmutableSet.of(itemUri())))
                 .thenReturn(ResolvedContent.builder().build());
-        when(imageExtractor.extractImages(Matchers.<BtVodPlproductImages>any())).thenReturn(ImmutableSet.<Image>of());
+        when(imageExtractor.extractImages(Matchers.<BtVodEntry>any())).thenReturn(ImmutableSet.<Image>of());
         when(seriesExtractor.getSeriesRefFor(btVodEntry)).thenReturn(Optional.of(seriesRef));
-        when(seriesExtractor.extractSeriesNumber(btVodEntry.getTitle())).thenReturn(Optional.of(1));
         when(brandExtractor.getBrandRefFor(btVodEntry)).thenReturn(Optional.of(parentRef));
 
         Item writtenItem = extractAndCapture(btVodEntry);
@@ -153,7 +153,7 @@ public class BtVodItemWriterTest {
 
         when(contentResolver.findByCanonicalUris(ImmutableSet.of(itemUri())))
                 .thenReturn(ResolvedContent.builder().build());
-        when(imageExtractor.extractImages(Matchers.<BtVodPlproductImages>any())).thenReturn(ImmutableSet.<Image>of());
+        when(imageExtractor.extractImages(Matchers.<BtVodEntry>any())).thenReturn(ImmutableSet.<Image>of());
         when(seriesExtractor.getSeriesRefFor(btVodEntry)).thenReturn(Optional.of(seriesRef));
         when(seriesExtractor.extractSeriesNumber(btVodEntry.getTitle())).thenReturn(Optional.of(1));
         when(brandExtractor.getBrandRefFor(btVodEntry)).thenReturn(Optional.of(parentRef));
@@ -179,9 +179,8 @@ public class BtVodItemWriterTest {
 
         when(contentResolver.findByCanonicalUris(ImmutableSet.of(itemUri())))
                 .thenReturn(ResolvedContent.builder().build());
-        when(imageExtractor.extractImages(Matchers.<BtVodPlproductImages>any())).thenReturn(ImmutableSet.<Image>of());
+        when(imageExtractor.extractImages(Matchers.<BtVodEntry>any())).thenReturn(ImmutableSet.<Image>of());
         when(seriesExtractor.getSeriesRefFor(btVodEntrySD)).thenReturn(Optional.of(seriesRef));
-        when(seriesExtractor.extractSeriesNumber(btVodEntrySD.getTitle())).thenReturn(Optional.of(1));
         when(brandExtractor.getBrandRefFor(btVodEntrySD)).thenReturn(Optional.of(parentRef));
 
         itemExtractor.process(btVodEntrySD);
@@ -218,9 +217,8 @@ public class BtVodItemWriterTest {
 
         when(contentResolver.findByCanonicalUris(ImmutableSet.of(itemUri())))
                 .thenReturn(ResolvedContent.builder().build());
-        when(imageExtractor.extractImages(Matchers.<BtVodPlproductImages>any())).thenReturn(ImmutableSet.<Image>of());
+        when(imageExtractor.extractImages(Matchers.<BtVodEntry>any())).thenReturn(ImmutableSet.<Image>of());
         when(seriesExtractor.getSeriesRefFor(btVodEntrySD)).thenReturn(Optional.of(seriesRef));
-        when(seriesExtractor.extractSeriesNumber(btVodEntrySD.getTitle())).thenReturn(Optional.of(1));
         when(brandExtractor.getBrandRefFor(btVodEntrySD)).thenReturn(Optional.of(parentRef));
 
         itemExtractor.process(btVodEntrySD);

--- a/src/test/java/org/atlasapi/remotesite/btvod/BtVodMpxImageExtractorTest.java
+++ b/src/test/java/org/atlasapi/remotesite/btvod/BtVodMpxImageExtractorTest.java
@@ -3,8 +3,10 @@ package org.atlasapi.remotesite.btvod;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+
 import org.atlasapi.media.entity.Image;
 import org.atlasapi.media.entity.ImageType;
+import org.atlasapi.remotesite.btvod.model.BtVodEntry;
 import org.atlasapi.remotesite.btvod.model.BtVodImage;
 import org.atlasapi.remotesite.btvod.model.BtVodPlproductImages;
 import org.junit.Test;
@@ -23,6 +25,8 @@ public class BtVodMpxImageExtractorTest {
 
     @Test
     public void testExtractImages() throws Exception {
+        BtVodEntry entry = new BtVodEntry();
+        
         BtVodImage packShotImage1 = new BtVodImage();
         packShotImage1.setPlproduct$mediaFileId("mediaFileId1");
         packShotImage1.setPlproduct$height(1);
@@ -52,7 +56,8 @@ public class BtVodMpxImageExtractorTest {
         images.setPackshotImages(ImmutableList.of(packShotImage1, packShotImage2));
         images.setBackgroundImages(ImmutableList.of(backgroundImage1, backgroundImage2));
 
-        Set<Image> extractedImages = imageExtractor.extractImages(images);
+        entry.setProductImages(images);
+        Set<Image> extractedImages = imageExtractor.extractImages(entry);
 
         assertThat(extractedImages.size(), is(4));
 

--- a/src/test/java/org/atlasapi/remotesite/btvod/BtVodSeriesWriterTest.java
+++ b/src/test/java/org/atlasapi/remotesite/btvod/BtVodSeriesWriterTest.java
@@ -3,6 +3,7 @@ package org.atlasapi.remotesite.btvod;
 
 import com.google.api.client.util.Sets;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import org.atlasapi.media.entity.ParentRef;
@@ -14,6 +15,8 @@ import org.atlasapi.persistence.content.ResolvedContent;
 import org.atlasapi.persistence.topic.TopicCreatingTopicResolver;
 import org.atlasapi.persistence.topic.TopicWriter;
 import org.atlasapi.remotesite.btvod.model.BtVodEntry;
+import org.atlasapi.remotesite.btvod.model.BtVodPlproduct$productTag;
+import org.atlasapi.remotesite.btvod.model.BtVodProductScope;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -65,7 +68,7 @@ public class BtVodSeriesWriterTest {
         when(contentResolver.findByCanonicalUris(ImmutableSet.of(brandUri + "/series/1")))
                 .thenReturn(ResolvedContent.builder().build());
 
-        when(brandExtractor.uriFor(entry)).thenReturn(Optional.of(brandUri));
+        when(brandExtractor.brandUriFor(entry)).thenReturn(Optional.of(brandUri));
         when(brandExtractor.getBrandRefFor(entry)).thenReturn(Optional.of(brandRef));
 
 
@@ -104,11 +107,11 @@ public class BtVodSeriesWriterTest {
         String brandUri4 = "http://brand-uri4.com";
         String brandUri5 = "http://brand-uri5.com";
 
-        when(brandExtractor.uriFor(row1)).thenReturn(Optional.of(brandUri));
-        when(brandExtractor.uriFor(row2)).thenReturn(Optional.of(brandUri2));
-        when(brandExtractor.uriFor(row3)).thenReturn(Optional.of(brandUri3));
-        when(brandExtractor.uriFor(row4)).thenReturn(Optional.of(brandUri4));
-        when(brandExtractor.uriFor(row5)).thenReturn(Optional.of(brandUri5));
+        when(brandExtractor.brandUriFor(row1)).thenReturn(Optional.of(brandUri));
+        when(brandExtractor.brandUriFor(row2)).thenReturn(Optional.of(brandUri2));
+        when(brandExtractor.brandUriFor(row3)).thenReturn(Optional.of(brandUri3));
+        when(brandExtractor.brandUriFor(row4)).thenReturn(Optional.of(brandUri4));
+        when(brandExtractor.brandUriFor(row5)).thenReturn(Optional.of(brandUri5));
 
 
         assertThat(seriesExtractor.uriFor(row1).get(), Matchers.is(brandUri + "/series/2"));
@@ -129,7 +132,7 @@ public class BtVodSeriesWriterTest {
         when(contentResolver.findByCanonicalUris(ImmutableSet.of(brandUri + "/series/1")))
                 .thenReturn(ResolvedContent.builder().build());
 
-        when(brandExtractor.uriFor(entry)).thenReturn(Optional.of(brandUri));
+        when(brandExtractor.brandUriFor(entry)).thenReturn(Optional.of(brandUri));
         when(brandExtractor.getBrandRefFor(entry)).thenReturn(Optional.of(brandRef));
 
 
@@ -149,6 +152,8 @@ public class BtVodSeriesWriterTest {
         entry.setProductOfferStartDate(1364774400000L); //"Apr  1 2013 12:00AM"
         entry.setProductOfferEndDate(1398816000000L);// "Apr 30 2014 12:00AM"
         entry.setProductType("episode");// "Apr 30 2014 12:00AM"
+        entry.setProductTags(ImmutableList.<BtVodPlproduct$productTag>of());
+        entry.setProductScopes(ImmutableList.<BtVodProductScope>of());
         return entry;
     }
 }

--- a/src/test/java/org/atlasapi/remotesite/btvod/DerivingFromItemBrandImageExtractorTest.java
+++ b/src/test/java/org/atlasapi/remotesite/btvod/DerivingFromItemBrandImageExtractorTest.java
@@ -1,0 +1,86 @@
+package org.atlasapi.remotesite.btvod;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.atlasapi.media.entity.Image;
+import org.atlasapi.remotesite.btvod.model.BtVodEntry;
+import org.atlasapi.remotesite.btvod.model.BtVodImage;
+import org.atlasapi.remotesite.btvod.model.BtVodPlproductImages;
+import org.atlasapi.remotesite.btvod.model.BtVodProductMetadata;
+import org.atlasapi.remotesite.btvod.model.BtVodProductScope;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class DerivingFromItemBrandImageExtractorTest {
+
+    private static final String BASE_URL = "http://example.org/";
+    
+    private final BrandUriExtractor brandUriExtractor = mock(BrandUriExtractor.class);
+    private final DerivingFromItemBrandImageExtractor extractor 
+                    = new DerivingFromItemBrandImageExtractor(brandUriExtractor, BASE_URL);
+    
+    @Test
+    public void testExtractsImagesFromLowestEpisodeNumber() {
+        BtVodEntry s1e1 = row(1, 1, "1/1-background.jpg", "1/1-packshot.jpg");
+        BtVodEntry s1e2 = row(1, 2, "1/2-background.jpg", "1/2-packshot.jpg");
+          
+        when(brandUriExtractor.extractBrandUri(s1e1)).thenReturn(Optional.of("http://example.org/"));
+        when(brandUriExtractor.extractBrandUri(s1e2)).thenReturn(Optional.of("http://example.org/"));
+        
+        extractor.process(s1e1);
+        extractor.process(s1e2);
+        
+        Map<String, Image> images = Maps.uniqueIndex(extractor.extractImages(s1e2), new Function<Image, String>() {
+
+            @Override
+            public String apply(Image input) {
+                return input.getCanonicalUri();
+            }
+        });
+        
+        assertNotNull(images.get("http://example.org/1/1-background.jpg"));
+        assertNotNull(images.get("http://example.org/1/1-packshot.jpg"));
+    }
+    
+    private BtVodEntry row(int seriesNumber, int episodeNumber, String backgroundImageUri,
+            String packshotImageUri) {
+        BtVodEntry entry = new BtVodEntry();
+        entry.setGuid("abc");
+        entry.setId("def");
+        entry.setTitle("Test S" + seriesNumber + "-E" + episodeNumber);
+        entry.setProductOfferStartDate(1364774400000L); //"Apr  1 2013 12:00AM"
+        entry.setProductOfferEndDate(1398816000000L);// "Apr 30 2014 12:00AM"
+        entry.setProductType("episode");
+        
+        BtVodProductMetadata metadata = new BtVodProductMetadata();
+        metadata.setEpisodeNumber("1");
+        BtVodProductScope scope = new BtVodProductScope();
+        scope.setProductMetadata(metadata);
+        entry.setProductScopes(ImmutableList.of(scope));
+        
+        BtVodImage backgroundImage = new BtVodImage();
+        backgroundImage.setPlproduct$url(backgroundImageUri);
+        
+        BtVodImage packshotImage = new BtVodImage();
+        packshotImage.setPlproduct$url(packshotImageUri);
+        
+        BtVodPlproductImages images = new BtVodPlproductImages();
+        images.setBackgroundImages(ImmutableList.of(backgroundImage));
+        images.setPackshotDoubleImages(ImmutableList.of(packshotImage));
+        entry.setProductImages(images);
+
+        return entry;
+    }
+}


### PR DESCRIPTION
- Add new source, to ingest low-res images into for testing
  without affecting users of the existing source
- Derive brand image from the image of the first episode
  in the feed, according to editorial ordering