### PR TITLE
TVE equiv should allow either a sequence or title score

### DIFF
--- a/src/main/java/org/atlasapi/equiv/scorers/SequenceItemScorer.java
+++ b/src/main/java/org/atlasapi/equiv/scorers/SequenceItemScorer.java
@@ -15,9 +15,11 @@ import com.google.common.collect.Iterables;
 
 public class SequenceItemScorer implements EquivalenceScorer<Item> {
 
+    public static final String SEQUENCE_SCORER = "Sequence";
+
     @Override
     public ScoredCandidates<Item> score(Item subject, Set<? extends Item> candidates, ResultDescription desc) {
-        Builder<Item> equivalents = DefaultScoredCandidates.fromSource("Sequence");
+        Builder<Item> equivalents = DefaultScoredCandidates.fromSource(SEQUENCE_SCORER);
         
         if (subject instanceof Episode) {
             Episode episode = (Episode) subject;


### PR DESCRIPTION
Previously anything with a null title score was filtered. This
causes problems if the titles are of a different format, e.g.
one is "Episode 1", the other the editorial title.