### PR TITLE
Don't double count series that are skipped

### DIFF
--- a/src/test/java/org/atlasapi/equiv/scorers/ContainerHierarchyMatchingScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/scorers/ContainerHierarchyMatchingScorerTest.java
@@ -100,10 +100,11 @@ public class ContainerHierarchyMatchingScorerTest {
         assertThat(scorer.scoreSortedSeriesSizes(list(1,2,3,4), list(1,2,3,4), "candidate", desc), is(Score.ONE));
         assertThat(scorer.scoreSortedSeriesSizes(list(1,2,3,4,5), list(1,2,3,4), "candidate", desc), is(Score.ONE));
         assertThat(scorer.scoreSortedSeriesSizes(list(1,2,3,4), list(1,3,4), "candidate", desc), is(Score.ONE));
+        assertThat(scorer.scoreSortedSeriesSizes(list(1,2,3,6), list(1,3,5), "candidate", desc), is(Score.ONE));
+        assertThat(scorer.scoreSortedSeriesSizes(list(12,12,12,13), list(3,12,12,12,13), "candidate", desc), is(Score.ONE));
+        
         
         assertThat(scorer.scoreSortedSeriesSizes(list(6,6), list(6,24,24,24), "candidate", desc), is(Score.negativeOne()));
-        
-        assertThat(scorer.scoreSortedSeriesSizes(list(1,2,3,6), list(1,3,5), "candidate", desc), is(Score.nullScore()));
         assertThat(scorer.scoreSortedSeriesSizes(list(6,6), list(24,24), "candidate", desc), is(Score.nullScore()));
         assertThat(scorer.scoreSortedSeriesSizes(list(2,3,4), list(3,4,6,7), "candidate", desc), is(Score.nullScore()));
         


### PR DESCRIPTION
They were being counted twice, both in the mismatch
count and also in the difference in number of elements.