### PR TITLE
Ingest release date from Nitro

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/ContentMerger.java
+++ b/src/main/java/org/atlasapi/remotesite/ContentMerger.java
@@ -76,7 +76,6 @@ public class ContentMerger {
         }
         
         if (current instanceof Episode) {
-            current.setReleaseDates(extracted.getReleaseDates());
             if (extracted instanceof Episode) {
                 current = mergeEpisodeSpecificFields((Episode) current, (Episode) extracted);
             } else if (extracted instanceof Item) {
@@ -85,7 +84,6 @@ public class ContentMerger {
                 current = newItem;
             }
         } else if (current instanceof Item) {
-            current.setReleaseDates(extracted.getReleaseDates());
             if (extracted instanceof Episode) {
                 Episode newEp = new Episode();
                 Item.copyTo(current, newEp);
@@ -99,7 +97,7 @@ public class ContentMerger {
             Film extractedFilm = (Film) extracted;
             currentFilm.setYear(extractedFilm.getYear());
         }
-
+        current.setReleaseDates(extracted.getReleaseDates());
         return current;
     }
 

--- a/src/main/java/org/atlasapi/remotesite/ContentMerger.java
+++ b/src/main/java/org/atlasapi/remotesite/ContentMerger.java
@@ -76,6 +76,7 @@ public class ContentMerger {
         }
         
         if (current instanceof Episode) {
+            current.setReleaseDates(extracted.getReleaseDates());
             if (extracted instanceof Episode) {
                 current = mergeEpisodeSpecificFields((Episode) current, (Episode) extracted);
             } else if (extracted instanceof Item) {
@@ -85,7 +86,6 @@ public class ContentMerger {
             }
         } else if (current instanceof Item) {
             current.setReleaseDates(extracted.getReleaseDates());
-
             if (extracted instanceof Episode) {
                 Episode newEp = new Episode();
                 Item.copyTo(current, newEp);

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroEpisodeExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroEpisodeExtractor.java
@@ -184,7 +184,7 @@ public final class NitroEpisodeExtractor extends BaseNitroItemExtractor<Episode,
 
     private void setReleaseDate(Item item, NitroItemSource<Episode> source) {
         XMLGregorianCalendar date = extractReleaseDate(source);
-        LocalDate localDate = new LocalDate(date.toGregorianCalendar().toZonedDateTime().toLocalDate());
+        LocalDate localDate = new LocalDate(date.getYear(),date.getMonth(),date.getDay());
         ReleaseDate releaseDate = new ReleaseDate(localDate, Countries.GB, ReleaseDate.ReleaseType.FIRST_BROADCAST);
         item.setReleaseDates(Lists.newArrayList(releaseDate));
     }

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroEpisodeExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroEpisodeExtractor.java
@@ -7,8 +7,12 @@ import java.util.Set;
 
 import com.google.common.collect.Lists;
 import com.metabroadcast.common.intl.Countries;
-import com.metabroadcast.common.intl.Country;
-import org.atlasapi.media.entity.*;
+import org.atlasapi.media.entity.CrewMember;
+import org.atlasapi.media.entity.Film;
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.ParentRef;
+import org.atlasapi.media.entity.Person;
+import org.atlasapi.media.entity.ReleaseDate;
 import org.atlasapi.persistence.content.people.QueuingItemsPeopleWriter;
 import org.atlasapi.persistence.content.people.QueuingPersonWriter;
 import org.atlasapi.remotesite.ContentExtractor;

--- a/src/test/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroEpisodeExtractorTest.java
+++ b/src/test/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroEpisodeExtractorTest.java
@@ -125,23 +125,6 @@ public class NitroEpisodeExtractorTest {
     }
 
     @Test
-    public void testReleaseDates() throws DatatypeConfigurationException {
-        Episode episode = new Episode();
-        LocalDate date = LocalDate.now();
-        GregorianCalendar gcal = GregorianCalendar.from(date.atStartOfDay(ZoneId.systemDefault()));
-        XMLGregorianCalendar xcal = DatatypeFactory.newInstance().newXMLGregorianCalendar(gcal);
-        episode.setReleaseDate(xcal);
-        episode.setPid("b012cl84");
-        episode.setTitle("Destiny");
-        episode.setEpisodeOf(pidRef("series", "b00zdhtg"));
-        episode.setAncestorsTitles(ancestorsTitles(null, null,
-                ImmutableMap.of("b00zdhtg", "Wonders of the Universe")
-        ));
-        Item extracted = extractor.extract(NitroItemSource.valueOf(episode, noAvailability));
-        assertThat(extracted.getReleaseDates(), notNullValue());
-    }
-
-    @Test
     public void testParentRefsForExtractedBrandSeriesEpisodeAreBrandAndSeries() {
         
         Episode brandSeriesEpisode = new Episode();

--- a/src/test/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroEpisodeExtractorTest.java
+++ b/src/test/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroEpisodeExtractorTest.java
@@ -9,12 +9,22 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.GregorianCalendar;
+import java.util.Locale;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.TimeZone;
 
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.XMLGregorianCalendar;
+import javax.xml.namespace.QName;
 
+import com.sun.org.apache.xerces.internal.jaxp.datatype.XMLGregorianCalendarImpl;
 import org.atlasapi.media.entity.Encoding;
 import org.atlasapi.media.entity.Film;
 import org.atlasapi.media.entity.Item;
@@ -112,6 +122,23 @@ public class NitroEpisodeExtractorTest {
         assertThat(episode.getContainer().getUri(), endsWith("b00zdhtg"));
         assertThat(episode.getSeriesRef().getUri(), endsWith("b00zdhtg"));
         assertThat(episode.getTitle(), is(brandEpisode.getTitle()));
+    }
+
+    @Test
+    public void testReleaseDates() throws DatatypeConfigurationException {
+        Episode episode = new Episode();
+        LocalDate date = LocalDate.now();
+        GregorianCalendar gcal = GregorianCalendar.from(date.atStartOfDay(ZoneId.systemDefault()));
+        XMLGregorianCalendar xcal = DatatypeFactory.newInstance().newXMLGregorianCalendar(gcal);
+        episode.setReleaseDate(xcal);
+        episode.setPid("b012cl84");
+        episode.setTitle("Destiny");
+        episode.setEpisodeOf(pidRef("series", "b00zdhtg"));
+        episode.setAncestorsTitles(ancestorsTitles(null, null,
+                ImmutableMap.of("b00zdhtg", "Wonders of the Universe")
+        ));
+        Item extracted = extractor.extract(NitroItemSource.valueOf(episode, noAvailability));
+        assertThat(extracted.getReleaseDates(), notNullValue());
     }
 
     @Test


### PR DESCRIPTION
This is ingested into a release date, of type first broadcast. We will use this as a sort order for upload to YouView where there is no position provided by Nitro.

`ContentMerger` now merges release dates, too.