### PR TITLE
Propagate tags from series to brands

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/btvod/AbstractBtVodSeriesExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/AbstractBtVodSeriesExtractor.java
@@ -1,9 +1,10 @@
 package org.atlasapi.remotesite.btvod;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
-import com.metabroadcast.common.scheduling.UpdateProgress;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Map;
+import java.util.Set;
+
 import org.atlasapi.media.entity.Brand;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.media.entity.Series;
@@ -12,32 +13,26 @@ import org.atlasapi.remotesite.btvod.model.BtVodEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Map;
-import java.util.Set;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import com.metabroadcast.common.scheduling.UpdateProgress;
 
 public abstract class AbstractBtVodSeriesExtractor implements BtVodDataProcessor<UpdateProgress> {
 
     private static final Logger log = LoggerFactory.getLogger(AbstractBtVodSeriesExtractor.class);
 
     private final BtVodBrandProvider brandProvider;
-
     private final Publisher publisher;
     private final Map<String, Series> processedSeries = Maps.newHashMap();
     private final BtVodContentListener listener;
-
     private final Set<String> processedRows;
-
     private final BtVodDescribedFieldsExtractor describedFieldsExtractor;
-
     private final ImageExtractor imageExtractor;
-
     private final BtVodSeriesUriExtractor seriesUriExtractor;
+    private final ImmutableSet<TopicRef> topicsToPropagateToParents;
+
     private UpdateProgress progress = UpdateProgress.START;
-
-    private final TopicRef newTopic;
-
 
     protected AbstractBtVodSeriesExtractor(
             BtVodBrandProvider brandProvider,
@@ -47,7 +42,7 @@ public abstract class AbstractBtVodSeriesExtractor implements BtVodDataProcessor
             BtVodDescribedFieldsExtractor describedFieldsExtractor,
             BtVodSeriesUriExtractor seriesUriExtractor,
             ImageExtractor imageExtractor,
-            final TopicRef newTopic
+            Iterable<TopicRef> topicsToPropagateToParents
     ) {
         this.processedRows = checkNotNull(processedRows);
         this.listener = checkNotNull(listener);
@@ -59,7 +54,7 @@ public abstract class AbstractBtVodSeriesExtractor implements BtVodDataProcessor
         //      Added as a collaborator for Alias extraction, but should be used more
         //      widely
         this.describedFieldsExtractor = checkNotNull(describedFieldsExtractor);
-        this.newTopic = checkNotNull(newTopic);
+        this.topicsToPropagateToParents = ImmutableSet.copyOf(topicsToPropagateToParents);
     }
 
     @Override
@@ -77,11 +72,9 @@ public abstract class AbstractBtVodSeriesExtractor implements BtVodDataProcessor
             } else {
                 series = seriesFrom(row);
             }
+            setFields(series, row);
             setAdditionalFields(series, row);
-            if (series.getTopicRefs().contains((newTopic))) {
-                Brand brand = brandProvider.brandFor(row).get();
-                brand.addTopicRef(newTopic);
-            }
+            addTopicsToParents(series, row);
             onSeriesProcessed(series, row);
             // This allows a lookup by series title. Note that the only reference from an episode to a series is the series title.
             // Consequently this map will be used to lookup SeriesRef when processing episodes
@@ -96,6 +89,24 @@ public abstract class AbstractBtVodSeriesExtractor implements BtVodDataProcessor
             progress = progress.reduce(thisProgress);
         }
         return true;
+    }
+
+    private final void setFields(Series series, BtVodEntry row) {
+        VodEntryAndContent vodEntryAndContent = new VodEntryAndContent(row, series);
+        series.addTopicRefs(describedFieldsExtractor.topicsFrom(vodEntryAndContent));
+    }
+    
+    //TODO Factor this out rather than duplicate from BtVodItemExtractor
+    private void addTopicsToParents(Series series, BtVodEntry row) {
+        for (TopicRef topicRef : topicsToPropagateToParents) {
+            if (series.getTopicRefs().contains(topicRef)) {
+                if (series.getParent() != null) {
+                    Brand brand = brandProvider.brandFor(row).get();
+                    brand.addTopicRef(topicRef);
+                    listener.onContent(brand, row);
+                }
+            }
+        }
     }
 
     @Override

--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodExplicitSeriesExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodExplicitSeriesExtractor.java
@@ -34,9 +34,18 @@ public class BtVodExplicitSeriesExtractor extends AbstractBtVodSeriesExtractor {
             BtVodVersionsExtractor versionsExtractor,
             TitleSanitiser titleSanitiser,
             ImageExtractor imageExtractor,
-            TopicRef newTopic
+            Iterable<TopicRef> topicsToPropagateToParents
     ) {
-        super(btVodBrandProvider, publisher, listener, processedRows, describedFieldsExtractor, seriesUriExtractor, imageExtractor, newTopic);
+        super(
+                btVodBrandProvider, 
+                publisher, 
+                listener, 
+                processedRows, 
+                describedFieldsExtractor, 
+                seriesUriExtractor, 
+                imageExtractor, 
+                topicsToPropagateToParents
+             );
         this.titleSanitiser = checkNotNull(titleSanitiser);
         this.versionsExtractor = checkNotNull(versionsExtractor);
         explicitSeries = Maps.newHashMap();

--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodItemExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodItemExtractor.java
@@ -77,10 +77,7 @@ public class BtVodItemExtractor implements BtVodDataProcessor<UpdateProgress> {
             TitleSanitiser titleSanitiser,
             ImageExtractor imageExtractor,
             BtVodVersionsExtractor versionsExtractor,
-            TopicRef newTopic,
-            TopicRef kidsTopic,
-            TopicRef tvTopic,
-            TopicRef subscriptionCatchupTopic
+            Iterable<TopicRef> topicsToPropagateToParents
     ) {
         this.brandProvider = checkNotNull(brandProvider);
         this.describedFieldsExtractor = checkNotNull(describedFieldsExtractor);
@@ -93,7 +90,7 @@ public class BtVodItemExtractor implements BtVodDataProcessor<UpdateProgress> {
         this.processedItems = Maps.newHashMap();
         this.imageExtractor = checkNotNull(imageExtractor);
         this.versionsExtractor = checkNotNull(versionsExtractor);
-        this.topicsToPropagateToParents = ImmutableSet.of(newTopic, kidsTopic, tvTopic, subscriptionCatchupTopic);
+        this.topicsToPropagateToParents = ImmutableSet.copyOf(topicsToPropagateToParents);
     }
 
     @Override
@@ -123,8 +120,8 @@ public class BtVodItemExtractor implements BtVodDataProcessor<UpdateProgress> {
 
     private boolean shouldProcess(BtVodEntry row) {
         return !COLLECTION_TYPE.equals(row.getProductType()) 
-                    && !HELP_TYPE.equals(row.getProductType());
-                    //&& !SEASON_TYPE.equals(row.getProductType());
+                    && !HELP_TYPE.equals(row.getProductType())
+                    && !SEASON_TYPE.equals(row.getProductType());
     }
 
     private boolean isEpisode(BtVodEntry row) {

--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodSynthesizedSeriesExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodSynthesizedSeriesExtractor.java
@@ -34,7 +34,7 @@ public class BtVodSynthesizedSeriesExtractor extends AbstractBtVodSeriesExtracto
             BtVodSeriesUriExtractor seriesUriExtractor,
             Set<String> explicitSeriesIds,
             ImageExtractor imageExtractor,
-            TopicRef newTopic
+            Iterable<TopicRef> topicsToPropagateToParents
     ) {
         super(
                 btVodBrandProvider,
@@ -44,7 +44,7 @@ public class BtVodSynthesizedSeriesExtractor extends AbstractBtVodSeriesExtracto
                 describedFieldsExtractor,
                 seriesUriExtractor,
                 imageExtractor,
-                newTopic
+                topicsToPropagateToParents
         );
 
         this.explicitSeriesIds = ImmutableSet.copyOf(explicitSeriesIds);

--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodUpdater.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodUpdater.java
@@ -7,12 +7,14 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.Iterables;
+
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.media.entity.Series;
 import org.atlasapi.media.entity.Topic;
+import org.atlasapi.media.entity.TopicRef;
 import org.atlasapi.persistence.content.ContentWriter;
 import org.atlasapi.remotesite.btvod.contentgroups.BtVodContentGroupUpdater;
 import org.slf4j.Logger;
@@ -20,6 +22,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.api.client.repackaged.com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.metabroadcast.common.scheduling.ScheduledTask;
 
@@ -113,6 +116,14 @@ public class BtVodUpdater extends ScheduledTask {
         String explicitSeriesExtractStatus = "[TODO]";
         String synthesizedSeriesExtractStatus = "[TODO]";
         String itemExtractStatus = "[TODO]";
+        
+        ImmutableSet<TopicRef> topicsToPropagateToParents = 
+                ImmutableSet.of(
+                                    describedFieldsExtractor.topicRefFor(newTopic),
+                                    describedFieldsExtractor.topicRefFor(kidsTopic),
+                                    describedFieldsExtractor.topicRefFor(tvBoxsetTopic),
+                                    describedFieldsExtractor.topicRefFor(subscriptionCatchupTopic)
+                                );
 
         try {
             reportStatus("Extracting brand images");
@@ -156,7 +167,7 @@ public class BtVodUpdater extends ScheduledTask {
                     seriesUriExtractor,
                     versionsExtractor, new TitleSanitiser(),
                     imageExtractor,
-                    describedFieldsExtractor.topicRefFor(newTopic)
+                    topicsToPropagateToParents
             );
             
             vodData.processData(explicitSeriesExtractor);
@@ -189,7 +200,7 @@ public class BtVodUpdater extends ScheduledTask {
                     seriesUriExtractor,
                     explicitSeries.keySet(),
                     imageExtractor,
-                    describedFieldsExtractor.topicRefFor(newTopic)
+                    topicsToPropagateToParents
             );
             vodData.processData(synthesizedSeriesExtractor);
             synthesizedSeriesExtractStatus = String.format(
@@ -224,10 +235,7 @@ public class BtVodUpdater extends ScheduledTask {
                     new TitleSanitiser(),
                     imageExtractor,
                     versionsExtractor,
-                    describedFieldsExtractor.topicRefFor(newTopic),
-                    describedFieldsExtractor.topicRefFor(kidsTopic),
-                    describedFieldsExtractor.topicRefFor(tvBoxsetTopic),
-                    describedFieldsExtractor.topicRefFor(subscriptionCatchupTopic)
+                    topicsToPropagateToParents
             );
 
             vodData.processData(itemExtractor);

--- a/src/test/java/org/atlasapi/remotesite/btvod/BtVodExplicitSeriesExtractorTest.java
+++ b/src/test/java/org/atlasapi/remotesite/btvod/BtVodExplicitSeriesExtractorTest.java
@@ -71,7 +71,7 @@ public class BtVodExplicitSeriesExtractorTest {
                 ),
                 new TitleSanitiser(),
                 imageExtractor,
-                newTopic
+                ImmutableSet.of(newTopic)
         );
     }
 

--- a/src/test/java/org/atlasapi/remotesite/btvod/BtVodItemExtractorTest.java
+++ b/src/test/java/org/atlasapi/remotesite/btvod/BtVodItemExtractorTest.java
@@ -119,10 +119,12 @@ public class BtVodItemExtractorTest {
                     null,
                     null
             ),
-            newTopicRef,
-            new TopicRef(new Topic(234L), 1.0f, false, TopicRef.Relationship.ABOUT),
-            new TopicRef(new Topic(345L), 1.0f, false, TopicRef.Relationship.ABOUT),
-            new TopicRef(new Topic(456L), 1.0f, false, TopicRef.Relationship.ABOUT)
+            ImmutableSet.of(
+                            newTopicRef,
+                            new TopicRef(new Topic(234L), 1.0f, false, TopicRef.Relationship.ABOUT),
+                            new TopicRef(new Topic(345L), 1.0f, false, TopicRef.Relationship.ABOUT),
+                            new TopicRef(new Topic(456L), 1.0f, false, TopicRef.Relationship.ABOUT)
+                    )
     );
     
     @Test


### PR DESCRIPTION
The box-set tag was being applied to brands through the
erroneous creation of an item from the season record in MPX.
When that was removed, the box-set tag wasn't applied to brands,
since the tag is only derived from the season record.

We now propagate the same set of tags from a series to a brand
as we do from an episode to its parents.