### PR TITLE
Fix NPE in building BtVodSeriesProvider with Series that has null Par…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
                     <target>1.7</target>
                     <fork>true</fork>
                     <compilerArgs>
-                        <arg>-J-Xss1M</arg>
+                        <arg>-J-Xss5M</arg>
                     </compilerArgs>
                 </configuration>
             </plugin>

--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodSeriesProvider.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodSeriesProvider.java
@@ -88,7 +88,9 @@ public class BtVodSeriesProvider {
         ImmutableTable.Builder<ParentRef, Integer, Series> builder = ImmutableTable.builder();
 
         for (Series series : seriesMap.values()) {
-            builder.put(series.getParent(), series.getSeriesNumber(), series);
+            if (series.getParent() != null && series.getSeriesNumber() != null) {
+                builder.put(series.getParent(), series.getSeriesNumber(), series);
+            }
         }
 
         return builder.build();

--- a/src/test/java/org/atlasapi/remotesite/btvod/BtVodSeriesProviderTest.java
+++ b/src/test/java/org/atlasapi/remotesite/btvod/BtVodSeriesProviderTest.java
@@ -2,6 +2,7 @@ package org.atlasapi.remotesite.btvod;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -103,5 +104,22 @@ public class BtVodSeriesProviderTest {
         objectUnderTest.updateSeriesFromEpisode(episodeRow, episode);
 
         verify(certificateUpdater).updateCertificates(EXPLICIT_SERIES, episode);
+    }
+
+    @Test
+    public void testCanConstructProviderFromSeriesWithNullParentAndNullSeriesNumber()
+            throws Exception {
+        Series series = mock(Series.class);
+
+        when(series.getParent()).thenReturn(null);
+        when(series.getSeriesNumber()).thenReturn(null);
+
+        new BtVodSeriesProvider(
+                ImmutableMap.of("guid", series),
+                ImmutableMap.<String, Series>of(),
+                seriesUriExtractor,
+                certificateUpdater,
+                brandProvider
+        );
     }
 }


### PR DESCRIPTION
…entRef or null series number

- Give compiler 5M of memory for stack to deal with compilation stack overflow