### PR TITLE
Disable hierarchy scoring for subscription catchup brands

### DIFF
--- a/src/main/java/org/atlasapi/equiv/EquivModule.java
+++ b/src/main/java/org/atlasapi/equiv/EquivModule.java
@@ -45,7 +45,6 @@ import static org.atlasapi.media.entity.Publisher.YOUVIEW_STAGE;
 import static org.atlasapi.media.entity.Publisher.YOUVIEW_SCOTLAND_RADIO;
 import static org.atlasapi.media.entity.Publisher.YOUVIEW_SCOTLAND_RADIO_STAGE;
 
-
 import java.io.File;
 import java.util.Set;
 
@@ -91,6 +90,7 @@ import org.atlasapi.equiv.scorers.SequenceContainerScorer;
 import org.atlasapi.equiv.scorers.SequenceItemScorer;
 import org.atlasapi.equiv.scorers.SeriesSequenceItemScorer;
 import org.atlasapi.equiv.scorers.SongCrewMemberExtractor;
+import org.atlasapi.equiv.scorers.SubscriptionCatchupBrandDetector;
 import org.atlasapi.equiv.scorers.TitleMatchingContainerScorer;
 import org.atlasapi.equiv.scorers.TitleMatchingItemScorer;
 import org.atlasapi.equiv.scorers.TitleSubsetBroadcastItemScorer;
@@ -539,7 +539,11 @@ public class EquivModule {
             )
             .withScorers(ImmutableSet.of(
                 new TitleMatchingContainerScorer(),
-                new ContainerHierarchyMatchingScorer(contentResolver, Score.negativeOne())
+                new ContainerHierarchyMatchingScorer(
+                        contentResolver, 
+                        Score.negativeOne(), 
+                        new SubscriptionCatchupBrandDetector(contentResolver)
+                    )
             ))
             .withCombiner(new RequiredScoreFilteringCombiner<Container>(
                 new NullScoreAwareAveragingCombiner<Container>(),

--- a/src/main/java/org/atlasapi/equiv/scorers/SubscriptionCatchupBrandDetector.java
+++ b/src/main/java/org/atlasapi/equiv/scorers/SubscriptionCatchupBrandDetector.java
@@ -1,0 +1,93 @@
+package org.atlasapi.equiv.scorers;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.atlasapi.media.entity.ChildRef;
+import org.atlasapi.media.entity.Container;
+import org.atlasapi.media.entity.Episode;
+import org.atlasapi.media.entity.Series;
+import org.atlasapi.persistence.content.ContentResolver;
+import org.atlasapi.persistence.content.ResolvedContent;
+
+import com.google.common.base.Function;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+
+/**
+ * Guess whether a brand contains a few episodes matching a subscription
+ * catch-up model, where the most recent few broadcast episodes are 
+ * available to watch, but no more. This is useful for a VOD catalogue
+ * that doesn't contain historical episodes, but just those currently
+ * available.
+ *
+ */
+public class SubscriptionCatchupBrandDetector {
+
+    private final ContentResolver contentResolver;
+
+    public SubscriptionCatchupBrandDetector(ContentResolver contentResolver) {
+        this.contentResolver = checkNotNull(contentResolver);
+    }
+    
+    public boolean couldBeSubscriptionCatchup(Container subject, List<Series> series) {
+        if (series.size() > 2
+                || series.size() == 0) {
+            return false;
+        }
+        if (series.size() == 2
+                && !areSeriesConsecutive(series.get(0), series.get(1))) {
+            return false;
+        }
+        for (Series s : series ) {
+            if (!allEpisodesAreConsecutive(s)) {
+                return false;
+            }
+        }
+        return true;
+    }
+    
+    private boolean areSeriesConsecutive(Series s1, Series s2) {
+        return !(s1.getSeriesNumber() == null 
+                    || s2.getSeriesNumber() == null
+                    || Math.abs(s1.getSeriesNumber() - s2.getSeriesNumber()) > 1);
+    }
+    
+    private boolean allEpisodesAreConsecutive(Series s) {
+        ResolvedContent children = contentResolver.findByCanonicalUris(ImmutableList.copyOf(Iterables.transform(s.getChildRefs(), ChildRef.TO_URI)));
+        Iterable<Episode> episodes = Iterables.filter(children.getAllResolvedResults(), Episode.class);
+        List<Integer> episodeNumbers = Lists.newArrayList(
+                                           Iterables.filter(
+                                                Iterables.transform(episodes, TO_EPISODE_NUMBER), 
+                                                Predicates.notNull()
+                                           )
+                                       );
+        
+        Collections.sort(Lists.newArrayList(episodeNumbers));
+        if (episodeNumbers.size() != s.getChildRefs().size()) {
+            // If null episode numbers were removed
+            return false;
+        }
+        Integer previousEpisodeNumber = null;
+        for (Integer episodeNumber : episodeNumbers) {
+            if (previousEpisodeNumber != null
+                    && episodeNumber - previousEpisodeNumber > 1) {
+                return false;
+            }
+            previousEpisodeNumber = episodeNumber;
+        }
+        return true;
+    }
+    
+    private static Function<Episode, Integer> TO_EPISODE_NUMBER = new Function<Episode, Integer>() {
+        
+        @Override
+        public Integer apply(Episode input) {
+            return input.getEpisodeNumber();
+        }
+    };
+}

--- a/src/test/java/org/atlasapi/equiv/scorers/ContainerHierarchyMatchingScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/scorers/ContainerHierarchyMatchingScorerTest.java
@@ -1,5 +1,6 @@
 package org.atlasapi.equiv.scorers;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
@@ -18,13 +19,17 @@ import org.atlasapi.equiv.results.scores.ScoredCandidates;
 import org.atlasapi.media.entity.Brand;
 import org.atlasapi.media.entity.ChildRef;
 import org.atlasapi.media.entity.Container;
+import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.EntityType;
+import org.atlasapi.media.entity.Episode;
 import org.atlasapi.media.entity.Identified;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.media.entity.Series;
 import org.atlasapi.media.entity.SeriesRef;
 import org.atlasapi.persistence.content.ContentResolver;
 import org.atlasapi.persistence.content.ResolvedContent;
+import org.atlasapi.persistence.content.ResolvedContent.ResolvedContentBuilder;
+import org.hamcrest.core.IsNull;
 import org.joda.time.DateTime;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,8 +46,9 @@ import com.metabroadcast.common.time.DateTimeZones;
 public class ContainerHierarchyMatchingScorerTest {
 
     private final ContentResolver contentResolver = mock(ContentResolver.class);
+    private SubscriptionCatchupBrandDetector subscriptionCatchupBrandDetector = mock(SubscriptionCatchupBrandDetector.class);
     
-    private final ContainerHierarchyMatchingScorer scorer = new ContainerHierarchyMatchingScorer(contentResolver, Score.negativeOne());
+    private final ContainerHierarchyMatchingScorer scorer = new ContainerHierarchyMatchingScorer(contentResolver, Score.negativeOne(), subscriptionCatchupBrandDetector);
     
     @Test
     @SuppressWarnings("unchecked")
@@ -184,7 +190,7 @@ public class ContainerHierarchyMatchingScorerTest {
     private Map<String, ? extends Identified> series(int seriesCount) {
         Builder<String, Series> builder = ImmutableMap.builder();
         for (int j = 0; j < seriesCount; j++) {
-            Series series = new Series("uri"+j, "curie", Publisher.BBC);
+            Series series = series("uri"+j, null);
             builder.put(series.getCanonicalUri(), series);
         };
         return builder.build();
@@ -204,6 +210,11 @@ public class ContainerHierarchyMatchingScorerTest {
 
     public void setChildren(int children, Container brand) {
         brand.setChildRefs(Iterables.limit(Iterables.cycle(new ChildRef(1234L, "uri", "sk", new DateTime(DateTimeZones.UTC), EntityType.EPISODE)), children));
+    }
+    
+    private Series series(String uri, Integer seriesNumber) {
+        Series series = new Series(uri, null, Publisher.METABROADCAST);
+        return series.withSeriesNumber(seriesNumber);
     }
 
 }

--- a/src/test/java/org/atlasapi/equiv/scorers/SubscriptionCatchupBrandDetectorTest.java
+++ b/src/test/java/org/atlasapi/equiv/scorers/SubscriptionCatchupBrandDetectorTest.java
@@ -1,0 +1,155 @@
+package org.atlasapi.equiv.scorers;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.atlasapi.media.entity.Brand;
+import org.atlasapi.media.entity.ChildRef;
+import org.atlasapi.media.entity.Container;
+import org.atlasapi.media.entity.Content;
+import org.atlasapi.media.entity.EntityType;
+import org.atlasapi.media.entity.Episode;
+import org.atlasapi.media.entity.Publisher;
+import org.atlasapi.media.entity.Series;
+import org.atlasapi.persistence.content.ContentResolver;
+import org.atlasapi.persistence.content.ResolvedContent;
+import org.atlasapi.persistence.content.ResolvedContent.ResolvedContentBuilder;
+import org.joda.time.DateTime;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.metabroadcast.common.time.DateTimeZones;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SubscriptionCatchupBrandDetectorTest {
+
+    private final ContentResolver contentResolver = mock(ContentResolver.class);
+    private final SubscriptionCatchupBrandDetector detector = new SubscriptionCatchupBrandDetector(contentResolver);
+    
+    @Test
+    public void testIdentifiesBrandWithTwoConsecutiveSeasonsAsMaybeCatchup() {
+        Brand brand = new Brand();
+        Series s1 = series("http://example.org/s1", 1);
+        Series s2 = series("http://example.org/s2", 2);
+        
+        Episode s1e1 = episode("http://example.org/s1e1", 1);
+        Episode s1e2 = episode("http://example.org/s1e2", 2);
+        s1.setChildRefs(ImmutableList.of(s1e1.childRef(), s1e2.childRef()));
+        
+        Episode s2e1 = episode("http://example.org/s2e1", 1);
+        Episode s2e2 = episode("http://example.org/s2e2", 2);
+        s2.setChildRefs(ImmutableList.of(s2e1.childRef(), s2e2.childRef()));
+        
+        brand.setSeriesRefs(ImmutableList.of(s1.seriesRef(), s2.seriesRef()));
+        
+        when(contentResolver.findByCanonicalUris(ImmutableList.of(s1.getCanonicalUri(), s2.getCanonicalUri())))
+            .thenReturn(resolved(ImmutableList.of(s1, s2)));
+        
+        when(contentResolver.findByCanonicalUris(ImmutableList.of(s1e1.getCanonicalUri(), s1e2.getCanonicalUri())))
+            .thenReturn(resolved(ImmutableList.of(s1e1, s1e2)));
+        
+        when(contentResolver.findByCanonicalUris(ImmutableList.of(s2e1.getCanonicalUri(), s2e2.getCanonicalUri())))
+            .thenReturn(resolved(ImmutableList.of(s2e1, s2e2)));
+        
+        assertTrue(detector.couldBeSubscriptionCatchup(brand, ImmutableList.of(s1, s2)));
+    }
+    
+    @Test
+    public void testIdentifiesBrandWithTwoNonConsecutiveSeasonsAsNotMaybeCatchup() {
+        Brand brand = new Brand();
+        Series s1 = series("http://example.org/s1", 1);
+        Series s3 = series("http://example.org/s3", 3);
+        
+        brand.setSeriesRefs(ImmutableList.of(s1.seriesRef(), s3.seriesRef()));
+        
+        when(contentResolver.findByCanonicalUris(ImmutableList.of(s1.getCanonicalUri(), s3.getCanonicalUri())))
+            .thenReturn(resolved(ImmutableList.of(s1, s3)));
+        
+        assertFalse(detector.couldBeSubscriptionCatchup(brand, ImmutableList.of(s1, s3)));
+    }
+    
+    @Test
+    public void testIdentifiesBrandWithTwoConsecutiveSeasonsButNotConsecutiveEpisodesAsNotMaybeCatchup() {
+        Brand brand = new Brand();
+        Series s1 = series("http://example.org/s1", 1);
+        Series s2 = series("http://example.org/s2", 2);
+        
+        Episode s1e1 = episode("http://example.org/s1e1", 1);
+        Episode s1e2 = episode("http://example.org/s1e2", 2);
+        s1.setChildRefs(ImmutableList.of(s1e1.childRef(), s1e2.childRef()));
+        
+        Episode s2e1 = episode("http://example.org/s2e1", 1);
+        Episode s2e2 = episode("http://example.org/s2e2", 3);
+       
+        s2.setChildRefs(ImmutableList.of(s2e1.childRef(), s2e2.childRef()));
+        
+        brand.setSeriesRefs(ImmutableList.of(s1.seriesRef(), s2.seriesRef()));
+        
+        when(contentResolver.findByCanonicalUris(ImmutableList.of(s1.getCanonicalUri(), s2.getCanonicalUri())))
+            .thenReturn(resolved(ImmutableList.of(s1, s2)));
+        
+        when(contentResolver.findByCanonicalUris(ImmutableList.of(s1e1.getCanonicalUri(), s1e2.getCanonicalUri())))
+            .thenReturn(resolved(ImmutableList.of(s1e1, s1e2)));
+        
+        when(contentResolver.findByCanonicalUris(ImmutableList.of(s2e1.getCanonicalUri(), s2e2.getCanonicalUri())))
+            .thenReturn(resolved(ImmutableList.of(s2e1, s2e2)));
+        
+        assertFalse(detector.couldBeSubscriptionCatchup(brand, ImmutableList.of(s1, s2)));
+    }
+    
+    @Test
+    // Three seasons is considered too many to be possibly subscription catchup
+    public void testIdentifiesBrandWithThreeConsecutiveSeasonsAsNotMaybeCatchup() {
+        Brand brand = new Brand();
+        Series s1 = series("http://example.org/s1", 1);
+        Series s2 = series("http://example.org/s2", 2);
+        Series s3 = series("http://example.org/s3", 3);
+        
+        assertFalse(detector.couldBeSubscriptionCatchup(brand, ImmutableList.of(s1, s2, s3)));
+    }
+
+    @Test
+    public void testIdentifiesBrandWithNoSeasonsAsNotMaybeCatchup() {
+        Brand brand = new Brand();
+        
+        assertFalse(detector.couldBeSubscriptionCatchup(brand, ImmutableList.<Series>of()));
+    }
+    
+    private ResolvedContent resolved(Iterable<? extends Content> contents) {
+        ResolvedContentBuilder builder = ResolvedContent.builder();
+        for (Content content : contents) {
+            builder.put(content.getCanonicalUri(), content);
+        }
+        return builder.build();
+    }
+    
+    
+    public Episode episode(String uri, Integer episodeNumber) {
+        Episode episode = new Episode(uri, null, Publisher.METABROADCAST);
+        episode.setEpisodeNumber(episodeNumber);
+        return episode;
+    }
+    
+    public Series series(String uri, Integer seriesNumber) {
+        Series series = new Series(uri, null, Publisher.METABROADCAST);
+        return series.withSeriesNumber(seriesNumber);
+    }
+
+    private Brand brandWithChildren(int children) {
+        Brand brand = new Brand();
+        setChildren(children, brand);
+        return brand;
+    }
+    
+    public void setChildren(int children, Container brand) {
+        brand.setChildRefs(Iterables.limit(Iterables.cycle(new ChildRef(1234L, "uri", "sk", new DateTime(DateTimeZones.UTC), EntityType.EPISODE)), children));
+    }
+}


### PR DESCRIPTION
These brands only have a few episodes available, so hierarchy
matching will score badly, since hierarchies will differ
greatly from equivalence candidates with fuller catalogues
(such as broadcast data sources)