### PR TITLE
Fix bug where images/descriptions only came from first row

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/btvod/AbstractBtVodSeriesExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/AbstractBtVodSeriesExtractor.java
@@ -59,16 +59,13 @@ public abstract class AbstractBtVodSeriesExtractor implements BtVodDataProcessor
             }
 
             Series series;
-            boolean updatingExisting;
             if (processedSeries.containsKey(seriesUriExtractor.seriesUriFor(row).get())) {
                 series = processedSeries.get(seriesUriExtractor.seriesUriFor(row).get());
-                updatingExisting = true;
             } else {
                 series = seriesFrom(row);
-                updatingExisting = false;
             }
             setFields(series, row);
-            setAdditionalFields(series, row, updatingExisting);
+            setAdditionalFields(series, row);
             onSeriesProcessed(series, row);
 
             brandProvider.updateBrandFromSeries(row, series);
@@ -110,8 +107,7 @@ public abstract class AbstractBtVodSeriesExtractor implements BtVodDataProcessor
 
     protected abstract void onSeriesProcessed(Series series, BtVodEntry row);
 
-    protected abstract void setAdditionalFields(Series series, BtVodEntry row,
-            boolean updatingExisting);
+    protected abstract void setAdditionalFields(Series series, BtVodEntry row);
 
     private Series seriesFrom(BtVodEntry row) {
         Series series = new Series(seriesUriExtractor.seriesUriFor(row).get(), null, publisher);

--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodDescribedFieldsExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodDescribedFieldsExtractor.java
@@ -240,15 +240,6 @@ public class BtVodDescribedFieldsExtractor {
         described.setAliases(aliasesFrom(row));
     }
 
-    public void setDescriptionsFrom(BtVodEntry row, Described described) {
-        if (row.getDescription() != null) {
-            described.setDescription(row.getDescription());
-        }
-        if (row.getProductLongDescription() != null) {
-            described.setLongDescription(row.getProductLongDescription());
-        }
-    }
-
     public Set<String> btGenreStringsFrom(BtVodEntry row) {
         ImmutableSet.Builder<String> genres = ImmutableSet.builder();
 

--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodExplicitSeriesExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodExplicitSeriesExtractor.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.atlasapi.media.entity.Certificate;
-import org.atlasapi.media.entity.Image;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.media.entity.Series;
 import org.atlasapi.media.entity.Version;
@@ -16,7 +15,6 @@ import org.atlasapi.remotesite.btvod.model.BtVodProductRating;
 import com.google.api.client.util.Maps;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.metabroadcast.common.intl.Countries;
 
@@ -69,17 +67,12 @@ public class BtVodExplicitSeriesExtractor extends AbstractBtVodSeriesExtractor {
     }
 
     @Override
-    protected void setAdditionalFields(Series series, BtVodEntry row, boolean updatingExisting) {
+    protected void setAdditionalFields(Series series, BtVodEntry row) {
         Set<Version> currentVersions = versionsExtractor.createVersions(row);
 
-        if (updatingExisting) {
-            descriptionAndImageUpdater.updateDescriptionsAndImages(
-                    series, row, imageExtractor.imagesFor(row), currentVersions
-            );
-        } else {
-            getDescribedFieldsExtractor().setDescriptionsFrom(row, series);
-            setImagesFrom(row, series);
-        }
+        descriptionAndImageUpdater.updateDescriptionsAndImages(
+                series, row, imageExtractor.imagesFor(row), currentVersions
+        );
 
         series.addVersions(currentVersions);
 
@@ -97,21 +90,5 @@ public class BtVodExplicitSeriesExtractor extends AbstractBtVodSeriesExtractor {
 
     public Map<String, Series> getExplicitSeries() {
         return ImmutableMap.copyOf(explicitSeries);
-    }
-
-    private void setImagesFrom(BtVodEntry row, Series series) {
-        Set<Image> images = imageExtractor.imagesFor(row);
-
-        if (images.isEmpty()) {
-            if (series.getImages() == null) {
-                series.setImages(ImmutableSet.<Image>of());
-            }
-            return;
-        }
-
-        series.setImages(images);
-        if (series.getImages() != null && !series.getImages().isEmpty()){
-            series.setImage(Iterables.get(series.getImages(), 0).getCanonicalUri());
-        }
     }
 }

--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodSynthesizedSeriesExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodSynthesizedSeriesExtractor.java
@@ -74,7 +74,7 @@ public class BtVodSynthesizedSeriesExtractor extends AbstractBtVodSeriesExtracto
     }
 
     @Override
-    protected void setAdditionalFields(Series series, BtVodEntry row, boolean updatingExisting) {}
+    protected void setAdditionalFields(Series series, BtVodEntry row) {}
 
     public Map<String, Series> getSynthesizedSeries() {
         return ImmutableMap.copyOf(synthesizedSeries);

--- a/src/test/java/org/atlasapi/remotesite/btvod/BtVodExplicitSeriesExtractorTest.java
+++ b/src/test/java/org/atlasapi/remotesite/btvod/BtVodExplicitSeriesExtractorTest.java
@@ -118,7 +118,6 @@ public class BtVodExplicitSeriesExtractorTest {
         Series series = Iterables.getOnlyElement(seriesExtractor.getExplicitSeries().values());
 
         verify(describedFieldsExtractor).setDescribedFieldsFrom(entry, series);
-        verify(describedFieldsExtractor).setDescriptionsFrom(entry, series);
 
         assertThat(series.getCanonicalUri(), is("seriesUri"));
         assertThat(series.getSeriesNumber(), is(1));

--- a/src/test/java/org/atlasapi/remotesite/btvod/DedupedDescriptionAndImageUpdaterTest.java
+++ b/src/test/java/org/atlasapi/remotesite/btvod/DedupedDescriptionAndImageUpdaterTest.java
@@ -22,6 +22,7 @@ import org.atlasapi.media.entity.Policy;
 import org.atlasapi.media.entity.Quality;
 import org.atlasapi.media.entity.Version;
 import org.atlasapi.remotesite.btvod.model.BtVodEntry;
+import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -59,20 +60,26 @@ public class DedupedDescriptionAndImageUpdaterTest {
     }
 
     @Test
-    public void testShouldNotUpdateIfTargetHasOwnDescriptionsAndImages() throws Exception {
-        Set<Image> images = ImmutableSet.of(new Image("image"));
+    public void testShouldNotUpdateIfSourceHasNoUsefulValues() throws Exception {
+        updater.updateDescriptionsAndImages(
+                target, new BtVodEntry(), ImmutableSet.<Image>of(),
+                getVersions(ImmutableMap.of(HD, SUBSCRIPTION))
+        );
 
+        assertThat(target.getDescription(), is(CoreMatchers.<String>nullValue()));
+        assertThat(target.getLongDescription(), is(CoreMatchers.<String>nullValue()));
+        assertThat(target.getImages(), is(CoreMatchers.<Set<Image>>nullValue()));
+    }
+
+    @Test
+    public void testShouldAlwaysUpdateIfTargetHasNotBeenSeenBefore() throws Exception {
         target.setDescription("desc");
-        target.setLongDescription("longDesc");
-        target.setImages(images);
 
         updater.updateDescriptionsAndImages(
                 target, firstRow, firstImages, getVersions(ImmutableMap.of(HD, SUBSCRIPTION))
         );
 
-        assertThat(target.getDescription(), is("desc"));
-        assertThat(target.getLongDescription(), is("longDesc"));
-        assertThat(target.getImages(), is(images));
+        checkChoice(firstRow, firstImages);
     }
 
     @Test


### PR DESCRIPTION
- The existing logic mistakenly selectes images and descriptions from
the first MPX row to be processed and ignored all those that were
deduped into it