### PR TITLE
Mbst 13615 changing extractor for people to contributions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -557,7 +557,7 @@
        <dependency>
           <groupId>com.metabroadcast.atlas.glycerin</groupId>
           <artifactId>glycerin</artifactId>
-          <version>0.1.12</version>
+          <version>1.0.2</version>
        </dependency>
        <dependency>
            <groupId>com.google.http-client</groupId>

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/GlycerinNitroContentAdapter.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/GlycerinNitroContentAdapter.java
@@ -1,5 +1,30 @@
 package org.atlasapi.remotesite.bbc.nitro;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.metabroadcast.atlas.glycerin.queries.ProgrammesMixin.ANCESTOR_TITLES;
+import static com.metabroadcast.atlas.glycerin.queries.ProgrammesMixin.CONTRIBUTIONS;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+
+import org.atlasapi.media.entity.Brand;
+import org.atlasapi.media.entity.Clip;
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Series;
+import org.atlasapi.persistence.content.people.QueuingPersonWriter;
+import org.atlasapi.remotesite.bbc.nitro.extract.NitroBrandExtractor;
+import org.atlasapi.remotesite.bbc.nitro.extract.NitroEpisodeExtractor;
+import org.atlasapi.remotesite.bbc.nitro.extract.NitroItemSource;
+import org.atlasapi.remotesite.bbc.nitro.extract.NitroSeriesExtractor;
+import org.atlasapi.remotesite.bbc.nitro.extract.NitroUtil;
+import org.atlasapi.remotesite.bbc.nitro.v1.NitroClient;
+import org.atlasapi.remotesite.bbc.nitro.v1.NitroGenreGroup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.api.client.util.Lists;
 import com.google.common.base.Function;
 import com.google.common.base.Predicates;
@@ -29,34 +54,9 @@ import com.metabroadcast.atlas.glycerin.queries.BroadcastsQuery;
 import com.metabroadcast.atlas.glycerin.queries.ProgrammesQuery;
 import com.metabroadcast.atlas.glycerin.queries.VersionsQuery;
 import com.metabroadcast.common.time.Clock;
-import org.atlasapi.media.entity.Brand;
-import org.atlasapi.media.entity.Clip;
-import org.atlasapi.media.entity.Item;
-import org.atlasapi.media.entity.Series;
-import org.atlasapi.persistence.content.people.QueuingPersonWriter;
-import org.atlasapi.remotesite.bbc.nitro.extract.NitroBrandExtractor;
-import org.atlasapi.remotesite.bbc.nitro.extract.NitroEpisodeExtractor;
-import org.atlasapi.remotesite.bbc.nitro.extract.NitroItemSource;
-import org.atlasapi.remotesite.bbc.nitro.extract.NitroSeriesExtractor;
-import org.atlasapi.remotesite.bbc.nitro.extract.NitroUtil;
-import org.atlasapi.remotesite.bbc.nitro.v1.NitroClient;
-import org.atlasapi.remotesite.bbc.nitro.v1.NitroGenreGroup;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.metabroadcast.atlas.glycerin.queries.ProgrammesMixin.ANCESTOR_TITLES;
-import static com.metabroadcast.atlas.glycerin.queries.ProgrammesMixin.CONTRIBUTIONS;
 
 /**
  * A {@link NitroContentAdapter} based on a {@link Glycerin}.
- *
  */
 public class GlycerinNitroContentAdapter implements NitroContentAdapter {
 
@@ -75,7 +75,9 @@ public class GlycerinNitroContentAdapter implements NitroContentAdapter {
 
     private final ListeningExecutorService executor;
 
-    public GlycerinNitroContentAdapter(Glycerin glycerin, NitroClient nitroClient, GlycerinNitroClipsAdapter clipsAdapter, QueuingPersonWriter peopleWriter, Clock clock, int pageSize) {
+    public GlycerinNitroContentAdapter(Glycerin glycerin, NitroClient nitroClient,
+            GlycerinNitroClipsAdapter clipsAdapter, QueuingPersonWriter peopleWriter, Clock clock,
+            int pageSize) {
         this.glycerin = checkNotNull(glycerin);
         this.nitroClient = checkNotNull(nitroClient);
         this.pageSize = pageSize;
@@ -200,6 +202,7 @@ public class GlycerinNitroContentAdapter implements NitroContentAdapter {
                  available here. */
         Iterable<PidReference> episodeRefs = Iterables.transform(episodes,
                 new Function<Episode, PidReference>() {
+
                     @Override
                     public PidReference apply(Episode input) {
                         PidReference pidReference = new PidReference();
@@ -240,6 +243,7 @@ public class GlycerinNitroContentAdapter implements NitroContentAdapter {
     private ImmutableList<Episode> getAsEpisodes(ImmutableList<Programme> programmes) {
         return ImmutableList.copyOf(Iterables.filter(Iterables.transform(programmes,
                 new Function<Programme, Episode>() {
+
                     @Override
                     public Episode apply(Programme input) {
                         if (input.isEpisode()) {
@@ -250,7 +254,8 @@ public class GlycerinNitroContentAdapter implements NitroContentAdapter {
                 }), Predicates.notNull()));
     }
 
-    private ImmutableList<Programme> fetchProgrammes(Iterable<ProgrammesQuery> queries) throws GlycerinException {
+    private ImmutableList<Programme> fetchProgrammes(Iterable<ProgrammesQuery> queries)
+            throws GlycerinException {
 
         List<ListenableFuture<ImmutableList<Programme>>> futures = Lists.newArrayList();
 
@@ -273,7 +278,7 @@ public class GlycerinNitroContentAdapter implements NitroContentAdapter {
         ImmutableList.Builder<T> programmes = ImmutableList.builder();
         ImmutableList<T> results = resp.getResults();
         programmes.addAll(results);
-        while(resp.hasNext()) {
+        while (resp.hasNext()) {
             resp = resp.getNext();
             programmes.addAll(resp.getResults());
         }
@@ -282,6 +287,7 @@ public class GlycerinNitroContentAdapter implements NitroContentAdapter {
 
     private Iterable<String> toStrings(Iterable<PidReference> refs) {
         return Iterables.transform(refs, new Function<PidReference, String>() {
+
             @Override
             public String apply(PidReference input) {
                 return input.getPid();
@@ -293,7 +299,8 @@ public class GlycerinNitroContentAdapter implements NitroContentAdapter {
         return nitroClient.genres(episode.getPid());
     }
 
-    private ListMultimap<String, Broadcast> broadcasts(ImmutableList<Episode> episodes) throws GlycerinException {
+    private ListMultimap<String, Broadcast> broadcasts(ImmutableList<Episode> episodes)
+            throws GlycerinException {
         List<ListenableFuture<ImmutableList<Broadcast>>> futures = Lists.newArrayList();
 
         for (List<Episode> episode : Iterables.partition(episodes, NITRO_BATCH_SIZE)) {
@@ -305,12 +312,14 @@ public class GlycerinNitroContentAdapter implements NitroContentAdapter {
         }
         ListenableFuture<List<ImmutableList<Broadcast>>> successful = Futures.allAsList(futures);
         try {
-            return Multimaps.index(Iterables.concat(successful.get()), new Function<Broadcast, String>() {
-                @Override
-                public String apply(Broadcast input) {
-                    return NitroUtil.programmePid(input).getPid();
-                }
-            });
+            return Multimaps.index(Iterables.concat(successful.get()),
+                    new Function<Broadcast, String>() {
+
+                        @Override
+                        public String apply(Broadcast input) {
+                            return NitroUtil.programmePid(input).getPid();
+                        }
+                    });
         } catch (InterruptedException | ExecutionException e) {
             if (e.getCause() instanceof GlycerinException) {
                 throw (GlycerinException) e.getCause();
@@ -319,7 +328,8 @@ public class GlycerinNitroContentAdapter implements NitroContentAdapter {
         }
     }
 
-    private ListMultimap<String, Version> versions(ImmutableList<Episode> episodes) throws GlycerinException {
+    private ListMultimap<String, Version> versions(ImmutableList<Episode> episodes)
+            throws GlycerinException {
         List<ListenableFuture<ImmutableList<Version>>> futures = Lists.newArrayList();
 
         for (List<Episode> episode : Iterables.partition(episodes, NITRO_BATCH_SIZE)) {
@@ -333,6 +343,7 @@ public class GlycerinNitroContentAdapter implements NitroContentAdapter {
         ListenableFuture<List<ImmutableList<Version>>> all = Futures.allAsList(futures);
         try {
             return Multimaps.index(Iterables.concat(all.get()), new Function<Version, String>() {
+
                 @Override
                 public String apply(Version input) {
                     return NitroUtil.programmePid(input).getPid();
@@ -346,7 +357,8 @@ public class GlycerinNitroContentAdapter implements NitroContentAdapter {
         }
     }
 
-    private ListMultimap<String, Availability> availabilities(ImmutableList<Episode> episodes) throws GlycerinException {
+    private ListMultimap<String, Availability> availabilities(ImmutableList<Episode> episodes)
+            throws GlycerinException {
         if (episodes.isEmpty()) {
             return ImmutableListMultimap.of();
         }
@@ -357,7 +369,11 @@ public class GlycerinNitroContentAdapter implements NitroContentAdapter {
             AvailabilityQuery query = AvailabilityQuery.builder()
                     .withDescendantsOf(toPids(episode))
                     .withPageSize(pageSize)
-                    .withMediaSet("apple-iphone4-ipad-hls-3g", "apple-iphone4-hls", "pc", "iptv-all", "captions")
+                    .withMediaSet("apple-iphone4-ipad-hls-3g",
+                            "apple-iphone4-hls",
+                            "pc",
+                            "iptv-all",
+                            "captions")
                     .build();
 
             futures.add(executor.submit(exhaustingAvailabilityCallable(query)));
@@ -376,6 +392,7 @@ public class GlycerinNitroContentAdapter implements NitroContentAdapter {
 
         return Multimaps.index(list,
                 new Function<Availability, String>() {
+
                     @Override
                     public String apply(Availability input) {
                         return NitroUtil.programmePid(input);
@@ -383,7 +400,8 @@ public class GlycerinNitroContentAdapter implements NitroContentAdapter {
                 });
     }
 
-    private Callable<ImmutableList<Availability>> exhaustingAvailabilityCallable(final AvailabilityQuery query) {
+    private Callable<ImmutableList<Availability>> exhaustingAvailabilityCallable(
+            final AvailabilityQuery query) {
 
         return new Callable<ImmutableList<Availability>>() {
 
@@ -405,7 +423,8 @@ public class GlycerinNitroContentAdapter implements NitroContentAdapter {
         };
     }
 
-    private Callable<ImmutableList<Broadcast>> exhaustingBroadcastsCallable(final BroadcastsQuery query) {
+    private Callable<ImmutableList<Broadcast>> exhaustingBroadcastsCallable(
+            final BroadcastsQuery query) {
 
         return new Callable<ImmutableList<Broadcast>>() {
 
@@ -416,7 +435,8 @@ public class GlycerinNitroContentAdapter implements NitroContentAdapter {
         };
     }
 
-    private Callable<ImmutableList<Programme>> exhaustingProgrammeCallable(final ProgrammesQuery query) {
+    private Callable<ImmutableList<Programme>> exhaustingProgrammeCallable(
+            final ProgrammesQuery query) {
 
         return new Callable<ImmutableList<Programme>>() {
 
@@ -429,6 +449,7 @@ public class GlycerinNitroContentAdapter implements NitroContentAdapter {
 
     private Iterable<String> toPids(List<Episode> episodes) {
         return Iterables.transform(episodes, new Function<Episode, String>() {
+
             @Override
             public String apply(Episode input) {
                 return input.getPid();

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/GlycerinNitroContentAdapter.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/GlycerinNitroContentAdapter.java
@@ -1,30 +1,5 @@
 package org.atlasapi.remotesite.bbc.nitro;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.metabroadcast.atlas.glycerin.queries.ProgrammesMixin.PEOPLE;
-import static com.metabroadcast.atlas.glycerin.queries.ProgrammesMixin.TITLES;
-
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
-
-import org.atlasapi.media.entity.Brand;
-import org.atlasapi.media.entity.Clip;
-import org.atlasapi.media.entity.Item;
-import org.atlasapi.media.entity.Series;
-import org.atlasapi.persistence.content.people.QueuingPersonWriter;
-import org.atlasapi.remotesite.bbc.nitro.extract.NitroBrandExtractor;
-import org.atlasapi.remotesite.bbc.nitro.extract.NitroEpisodeExtractor;
-import org.atlasapi.remotesite.bbc.nitro.extract.NitroItemSource;
-import org.atlasapi.remotesite.bbc.nitro.extract.NitroSeriesExtractor;
-import org.atlasapi.remotesite.bbc.nitro.extract.NitroUtil;
-import org.atlasapi.remotesite.bbc.nitro.v1.NitroClient;
-import org.atlasapi.remotesite.bbc.nitro.v1.NitroGenreGroup;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.api.client.util.Lists;
 import com.google.common.base.Function;
 import com.google.common.base.Predicates;
@@ -54,6 +29,30 @@ import com.metabroadcast.atlas.glycerin.queries.BroadcastsQuery;
 import com.metabroadcast.atlas.glycerin.queries.ProgrammesQuery;
 import com.metabroadcast.atlas.glycerin.queries.VersionsQuery;
 import com.metabroadcast.common.time.Clock;
+import org.atlasapi.media.entity.Brand;
+import org.atlasapi.media.entity.Clip;
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Series;
+import org.atlasapi.persistence.content.people.QueuingPersonWriter;
+import org.atlasapi.remotesite.bbc.nitro.extract.NitroBrandExtractor;
+import org.atlasapi.remotesite.bbc.nitro.extract.NitroEpisodeExtractor;
+import org.atlasapi.remotesite.bbc.nitro.extract.NitroItemSource;
+import org.atlasapi.remotesite.bbc.nitro.extract.NitroSeriesExtractor;
+import org.atlasapi.remotesite.bbc.nitro.extract.NitroUtil;
+import org.atlasapi.remotesite.bbc.nitro.v1.NitroClient;
+import org.atlasapi.remotesite.bbc.nitro.v1.NitroGenreGroup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.metabroadcast.atlas.glycerin.queries.ProgrammesMixin.ANCESTOR_TITLES;
+import static com.metabroadcast.atlas.glycerin.queries.ProgrammesMixin.CONTRIBUTIONS;
 
 /**
  * A {@link NitroContentAdapter} based on a {@link Glycerin}.
@@ -147,7 +146,7 @@ public class GlycerinNitroContentAdapter implements NitroContentAdapter {
         for (List<PidReference> ref : Iterables.partition(refs, NITRO_BATCH_SIZE)) {
             ProgrammesQuery query = ProgrammesQuery.builder()
                     .withPid(toStrings(ref))
-                    .withMixins(TITLES, PEOPLE)
+                    .withMixins(ANCESTOR_TITLES, CONTRIBUTIONS)
                     .withPageSize(pageSize)
                     .build();
 

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/BaseNitroItemExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/BaseNitroItemExtractor.java
@@ -1,5 +1,28 @@
 package org.atlasapi.remotesite.bbc.nitro.extract;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.metabroadcast.atlas.glycerin.model.Version.Types;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.atlasapi.media.entity.Broadcast;
+import org.atlasapi.media.entity.Encoding;
+import org.atlasapi.media.entity.Film;
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Location;
+import org.atlasapi.media.entity.MediaType;
+import org.atlasapi.media.entity.Restriction;
+import org.atlasapi.media.entity.Specialization;
+import org.atlasapi.media.entity.Version;
+import org.atlasapi.remotesite.bbc.BbcFeeds;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Duration;
+
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMap;
@@ -15,44 +38,23 @@ import com.metabroadcast.atlas.glycerin.model.Warnings;
 import com.metabroadcast.common.collect.ImmutableOptionalMap;
 import com.metabroadcast.common.collect.OptionalMap;
 import com.metabroadcast.common.time.Clock;
-import org.atlasapi.media.entity.Broadcast;
-import org.atlasapi.media.entity.Encoding;
-import org.atlasapi.media.entity.Film;
-import org.atlasapi.media.entity.Item;
-import org.atlasapi.media.entity.Location;
-import org.atlasapi.media.entity.MediaType;
-import org.atlasapi.media.entity.Restriction;
-import org.atlasapi.media.entity.Specialization;
-import org.atlasapi.media.entity.Version;
-import org.atlasapi.remotesite.bbc.BbcFeeds;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.Duration;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.metabroadcast.atlas.glycerin.model.Version.Types;
 
 /**
  * Base extractor for extracting common properties of {@link Item}s from a
  * {@link NitroItemSource}.
- * 
+ *
  * @param <SOURCE> - the type of {@link Programme}.
- * @param <ITEM> - the {@link Item} type extracted.
+ * @param <ITEM>   - the {@link Item} type extracted.
  */
 public abstract class BaseNitroItemExtractor<SOURCE, ITEM extends Item>
-    extends NitroContentExtractor<NitroItemSource<SOURCE>, ITEM> {
+        extends NitroContentExtractor<NitroItemSource<SOURCE>, ITEM> {
 
     private static final String AUDIO_DESCRIBED_VERSION_TYPE = "DubbedAudioDescribed";
     private static final String SIGNED_VERSION_TYPE = "Signed";
     private static final String WARNING_TEXT_LONG_LENGTH = "long";
 
     private final Predicate<WarningText> IS_LONG_WARNING = new Predicate<WarningText>() {
+
         @Override
         public boolean apply(WarningText input) {
             return WARNING_TEXT_LONG_LENGTH.equals(input.getLength());
@@ -60,18 +62,22 @@ public abstract class BaseNitroItemExtractor<SOURCE, ITEM extends Item>
     };
 
     private final NitroBroadcastExtractor broadcastExtractor
-        = new NitroBroadcastExtractor();
+            = new NitroBroadcastExtractor();
     private final NitroAvailabilityExtractor availabilityExtractor
-        = new NitroAvailabilityExtractor();
+            = new NitroAvailabilityExtractor();
 
     public BaseNitroItemExtractor(Clock clock) {
         super(clock);
     }
 
     @Override
-    protected final void extractAdditionalFields(NitroItemSource<SOURCE> source, ITEM item, DateTime now) {
-        ImmutableSetMultimap<String, Broadcast> broadcasts = extractBroadcasts(source.getBroadcasts(), now);
-        OptionalMap<String, Set<Encoding>> encodings = extractEncodings(source.getAvailabilities(), now, extractMediaType(source));
+    protected final void extractAdditionalFields(NitroItemSource<SOURCE> source, ITEM item,
+            DateTime now) {
+        ImmutableSetMultimap<String, Broadcast> broadcasts = extractBroadcasts(source.getBroadcasts(),
+                now);
+        OptionalMap<String, Set<Encoding>> encodings = extractEncodings(source.getAvailabilities(),
+                now,
+                extractMediaType(source));
 
         ImmutableSet.Builder<Version> versions = ImmutableSet.builder();
 
@@ -80,7 +86,8 @@ public abstract class BaseNitroItemExtractor<SOURCE, ITEM extends Item>
                 Version version = generateVersion(now, broadcasts, encodings, nitroVersion);
                 versions.add(version);
             } catch (Exception e) {
-                throw new RuntimeException("Exception processing version " + nitroVersion.getPid(), e);
+                throw new RuntimeException("Exception processing version " + nitroVersion.getPid(),
+                        e);
             }
         }
 
@@ -131,7 +138,7 @@ public abstract class BaseNitroItemExtractor<SOURCE, ITEM extends Item>
          * Even if aspect ratio and the audio described and signed flags are on Version in the Nitro model,
          * in Atlas they naturally belong to Encoding
          */
-        for (Encoding encoding: encodings) {
+        for (Encoding encoding : encodings) {
             encoding.setVideoAspectRatio(nitroVersion.getAspectRatio());
             encoding.setAudioDescribed(isVersionOfType(nitroVersion, AUDIO_DESCRIBED_VERSION_TYPE));
             encoding.setSigned(isVersionOfType(nitroVersion, SIGNED_VERSION_TYPE));
@@ -150,7 +157,8 @@ public abstract class BaseNitroItemExtractor<SOURCE, ITEM extends Item>
         return restriction;
     }
 
-    private boolean isVersionOfType(com.metabroadcast.atlas.glycerin.model.Version nitroVersion, String versionType) {
+    private boolean isVersionOfType(com.metabroadcast.atlas.glycerin.model.Version nitroVersion,
+            String versionType) {
         Types versionTypes = nitroVersion.getTypes();
 
         if (versionTypes == null) {
@@ -162,6 +170,7 @@ public abstract class BaseNitroItemExtractor<SOURCE, ITEM extends Item>
 
     private Predicate<Types.Type> isOfType(final String type) {
         return new Predicate<Types.Type>() {
+
             @Override
             public boolean apply(Types.Type input) {
                 return type.equals(input.getId());
@@ -183,6 +192,7 @@ public abstract class BaseNitroItemExtractor<SOURCE, ITEM extends Item>
 
     /**
      * Extract the media type of the source.
+     *
      * @param source
      * @return the media type of the source, or null if not present.
      */
@@ -191,21 +201,24 @@ public abstract class BaseNitroItemExtractor<SOURCE, ITEM extends Item>
     /**
      * Concrete implementations can override this method to perform additional
      * configuration of the extracted content from the source.
-     * 
+     *
      * @param source - the source data.
-     * @param item - the extracted item.
-     * @param now - the current time.
+     * @param item   - the extracted item.
+     * @param now    - the current time.
      */
-    protected void extractAdditionalItemFields(NitroItemSource<SOURCE> source, ITEM item, DateTime now) {
-        
+    protected void extractAdditionalItemFields(NitroItemSource<SOURCE> source, ITEM item,
+            DateTime now) {
+
     }
 
-    private OptionalMap<String, Set<Encoding>> extractEncodings(List<Availability> availabilities, DateTime now,
+    private OptionalMap<String, Set<Encoding>> extractEncodings(List<Availability> availabilities,
+            DateTime now,
             String mediaType) {
         Map<String, Collection<Availability>> byVersion = indexByVersion(availabilities);
         ImmutableMap.Builder<String, Set<Encoding>> results = ImmutableMap.builder();
         for (Entry<String, Collection<Availability>> availability : byVersion.entrySet()) {
-            Set<Encoding> extracted = availabilityExtractor.extract(availability.getValue(), mediaType);
+            Set<Encoding> extracted = availabilityExtractor.extract(availability.getValue(),
+                    mediaType);
             if (!extracted.isEmpty()) {
                 results.put(availability.getKey(), setLastUpdated(extracted, now));
             }
@@ -214,7 +227,7 @@ public abstract class BaseNitroItemExtractor<SOURCE, ITEM extends Item>
     }
 
     private Set<Encoding> setLastUpdated(Set<Encoding> encodings, DateTime now) {
-        for (Encoding encoding: encodings) {
+        for (Encoding encoding : encodings) {
             encoding.setLastUpdated(now);
             for (Location location : encoding.getAvailableAt()) {
                 location.setLastUpdated(now);
@@ -224,9 +237,10 @@ public abstract class BaseNitroItemExtractor<SOURCE, ITEM extends Item>
         return encodings;
     }
 
-    private Map<String, Collection<Availability>> indexByVersion(List<Availability> availabilities) {
+    private Map<String, Collection<Availability>> indexByVersion(
+            List<Availability> availabilities) {
         ImmutableSetMultimap.Builder<String, Availability> availabilitiesByVersion
-            = ImmutableSetMultimap.builder();
+                = ImmutableSetMultimap.builder();
         for (Availability availability : availabilities) {
             String versionPid = checkNotNull(NitroUtil.versionPid(availability));
             availabilitiesByVersion.put(versionPid, availability);
@@ -240,7 +254,8 @@ public abstract class BaseNitroItemExtractor<SOURCE, ITEM extends Item>
         for (com.metabroadcast.atlas.glycerin.model.Broadcast broadcast : nitroBroadcasts) {
             Optional<Broadcast> extractedBroadcast = broadcastExtractor.extract(broadcast);
             if (extractedBroadcast.isPresent()) {
-                broadcasts.put(versionPid(broadcast), setLastUpdated(extractedBroadcast.get(), now));
+                broadcasts.put(versionPid(broadcast),
+                        setLastUpdated(extractedBroadcast.get(), now));
             }
         }
         return broadcasts.build();
@@ -266,7 +281,8 @@ public abstract class BaseNitroItemExtractor<SOURCE, ITEM extends Item>
         return Duration.millis(xmlDuration.getTimeInMillis(now.toDate()));
     }
 
-    private Optional<WarningText> warningTextFrom(com.metabroadcast.atlas.glycerin.model.Version version) {
+    private Optional<WarningText> warningTextFrom(
+            com.metabroadcast.atlas.glycerin.model.Version version) {
         Warnings warnings = version.getWarnings();
 
         if (warnings == null) {
@@ -275,5 +291,5 @@ public abstract class BaseNitroItemExtractor<SOURCE, ITEM extends Item>
 
         return Iterables.tryFind(warnings.getWarningText(), IS_LONG_WARNING);
     }
-    
+
 }

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/BaseNitroItemExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/BaseNitroItemExtractor.java
@@ -1,13 +1,20 @@
 package org.atlasapi.remotesite.bbc.nitro.extract;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.ImmutableSetMultimap.Builder;
+import com.google.common.collect.Iterables;
+import com.metabroadcast.atlas.glycerin.model.Availability;
+import com.metabroadcast.atlas.glycerin.model.PidReference;
+import com.metabroadcast.atlas.glycerin.model.Programme;
+import com.metabroadcast.atlas.glycerin.model.WarningText;
+import com.metabroadcast.atlas.glycerin.model.Warnings;
+import com.metabroadcast.common.collect.ImmutableOptionalMap;
+import com.metabroadcast.common.collect.OptionalMap;
+import com.metabroadcast.common.time.Clock;
 import org.atlasapi.media.entity.Broadcast;
 import org.atlasapi.media.entity.Encoding;
 import org.atlasapi.media.entity.Film;
@@ -22,25 +29,14 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
 
-import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSetMultimap;
-import com.google.common.collect.ImmutableSetMultimap.Builder;
-import com.google.common.collect.Iterables;
-import com.metabroadcast.atlas.glycerin.model.Availability;
-import com.metabroadcast.atlas.glycerin.model.Brand;
-import com.metabroadcast.atlas.glycerin.model.PidReference;
-import com.metabroadcast.atlas.glycerin.model.Programme;
-import com.metabroadcast.atlas.glycerin.model.VersionType;
-import com.metabroadcast.atlas.glycerin.model.VersionTypes;
-import com.metabroadcast.atlas.glycerin.model.WarningText;
-import com.metabroadcast.atlas.glycerin.model.Warnings;
-import com.metabroadcast.common.collect.ImmutableOptionalMap;
-import com.metabroadcast.common.collect.OptionalMap;
-import com.metabroadcast.common.time.Clock;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.metabroadcast.atlas.glycerin.model.Version.Types;
 
 /**
  * Base extractor for extracting common properties of {@link Item}s from a
@@ -155,20 +151,20 @@ public abstract class BaseNitroItemExtractor<SOURCE, ITEM extends Item>
     }
 
     private boolean isVersionOfType(com.metabroadcast.atlas.glycerin.model.Version nitroVersion, String versionType) {
-        VersionTypes versionTypes = nitroVersion.getVersionTypes();
+        Types versionTypes = nitroVersion.getTypes();
 
         if (versionTypes == null) {
             return false;
         }
 
-        return Iterables.any(versionTypes.getVersionType(), isOfType(versionType));
+        return Iterables.any(versionTypes.getType(), isOfType(versionType));
     }
 
-    private Predicate<VersionType> isOfType(final String versionType) {
-        return new Predicate<VersionType>() {
+    private Predicate<Types.Type> isOfType(final String type) {
+        return new Predicate<Types.Type>() {
             @Override
-            public boolean apply(VersionType input) {
-                return versionType.equals(input.getId());
+            public boolean apply(Types.Type input) {
+                return type.equals(input.getId());
             }
         };
     }

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/LocationEquivalence.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/LocationEquivalence.java
@@ -31,23 +31,23 @@ final class LocationEquivalence extends Equivalence<Location> {
     @Override
     protected int doHash(Location loc) {
         return Objects.hashCode(
-                loc.getAliases(), 
-                loc.getAliasUrls(), 
-                loc.getEquivalentTo(), 
-                loc.getAvailable(), 
-                loc.getTransportType(), 
-                loc.getCanonicalUri(), 
+                loc.getAliases(),
+                loc.getAliasUrls(),
+                loc.getEquivalentTo(),
+                loc.getAvailable(),
+                loc.getTransportType(),
+                loc.getCanonicalUri(),
                 hashCode(loc.getPolicy())
         );
     }
 
     private int hashCode(Policy policy) {
         return Objects.hashCode(
-                policy.getAvailabilityStart(), 
-                policy.getAvailabilityEnd(), 
-                policy.getActualAvailabilityStart(), 
-                policy.getAvailableCountries(), 
-                policy.getPlatform(), 
+                policy.getAvailabilityStart(),
+                policy.getAvailabilityEnd(),
+                policy.getActualAvailabilityStart(),
+                policy.getAvailableCountries(),
+                policy.getPlatform(),
                 policy.getNetwork()
         );
     }

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroAvailabilityExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroAvailabilityExtractor.java
@@ -36,26 +36,28 @@ import com.metabroadcast.common.time.DateTimeZones;
  * Possibly extracts an {@link Encoding} and {@link Location}s for it from some
  * {@link Availability}s.
  */
-public class NitroAvailabilityExtractor  {
+public class NitroAvailabilityExtractor {
 
     private static final LocationEquivalence LOCATION_EQUIVALENCE = new LocationEquivalence();
 
-    private static final Function<Location, Equivalence.Wrapper<Location>> TO_WRAPPED_LOCATION 
+    private static final Function<Location, Equivalence.Wrapper<Location>> TO_WRAPPED_LOCATION
             = new Function<Location, Equivalence.Wrapper<Location>>() {
-                @Override
-                public Wrapper<Location> apply(Location input) {
-                    return LOCATION_EQUIVALENCE.wrap(input);
-                }
-            };
-            
-    private static final Function<Equivalence.Wrapper<Location>, Location> UNWRAP_LOCATION 
+
+        @Override
+        public Wrapper<Location> apply(Location input) {
+            return LOCATION_EQUIVALENCE.wrap(input);
+        }
+    };
+
+    private static final Function<Equivalence.Wrapper<Location>, Location> UNWRAP_LOCATION
             = new Function<Equivalence.Wrapper<Location>, Location>() {
-                @Override
-                public Location apply(Equivalence.Wrapper<Location> input) {
-                    return input.get();
-                }
-            };
-    
+
+        @Override
+        public Location apply(Equivalence.Wrapper<Location> input) {
+            return input.get();
+        }
+    };
+
     private static final String IPLAYER_URL_BASE = "http://www.bbc.co.uk/iplayer/episode/";
     private static final String APPLE_IPHONE4_IPAD_HLS_3G = "apple-iphone4-ipad-hls-3g";
     private static final String APPLE_IPHONE4_HLS = "apple-iphone4-hls";
@@ -71,33 +73,36 @@ public class NitroAvailabilityExtractor  {
 
     private static final int HD_BITRATE = 3_200_000;
     private static final int SD_BITRATE = 1_500_000;
-    
+
     private static final String VIDEO_MEDIA_TYPE = "Video";
 
     private static final Predicate<Availability> IS_HD = new Predicate<Availability>() {
+
         @Override
         public boolean apply(Availability input) {
             return !input.getMediaSet().contains("iptv-sd");
         }
     };
-    
+
     private static final Predicate<Availability> IS_SUBTITLED = new Predicate<Availability>() {
+
         @Override
         public boolean apply(Availability input) {
             return input.getMediaSet().contains("captions");
         }
     };
-    
+
     private static final Predicate<Availability> IS_AVAILABLE = new Predicate<Availability>() {
 
         @Override
         public boolean apply(Availability input) {
             return AVAILABLE.equals(input.getStatus());
         }
-        
+
     };
 
     private static final Predicate<Availability> IS_IPTV = new Predicate<Availability>() {
+
         @Override
         public boolean apply(Availability input) {
             return input.getMediaSet().contains("iptv-all");
@@ -105,39 +110,38 @@ public class NitroAvailabilityExtractor  {
     };
 
     private final Map<String, Platform> mediaSetPlatform = ImmutableMap.of(
-        PC, Platform.PC,
-        APPLE_IPHONE4_HLS, Platform.IOS,
-        APPLE_IPHONE4_IPAD_HLS_3G, Platform.IOS,
-        YOUVIEW, Platform.YOUVIEW_IPLAYER
+            PC, Platform.PC,
+            APPLE_IPHONE4_HLS, Platform.IOS,
+            APPLE_IPHONE4_IPAD_HLS_3G, Platform.IOS,
+            YOUVIEW, Platform.YOUVIEW_IPLAYER
     );
 
     private final Map<String, Network> mediaSetNetwork = ImmutableMap.of(
-        APPLE_IPHONE4_HLS, Network.WIFI,
-        APPLE_IPHONE4_IPAD_HLS_3G, Network.THREE_G
+            APPLE_IPHONE4_HLS, Network.WIFI,
+            APPLE_IPHONE4_IPAD_HLS_3G, Network.THREE_G
     );
-    
+
     /**
      * This simplifies the Availability extraction, by assuming that the only difference for an
      * encoding is whether there are HD or SD availabilities. Thus, this creates a maximum of
      * two Encodings, one for SD, one for HD, then maps and dedupes the Locations generated from
      * the availabilities onto those Encodings.
-     * 
+     * <p>
      * The provided collection of {@link Availability} must all be from the same version.
-     * 
      */
     public Set<Encoding> extract(Iterable<Availability> availabilities, String mediaType) {
         Set<Equivalence.Wrapper<Location>> hdLocations = Sets.newHashSet();
         Set<Equivalence.Wrapper<Location>> sdLocations = Sets.newHashSet();
-        
-        boolean isSubtitled = Iterables.any(availabilities, 
+
+        boolean isSubtitled = Iterables.any(availabilities,
                 Predicates.and(IS_SUBTITLED, IS_AVAILABLE));
-        
+
         for (Availability availability : availabilities) {
             ImmutableList<Wrapper<Location>> locations = FluentIterable.
                     from(getLocationsFor(availability, mediaType))
-                      .transform(TO_WRAPPED_LOCATION)
-                      .toList();
-            
+                    .transform(TO_WRAPPED_LOCATION)
+                    .toList();
+
             if (IS_IPTV.apply(availability) && IS_HD.apply(availability)) {
                 hdLocations.addAll(locations);
             } else {
@@ -150,27 +154,28 @@ public class NitroAvailabilityExtractor  {
                 return ImmutableSet.of();
             }
             return ImmutableSet.of(createEncoding(false, isSubtitled, sdLocations));
-        } 
+        }
         if (sdLocations.isEmpty()) {
             return ImmutableSet.of(createEncoding(true, isSubtitled, hdLocations));
         }
-        return ImmutableSet.of(createEncoding(true, isSubtitled, hdLocations), createEncoding(false, isSubtitled, sdLocations));    
+        return ImmutableSet.of(createEncoding(true, isSubtitled, hdLocations),
+                createEncoding(false, isSubtitled, sdLocations));
     }
 
-    private Encoding createEncoding(boolean isHd, boolean isSubtitled, 
+    private Encoding createEncoding(boolean isHd, boolean isSubtitled,
             Set<Equivalence.Wrapper<Location>> wrappedLocations) {
         Encoding encoding = new Encoding();
-        
+
         setHorizontalAndVerticalSize(encoding, isHd);
         encoding.setVideoBitRate(isHd ? HD_BITRATE : SD_BITRATE);
-        
+
         ImmutableSet<Location> locations = FluentIterable.from(wrappedLocations)
                 .transform(UNWRAP_LOCATION)
                 .toSet();
-        
+
         encoding.setAvailableAt(locations);
         encoding.setSubtitled(isSubtitled);
-        
+
         return encoding;
     }
 
@@ -185,14 +190,14 @@ public class NitroAvailabilityExtractor  {
         for (String mediaSet : availability.getMediaSet()) {
             Platform platform = mediaSetPlatform.get(mediaSet);
             if (platform != null) {
-                locations.add(newLocation(availability, platform, 
+                locations.add(newLocation(availability, platform,
                         mediaSetNetwork.get(mediaSet), mediaType));
             }
         }
         return locations.build();
     }
 
-    private Location newLocation(Availability source, Platform platform, Network network, 
+    private Location newLocation(Availability source, Platform platform, Network network,
             String mediaType) {
         Location location = new Location();
         location.setUri(IPLAYER_URL_BASE + checkNotNull(NitroUtil.programmePid(source)));
@@ -201,14 +206,15 @@ public class NitroAvailabilityExtractor  {
         return location;
     }
 
-    private Policy policy(Availability source, Platform platform, Network network, String mediaType) {
+    private Policy policy(Availability source, Platform platform, Network network,
+            String mediaType) {
         Policy policy = new Policy();
         ScheduledTime scheduledTime = source.getScheduledTime();
         if (scheduledTime != null) {
             policy.setAvailabilityStart(toDateTime(scheduledTime.getStart()));
             policy.setAvailabilityEnd(toDateTime(scheduledTime.getEnd()));
         }
-        
+
         if (shouldIngestActualAvailabilityStart(source, mediaType, policy)) {
             policy.setActualAvailabilityStart(toDateTime(source.getActualStart()));
         }
@@ -217,21 +223,21 @@ public class NitroAvailabilityExtractor  {
         policy.setAvailableCountries(ImmutableSet.of(Countries.GB));
         return policy;
     }
-        
+
     private boolean shouldIngestActualAvailabilityStart(Availability source, String mediaType,
             Policy policy) {
         DateTime actualStart = toDateTime(source.getActualStart());
-        
+
         if (actualStart == null) {
             // Ensures we remove it if not set in Nitro
             return true;
         }
-        
+
         if (REVOKED.equals(source.getRevocationStatus())) {
             // A revoked availability isn't actually available
             return false;
         }
-        
+
         if (actualStart.isAfterNow()) {
             // This is not an expected case on the Nitro API, and would cause 
             // problems in output feeds that make relative date checks to set a 
@@ -239,8 +245,8 @@ public class NitroAvailabilityExtractor  {
             // the media becomes available
             return false;
         }
-        
-        if (policy.getAvailabilityEnd() != null 
+
+        if (policy.getAvailabilityEnd() != null
                 && policy.getAvailabilityEnd().isBeforeNow()) {
             // If we've passed the end of the availability window then ingest 
             // the actual availability start for reference, since there's the 
@@ -248,11 +254,11 @@ public class NitroAvailabilityExtractor  {
             // availability window.
             return true;
         }
-        
+
         if (!VIDEO_MEDIA_TYPE.equals(mediaType)) {
             // Since media type is only reliably set on video, not audio, 
             // our condition is inverted to check for this being a radio asset
-            
+
             // Radio assets are delivered by a range of systems, which don't 
             // reliably record an actual availability start time. However,
             // Nitro synthesises it, and also has logic in the setting of
@@ -269,13 +275,13 @@ public class NitroAvailabilityExtractor  {
             return true;
         }
     }
-    
+
     private DateTime toDateTime(XMLGregorianCalendar start) {
         if (start == null) {
             return null;
         }
         return new DateTime(start.toGregorianCalendar(), ISOChronology.getInstance())
-            .toDateTime(DateTimeZones.UTC);
+                .toDateTime(DateTimeZones.UTC);
     }
 
 }

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroBrandExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroBrandExtractor.java
@@ -9,7 +9,7 @@ import com.metabroadcast.common.time.Clock;
 /**
  * Extracts a {@link org.atlasapi.media.entity.Brand Atlas Brand} from a
  * {@link Brand Nitro Brand}.
- * 
+ *
  * @see NitroContentExtractor
  */
 public class NitroBrandExtractor
@@ -40,8 +40,8 @@ public class NitroBrandExtractor
     }
 
     @Override
-    protected Brand.People extractPeople(Brand brand) {
-        return brand.getPeople();
+    protected Brand.Contributions extractContributions(Brand brand) {
+        return brand.getContributions();
     }
 
     @Override

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroBrandExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroBrandExtractor.java
@@ -1,7 +1,6 @@
 package org.atlasapi.remotesite.bbc.nitro.extract;
 
 import com.metabroadcast.atlas.glycerin.model.Brand;
-import com.metabroadcast.atlas.glycerin.model.Brand.Image;
 import com.metabroadcast.atlas.glycerin.model.Brand.MasterBrand;
 import com.metabroadcast.atlas.glycerin.model.Synopses;
 import com.metabroadcast.common.time.Clock;
@@ -45,8 +44,8 @@ public class NitroBrandExtractor
     }
 
     @Override
-    protected Image extractImage(Brand source) {
-        return source.getImage();
+    protected Brand.Images.Image extractImage(Brand source) {
+        return source.getImages().getImage();
     }
 
     @Override

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroBroadcastExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroBroadcastExtractor.java
@@ -9,7 +9,6 @@ import org.atlasapi.remotesite.bbc.ion.BbcIonServices;
 import org.joda.time.DateTime;
 
 import com.google.api.client.repackaged.com.google.common.base.Joiner;
-import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
@@ -23,21 +22,22 @@ import com.metabroadcast.atlas.glycerin.model.Ids;
  * Broadcast} from a {@link Broadcast Nitro Broadcast}.
  */
 public class NitroBroadcastExtractor
-    implements ContentExtractor<com.metabroadcast.atlas.glycerin.model.Broadcast, Optional<Broadcast>> {
+        implements
+        ContentExtractor<com.metabroadcast.atlas.glycerin.model.Broadcast, Optional<Broadcast>> {
 
     private static final String TERRESTRIAL_EVENT_LOCATOR_TYPE = "terrestrial_event_locator";
     private static final String TERRESTRIAL_PROGRAM_CRID_TYPE = "terrestrial_programme_crid";
     private static final String BID_TYPE = "bid";
     private static final String PIPS_AUTHORITY = "pips";
     private static final String TELEVIEW_AUTHORITY = "teleview";
-    
+
     private static final Predicate<Alias> PCRID_ALIAS = new Predicate<Alias>() {
 
         @Override
         public boolean apply(Alias input) {
             return input.getNamespace().contains(TERRESTRIAL_PROGRAM_CRID_TYPE);
         }
-        
+
     };
 
     @Override
@@ -49,15 +49,15 @@ public class NitroBroadcastExtractor
         DateTime start = NitroUtil.toDateTime(source.getPublishedTime().getStart());
         DateTime end = NitroUtil.toDateTime(source.getPublishedTime().getEnd());
         Broadcast broadcast = new Broadcast(channel, start, end)
-            .withId("bbc:"+source.getPid());
+                .withId("bbc:" + source.getPid());
         broadcast.setRepeat(source.isIsRepeat());
         broadcast.setAudioDescribed(source.isIsAudioDescribed());
         broadcast.setAliases(extractAliasesFrom(source));
-        
+
         // Adding an alias uri for equivalence between Nitro and YV broadcasts
         Optional<Alias> pcridAlias = Iterables.tryFind(broadcast.getAliases(), PCRID_ALIAS);
         if (pcridAlias.isPresent()) {
-            broadcast.setAliasUrls(ImmutableSet.of("pcrid:" + pcridAlias.get().getValue()));            
+            broadcast.setAliasUrls(ImmutableSet.of("pcrid:" + pcridAlias.get().getValue()));
         }
         broadcast.setAudioDescribed(source.isIsAudioDescribed());
         return Optional.of(broadcast);
@@ -79,6 +79,7 @@ public class NitroBroadcastExtractor
 
     private Predicate<Id> idOfTypeAndAuthority(final TypeAndAuthority typeAndAuthority) {
         return new Predicate<Id>() {
+
             @Override
             public boolean apply(Id input) {
                 return typeAndAuthority.getType().equals(input.getType())
@@ -112,6 +113,7 @@ public class NitroBroadcastExtractor
     }
 
     private static class TypeAndAuthority {
+
         private final String type;
         private final String authority;
 

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroClipExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroClipExtractor.java
@@ -1,20 +1,17 @@
 package org.atlasapi.remotesite.bbc.nitro.extract;
 
 import com.metabroadcast.atlas.glycerin.model.Brand;
-import com.metabroadcast.atlas.glycerin.model.Brand.Image;
 import com.metabroadcast.atlas.glycerin.model.Brand.MasterBrand;
 import com.metabroadcast.atlas.glycerin.model.Clip;
 import com.metabroadcast.atlas.glycerin.model.Synopses;
 import com.metabroadcast.common.time.Clock;
 
-
 /**
  * Extracts a {@link org.atlasapi.media.entity.Clip Atlas Clip} from a
  * {@link Clip}.
- *
+ * <p>
  * The "{@link org.atlasapi.media.entity.Clip#getClipOf clip of}" field is not
  * set.
- *
  */
 public class NitroClipExtractor
         extends BaseNitroItemExtractor<Clip, org.atlasapi.media.entity.Clip> {
@@ -49,8 +46,8 @@ public class NitroClipExtractor
     }
 
     @Override
-    protected Image extractImage(NitroItemSource<Clip> source) {
-        return source.getProgramme().getImage();
+    protected Brand.Images.Image extractImage(NitroItemSource<Clip> source) {
+        return source.getProgramme().getImages().getImage();
     }
 
     @Override

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroClipExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroClipExtractor.java
@@ -11,13 +11,13 @@ import com.metabroadcast.common.time.Clock;
 /**
  * Extracts a {@link org.atlasapi.media.entity.Clip Atlas Clip} from a
  * {@link Clip}.
- * 
+ *
  * The "{@link org.atlasapi.media.entity.Clip#getClipOf clip of}" field is not
  * set.
- * 
+ *
  */
 public class NitroClipExtractor
-    extends BaseNitroItemExtractor<Clip, org.atlasapi.media.entity.Clip> {
+        extends BaseNitroItemExtractor<Clip, org.atlasapi.media.entity.Clip> {
 
     public NitroClipExtractor(Clock clock) {
         super(clock);
@@ -44,8 +44,8 @@ public class NitroClipExtractor
     }
 
     @Override
-    protected Brand.People extractPeople(NitroItemSource<Clip> source) {
-        return source.getProgramme().getPeople();
+    protected Brand.Contributions extractContributions(NitroItemSource<Clip> source) {
+        return source.getProgramme().getContributions();
     }
 
     @Override
@@ -62,5 +62,5 @@ public class NitroClipExtractor
     protected MasterBrand extractMasterBrand(NitroItemSource<Clip> source) {
         return source.getProgramme().getMasterBrand();
     }
-    
+
 }

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroContentExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroContentExtractor.java
@@ -1,12 +1,8 @@
 package org.atlasapi.remotesite.bbc.nitro.extract;
 
-import com.google.api.client.repackaged.com.google.common.base.Strings;
-import com.google.common.base.Objects;
-import com.google.common.collect.ImmutableSet;
-import com.metabroadcast.atlas.glycerin.model.Brand;
-import com.metabroadcast.atlas.glycerin.model.Brand.MasterBrand;
-import com.metabroadcast.atlas.glycerin.model.Synopses;
-import com.metabroadcast.common.time.Clock;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import org.atlasapi.feeds.radioplayer.RadioPlayerServices;
 import org.atlasapi.media.entity.Alias;
 import org.atlasapi.media.entity.Content;
@@ -20,16 +16,21 @@ import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import com.google.api.client.repackaged.com.google.common.base.Strings;
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableSet;
+import com.metabroadcast.atlas.glycerin.model.Brand;
+import com.metabroadcast.atlas.glycerin.model.Brand.MasterBrand;
+import com.metabroadcast.atlas.glycerin.model.Synopses;
+import com.metabroadcast.common.time.Clock;
 
 /**
  * Template extractor for extracting {@link Content} from Nitro sources.
- *
+ * <p>
  * Concrete implementations must override methods to create the intended type of
  * {@code Content} and project required fields out of the source.
  *
- * @param <SOURCE> - the Nitro source type.
+ * @param <SOURCE>  - the Nitro source type.
  * @param <CONTENT> - the {@link Content} type to be extracted.
  */
 public abstract class NitroContentExtractor<SOURCE, CONTENT extends Content>
@@ -68,7 +69,7 @@ public abstract class NitroContentExtractor<SOURCE, CONTENT extends Content>
             content.setMediumDescription(synposes.getMedium());
             content.setLongDescription(synposes.getLong());
         }
-        com.metabroadcast.atlas.glycerin.model.Brand.Image srcImage = extractImage(source);
+        com.metabroadcast.atlas.glycerin.model.Brand.Images.Image srcImage = extractImage(source);
         if (srcImage != null && !Strings.isNullOrEmpty(srcImage.getTemplateUrl())) {
             Image image = imageExtractor.extract(srcImage);
             content.setImage(image.getCanonicalUri());
@@ -91,8 +92,7 @@ public abstract class NitroContentExtractor<SOURCE, CONTENT extends Content>
     /**
      * Projects the masterbrand of the source data.
      *
-     * @param source
-     *            - the source data
+     * @param source - the source data
      * @return - the masterbrand of the source data, or {@code null} if there is none.
      */
     protected abstract @Nullable MasterBrand extractMasterBrand(SOURCE source);
@@ -100,9 +100,8 @@ public abstract class NitroContentExtractor<SOURCE, CONTENT extends Content>
     /**
      * Creates a the raw {@code Content} object to be extracted.
      *
-     * @param source
-     *            - the source data, this can be used to determine the right type of
-     *            {@code Content} to create.
+     * @param source - the source data, this can be used to determine the right type of
+     *               {@code Content} to create.
      * @return - returns a {@link Content} object.
      */
     protected abstract @Nonnull CONTENT createContent(SOURCE source);
@@ -110,8 +109,7 @@ public abstract class NitroContentExtractor<SOURCE, CONTENT extends Content>
     /**
      * Projects the PID of the source data.
      *
-     * @param source
-     *            - the source data
+     * @param source - the source data
      * @return - the PID of the source data, must not be {@code null}.
      */
     protected abstract @Nonnull String extractPid(SOURCE source);
@@ -119,8 +117,7 @@ public abstract class NitroContentExtractor<SOURCE, CONTENT extends Content>
     /**
      * Projects the title of the source data.
      *
-     * @param source
-     *            - the source data
+     * @param source - the source data
      * @return - the title of the source data, or {@code null} if there is none.
      */
     protected abstract @Nullable String extractTitle(SOURCE source);
@@ -128,10 +125,9 @@ public abstract class NitroContentExtractor<SOURCE, CONTENT extends Content>
     /**
      * Projects the {@link Synopses} of the source data.
      *
-     * @param source
-     *            - the source data
+     * @param source - the source data
      * @return - the synopses of the source data, or {@code null} if there is
-     *         none.
+     * none.
      */
     protected abstract @Nullable Synopses extractSynopses(SOURCE source);
 
@@ -139,8 +135,7 @@ public abstract class NitroContentExtractor<SOURCE, CONTENT extends Content>
      * Projects the {@link com.metabroadcast.atlas.glycerin.model.Brand.Contributions}
      * of the source data.
      *
-     * @param source
-     *            - the source data
+     * @param source - the source data
      * @return - the contributors of the source data, or {@code null} if there is none.
      */
 
@@ -150,19 +145,18 @@ public abstract class NitroContentExtractor<SOURCE, CONTENT extends Content>
      * Projects the {@link com.metabroadcast.atlas.glycerin.model.Image Image}
      * of the source data.
      *
-     * @param source
-     *            - the source data
+     * @param source - the source data
      * @return - the image of the source data, or {@code null} if there is none.
      */
-    protected abstract @Nullable Brand.Image extractImage(SOURCE source);
+    protected abstract @Nullable Brand.Images.Image extractImage(SOURCE source);
 
     /**
      * Concrete implementations can override this method to perform additional
      * configuration of the extracted content from the source.
      *
-     * @param source - the source data.
+     * @param source  - the source data.
      * @param content - the extracted content.
-     * @param now - the current time.
+     * @param now     - the current time.
      */
     protected void extractAdditionalFields(SOURCE source, CONTENT content, DateTime now) {
 
@@ -181,8 +175,8 @@ public abstract class NitroContentExtractor<SOURCE, CONTENT extends Content>
         }
 
         return RadioPlayerServices.masterBrandIdToService.containsKey(masterBrand.getMid()) ?
-                MediaType.AUDIO :
-                MediaType.VIDEO;
+               MediaType.AUDIO :
+               MediaType.VIDEO;
     }
 
 }

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroContentExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroContentExtractor.java
@@ -1,8 +1,12 @@
 package org.atlasapi.remotesite.bbc.nitro.extract;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
+import com.google.api.client.repackaged.com.google.common.base.Strings;
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableSet;
+import com.metabroadcast.atlas.glycerin.model.Brand;
+import com.metabroadcast.atlas.glycerin.model.Brand.MasterBrand;
+import com.metabroadcast.atlas.glycerin.model.Synopses;
+import com.metabroadcast.common.time.Clock;
 import org.atlasapi.feeds.radioplayer.RadioPlayerServices;
 import org.atlasapi.media.entity.Alias;
 import org.atlasapi.media.entity.Content;
@@ -16,40 +20,34 @@ import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.api.client.repackaged.com.google.common.base.Strings;
-import com.google.common.base.Objects;
-import com.google.common.collect.ImmutableSet;
-import com.metabroadcast.atlas.glycerin.model.Brand;
-import com.metabroadcast.atlas.glycerin.model.Brand.MasterBrand;
-import com.metabroadcast.atlas.glycerin.model.Series;
-import com.metabroadcast.atlas.glycerin.model.Synopses;
-import com.metabroadcast.common.time.Clock;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * Template extractor for extracting {@link Content} from Nitro sources.
- * 
+ *
  * Concrete implementations must override methods to create the intended type of
  * {@code Content} and project required fields out of the source.
- * 
+ *
  * @param <SOURCE> - the Nitro source type.
- * @param <CONTENT> - the {@link Content} type to be extracted. 
+ * @param <CONTENT> - the {@link Content} type to be extracted.
  */
 public abstract class NitroContentExtractor<SOURCE, CONTENT extends Content>
-    implements ContentExtractor<SOURCE, CONTENT> {
+        implements ContentExtractor<SOURCE, CONTENT> {
 
     private static final Logger log = LoggerFactory.getLogger(NitroContentExtractor.class);
-    
+
     private static final String PID_NAMESPACE = "gb:bbc:pid";
     private static final String URI_NAMESPACE = "uri";
-    
+
     private final Clock clock;
     private final NitroImageExtractor imageExtractor
-        = new NitroImageExtractor(1024, 576);
-    
+            = new NitroImageExtractor(1024, 576);
+
     public NitroContentExtractor(Clock clock) {
         this.clock = clock;
     }
-    
+
     @Override
     public final CONTENT extract(SOURCE source) {
         DateTime now = clock.now();
@@ -60,8 +58,8 @@ public abstract class NitroContentExtractor<SOURCE, CONTENT extends Content>
         content.setPublisher(Publisher.BBC_NITRO);
         content.setTitle(extractTitle(source));
         content.setAliases(ImmutableSet.of(
-            new Alias(PID_NAMESPACE, pid),
-            new Alias(URI_NAMESPACE, content.getCanonicalUri())
+                new Alias(PID_NAMESPACE, pid),
+                new Alias(URI_NAMESPACE, content.getCanonicalUri())
         ));
         Synopses synposes = extractSynopses(source);
         if (synposes != null) {
@@ -89,10 +87,10 @@ public abstract class NitroContentExtractor<SOURCE, CONTENT extends Content>
         extractAdditionalFields(source, content, now);
         return content;
     }
-    
+
     /**
      * Projects the masterbrand of the source data.
-     * 
+     *
      * @param source
      *            - the source data
      * @return - the masterbrand of the source data, or {@code null} if there is none.
@@ -101,52 +99,52 @@ public abstract class NitroContentExtractor<SOURCE, CONTENT extends Content>
 
     /**
      * Creates a the raw {@code Content} object to be extracted.
-     * 
+     *
      * @param source
      *            - the source data, this can be used to determine the right type of
      *            {@code Content} to create.
      * @return - returns a {@link Content} object.
      */
     protected abstract @Nonnull CONTENT createContent(SOURCE source);
-    
+
     /**
      * Projects the PID of the source data.
-     * 
+     *
      * @param source
      *            - the source data
      * @return - the PID of the source data, must not be {@code null}.
      */
     protected abstract @Nonnull String extractPid(SOURCE source);
-    
+
     /**
      * Projects the title of the source data.
-     * 
+     *
      * @param source
      *            - the source data
      * @return - the title of the source data, or {@code null} if there is none.
      */
     protected abstract @Nullable String extractTitle(SOURCE source);
-    
+
     /**
      * Projects the {@link Synopses} of the source data.
-     * 
+     *
      * @param source
      *            - the source data
      * @return - the synopses of the source data, or {@code null} if there is
      *         none.
      */
     protected abstract @Nullable Synopses extractSynopses(SOURCE source);
-    
+
     /**
-     * Projects the {@link com.metabroadcast.atlas.glycerin.model.Brand.People}
+     * Projects the {@link com.metabroadcast.atlas.glycerin.model.Brand.Contributions}
      * of the source data.
-     * 
+     *
      * @param source
      *            - the source data
-     * @return - the people of the source data, or {@code null} if there is none.
+     * @return - the contributors of the source data, or {@code null} if there is none.
      */
 
-    protected abstract @Nullable Brand.People extractPeople(SOURCE source);
+    protected abstract @Nullable Brand.Contributions extractContributions(SOURCE source);
 
     /**
      * Projects the {@link com.metabroadcast.atlas.glycerin.model.Image Image}
@@ -157,24 +155,24 @@ public abstract class NitroContentExtractor<SOURCE, CONTENT extends Content>
      * @return - the image of the source data, or {@code null} if there is none.
      */
     protected abstract @Nullable Brand.Image extractImage(SOURCE source);
-    
+
     /**
      * Concrete implementations can override this method to perform additional
      * configuration of the extracted content from the source.
-     * 
+     *
      * @param source - the source data.
      * @param content - the extracted content.
      * @param now - the current time.
      */
     protected void extractAdditionalFields(SOURCE source, CONTENT content, DateTime now) {
-        
+
     }
 
     private String longestSynopsis(Synopses synopses) {
         return Strings.emptyToNull(
-            Objects.firstNonNull(synopses.getLong(), 
-                Objects.firstNonNull(synopses.getMedium(), 
-                    Objects.firstNonNull(synopses.getShort(), ""))));
+                Objects.firstNonNull(synopses.getLong(),
+                        Objects.firstNonNull(synopses.getMedium(),
+                                Objects.firstNonNull(synopses.getShort(), ""))));
     }
 
     private MediaType computeMediaType(MasterBrand masterBrand) {
@@ -183,8 +181,8 @@ public abstract class NitroContentExtractor<SOURCE, CONTENT extends Content>
         }
 
         return RadioPlayerServices.masterBrandIdToService.containsKey(masterBrand.getMid()) ?
-               MediaType.AUDIO :
-               MediaType.VIDEO;
+                MediaType.AUDIO :
+                MediaType.VIDEO;
     }
 
 }

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroCrewMemberExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroCrewMemberExtractor.java
@@ -1,16 +1,17 @@
 package org.atlasapi.remotesite.bbc.nitro.extract;
 
-import com.google.api.client.repackaged.com.google.common.base.Joiner;
-import com.google.api.client.repackaged.com.google.common.base.Strings;
-import com.google.common.base.Optional;
-import com.metabroadcast.atlas.glycerin.model.Brand;
+import static org.atlasapi.remotesite.bbc.nitro.extract.NitroUtil.curieFor;
+import static org.atlasapi.remotesite.bbc.nitro.extract.NitroUtil.uriFor;
+
 import org.atlasapi.media.entity.Actor;
 import org.atlasapi.media.entity.CrewMember;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.remotesite.ContentExtractor;
 
-import static org.atlasapi.remotesite.bbc.nitro.extract.NitroUtil.curieFor;
-import static org.atlasapi.remotesite.bbc.nitro.extract.NitroUtil.uriFor;
+import com.google.api.client.repackaged.com.google.common.base.Joiner;
+import com.google.api.client.repackaged.com.google.common.base.Strings;
+import com.google.common.base.Optional;
+import com.metabroadcast.atlas.glycerin.model.Brand;
 
 public class NitroCrewMemberExtractor implements
         ContentExtractor<Brand.Contributions.Contribution, Optional<CrewMember>> {
@@ -19,7 +20,8 @@ public class NitroCrewMemberExtractor implements
 
     @Override
     public Optional<CrewMember> extract(Brand.Contributions.Contribution contribution) {
-        Optional<CrewMember.Role> role = CrewMember.Role.fromPossibleTvaCode(contribution.getCreditRole().getId());
+        Optional<CrewMember.Role> role = CrewMember.Role.fromPossibleTvaCode(contribution.getCreditRole()
+                .getId());
 
         if (!role.isPresent()) {
             return Optional.absent();
@@ -34,7 +36,8 @@ public class NitroCrewMemberExtractor implements
         return Optional.of(crewMember);
     }
 
-    private static CrewMember crewMemberFor(Brand.Contributions.Contribution contribution, CrewMember.Role role) {
+    private static CrewMember crewMemberFor(Brand.Contributions.Contribution contribution,
+            CrewMember.Role role) {
         CrewMember crewMember;
         if (CrewMember.Role.ACTOR.equals(role)) {
             crewMember = createActor(contribution);

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroCrewMemberExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroCrewMemberExtractor.java
@@ -1,26 +1,25 @@
 package org.atlasapi.remotesite.bbc.nitro.extract;
 
-import static org.atlasapi.remotesite.bbc.nitro.extract.NitroUtil.curieFor;
-import static org.atlasapi.remotesite.bbc.nitro.extract.NitroUtil.uriFor;
-
+import com.google.api.client.repackaged.com.google.common.base.Joiner;
+import com.google.api.client.repackaged.com.google.common.base.Strings;
+import com.google.common.base.Optional;
+import com.metabroadcast.atlas.glycerin.model.Brand;
 import org.atlasapi.media.entity.Actor;
 import org.atlasapi.media.entity.CrewMember;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.remotesite.ContentExtractor;
 
-import com.google.api.client.repackaged.com.google.common.base.Joiner;
-import com.google.api.client.repackaged.com.google.common.base.Strings;
-import com.google.common.base.Optional;
-import com.metabroadcast.atlas.glycerin.model.Brand;
+import static org.atlasapi.remotesite.bbc.nitro.extract.NitroUtil.curieFor;
+import static org.atlasapi.remotesite.bbc.nitro.extract.NitroUtil.uriFor;
 
 public class NitroCrewMemberExtractor implements
-        ContentExtractor<Brand.People.Contribution, Optional<CrewMember>> {
+        ContentExtractor<Brand.Contributions.Contribution, Optional<CrewMember>> {
 
     private static final Publisher PUBLISHER = Publisher.BBC_NITRO;
 
     @Override
-    public Optional<CrewMember> extract(Brand.People.Contribution contribution) {
-        Optional<CrewMember.Role> role = CrewMember.Role.fromPossibleTvaCode(contribution.getCreditRoleId());
+    public Optional<CrewMember> extract(Brand.Contributions.Contribution contribution) {
+        Optional<CrewMember.Role> role = CrewMember.Role.fromPossibleTvaCode(contribution.getCreditRole().getId());
 
         if (!role.isPresent()) {
             return Optional.absent();
@@ -28,14 +27,14 @@ public class NitroCrewMemberExtractor implements
 
         CrewMember crewMember = crewMemberFor(contribution, role.get()).withRole(role.get());
 
-        if (contribution.getContributorName() != null) {
-            crewMember.withName(fullName(contribution.getContributorName()));
+        if (contribution.getContributor().getName() != null) {
+            crewMember.withName(fullName(contribution.getContributor().getName()));
         }
 
         return Optional.of(crewMember);
     }
 
-    private static CrewMember crewMemberFor(Brand.People.Contribution contribution, CrewMember.Role role) {
+    private static CrewMember crewMemberFor(Brand.Contributions.Contribution contribution, CrewMember.Role role) {
         CrewMember crewMember;
         if (CrewMember.Role.ACTOR.equals(role)) {
             crewMember = createActor(contribution);
@@ -45,16 +44,16 @@ public class NitroCrewMemberExtractor implements
         return crewMember;
     }
 
-    private static CrewMember createCrewMember(Brand.People.Contribution contribution) {
+    private static CrewMember createCrewMember(Brand.Contributions.Contribution contribution) {
         return new CrewMember(uriFor(contribution), curieFor(contribution), PUBLISHER);
     }
 
-    private static CrewMember createActor(Brand.People.Contribution contribution) {
+    private static CrewMember createActor(Brand.Contributions.Contribution contribution) {
         return new Actor(uriFor(contribution), curieFor(contribution), PUBLISHER)
                 .withCharacter(contribution.getCharacterName());
     }
 
-    private static String fullName(Brand.People.Contribution.ContributorName name) {
+    private static String fullName(Brand.Contributions.Contribution.Contributor.Name name) {
         return Joiner.on(" ").skipNulls().join(
                 Strings.emptyToNull(name.getGiven()),
                 Strings.emptyToNull(name.getFamily())

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroEpisodeExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroEpisodeExtractor.java
@@ -1,55 +1,52 @@
 package org.atlasapi.remotesite.bbc.nitro.extract;
 
-import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.metabroadcast.atlas.glycerin.model.AncestorsTitles;
+import com.metabroadcast.atlas.glycerin.model.AncestorsTitles.Brand;
+import com.metabroadcast.atlas.glycerin.model.AncestorsTitles.Series;
+import com.metabroadcast.atlas.glycerin.model.Brand.Image;
+import com.metabroadcast.atlas.glycerin.model.Brand.MasterBrand;
+import com.metabroadcast.atlas.glycerin.model.Episode;
+import com.metabroadcast.atlas.glycerin.model.Format;
+import com.metabroadcast.atlas.glycerin.model.PidReference;
+import com.metabroadcast.atlas.glycerin.model.Synopses;
 import com.metabroadcast.common.intl.Countries;
+import com.metabroadcast.common.time.Clock;
 import org.atlasapi.media.entity.CrewMember;
 import org.atlasapi.media.entity.Film;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.ParentRef;
 import org.atlasapi.media.entity.Person;
 import org.atlasapi.media.entity.ReleaseDate;
-import org.atlasapi.persistence.content.people.QueuingItemsPeopleWriter;
 import org.atlasapi.persistence.content.people.QueuingPersonWriter;
 import org.atlasapi.remotesite.ContentExtractor;
 import org.atlasapi.remotesite.bbc.BbcFeeds;
 import org.atlasapi.remotesite.bbc.nitro.v1.NitroGenreGroup;
 import org.joda.time.DateTime;
-
-import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import com.metabroadcast.atlas.glycerin.model.AncestorsTitles;
-import com.metabroadcast.atlas.glycerin.model.AncestorsTitles.Brand;
-import com.metabroadcast.atlas.glycerin.model.AncestorsTitles.Series;
-import com.metabroadcast.atlas.glycerin.model.Brand.Image;
-import com.metabroadcast.atlas.glycerin.model.Brand.People;
-import com.metabroadcast.atlas.glycerin.model.Brand.MasterBrand;
-import com.metabroadcast.atlas.glycerin.model.Episode;
-import com.metabroadcast.atlas.glycerin.model.Format;
-import com.metabroadcast.atlas.glycerin.model.PidReference;
-import com.metabroadcast.atlas.glycerin.model.Synopses;
-import com.metabroadcast.common.time.Clock;
 import org.joda.time.LocalDate;
 
 import javax.xml.datatype.XMLGregorianCalendar;
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Set;
+
+import static com.metabroadcast.atlas.glycerin.model.Brand.Contributions;
 
 /**
  * <p>
  * A {@link BaseNitroItemExtractor} for extracting {@link Item}s from
  * {@link Episode} sources.
  * </p>
- * 
+ *
  * <p>
  * Creates and {@link Item} or {@link org.atlasapi.media.entity.Episode Atlas
  * Episode} and sets the parent and episode number fields as necessary.
  * </p>
- * 
+ *
  * @see BaseNitroItemExtractor
  * @see NitroContentExtractor
  */
@@ -64,7 +61,7 @@ public final class NitroEpisodeExtractor extends BaseNitroItemExtractor<Episode,
     };
 
     private final ContentExtractor<List<NitroGenreGroup>, Set<String>> genresExtractor
-        = new NitroGenresExtractor();
+            = new NitroGenresExtractor();
 
     private final NitroCrewMemberExtractor crewMemberExtractor = new NitroCrewMemberExtractor();
     private final NitroPersonExtractor personExtractor = new NitroPersonExtractor();
@@ -116,8 +113,8 @@ public final class NitroEpisodeExtractor extends BaseNitroItemExtractor<Episode,
     }
 
     @Override
-    protected People extractPeople(NitroItemSource<Episode> source) {
-        return source.getProgramme().getPeople();
+    protected Contributions extractContributions(NitroItemSource<Episode> source) {
+        return source.getProgramme().getContributions();
     }
 
     @Override
@@ -134,7 +131,7 @@ public final class NitroEpisodeExtractor extends BaseNitroItemExtractor<Episode,
         Episode episode = source.getProgramme();
         if (item.getTitle() == null) {
             item.setTitle(episode.getPresentationTitle());
-        } 
+        }
         if (hasMoreThanOneSeriesAncestor(episode)) {
             item.setTitle(compileTitleForSeriesSeriesEpisode(episode));
         }
@@ -155,12 +152,11 @@ public final class NitroEpisodeExtractor extends BaseNitroItemExtractor<Episode,
     }
 
     private void writeAndSetPeople(Item item, NitroItemSource<Episode> source) {
-        People people = source.getProgramme().getPeople();
+        Contributions contributions = source.getProgramme().getContributions();
 
-        if (people != null) {
+        if (contributions != null) {
             ImmutableList.Builder<CrewMember> crewMembers = ImmutableList.builder();
-
-            for (People.Contribution contribution : people.getPeopleMixinContribution()) {
+            for (Contributions.Contribution contribution : contributions.getContributionsMixinContribution()) {
                 Optional<CrewMember> crewMember = crewMemberExtractor.extract(contribution);
 
                 if (crewMember.isPresent()) {
@@ -208,8 +204,8 @@ public final class NitroEpisodeExtractor extends BaseNitroItemExtractor<Episode,
         } else if (isBrandSeriesEpisode(episode)) {
             brandRef = getRefFromBrandAncestor(episode);
         } else if (isTopLevelSeriesEpisode(episode)) {
-           Series topSeries = episode.getAncestorsTitles().getSeries().get(0);
-           brandRef = new ParentRef(BbcFeeds.nitroUriForPid(topSeries.getPid()));
+            Series topSeries = episode.getAncestorsTitles().getSeries().get(0);
+            brandRef = new ParentRef(BbcFeeds.nitroUriForPid(topSeries.getPid()));
         }
         return brandRef;
     }
@@ -227,13 +223,13 @@ public final class NitroEpisodeExtractor extends BaseNitroItemExtractor<Episode,
         }
         return seriesRef;
     }
-    
+
     private boolean isBrandEpisode(Episode episode) {
         PidReference episodeOf = episode.getEpisodeOf();
         return episodeOf != null
-            && "brand".equals(episodeOf.getResultType());
+                && "brand".equals(episodeOf.getResultType());
     }
-    
+
     private boolean isBrandSeriesEpisode(Episode episode) {
         PidReference episodeOf = episode.getEpisodeOf();
         return episodeOf != null
@@ -243,7 +239,7 @@ public final class NitroEpisodeExtractor extends BaseNitroItemExtractor<Episode,
 
     private boolean hasBrandAncestor(Episode episode) {
         return episode.getAncestorsTitles() != null
-            && episode.getAncestorsTitles().getBrand() != null;
+                && episode.getAncestorsTitles().getBrand() != null;
     }
 
     private boolean isTopLevelSeriesEpisode(Episode episode) {
@@ -262,5 +258,5 @@ public final class NitroEpisodeExtractor extends BaseNitroItemExtractor<Episode,
     protected MasterBrand extractMasterBrand(NitroItemSource<Episode> source) {
         return source.getProgramme().getMasterBrand();
     }
-    
+
 }

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroEpisodeExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroEpisodeExtractor.java
@@ -1,21 +1,13 @@
 package org.atlasapi.remotesite.bbc.nitro.extract;
 
-import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.metabroadcast.atlas.glycerin.model.AncestorsTitles;
-import com.metabroadcast.atlas.glycerin.model.AncestorsTitles.Brand;
-import com.metabroadcast.atlas.glycerin.model.AncestorsTitles.Series;
-import com.metabroadcast.atlas.glycerin.model.Brand.Image;
-import com.metabroadcast.atlas.glycerin.model.Brand.MasterBrand;
-import com.metabroadcast.atlas.glycerin.model.Episode;
-import com.metabroadcast.atlas.glycerin.model.Format;
-import com.metabroadcast.atlas.glycerin.model.PidReference;
-import com.metabroadcast.atlas.glycerin.model.Synopses;
-import com.metabroadcast.common.intl.Countries;
-import com.metabroadcast.common.time.Clock;
+import static com.metabroadcast.atlas.glycerin.model.Brand.Contributions;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Set;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+
 import org.atlasapi.media.entity.CrewMember;
 import org.atlasapi.media.entity.Film;
 import org.atlasapi.media.entity.Item;
@@ -29,19 +21,28 @@ import org.atlasapi.remotesite.bbc.nitro.v1.NitroGenreGroup;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 
-import javax.xml.datatype.XMLGregorianCalendar;
-import java.math.BigInteger;
-import java.util.List;
-import java.util.Set;
-
-import static com.metabroadcast.atlas.glycerin.model.Brand.Contributions;
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.metabroadcast.atlas.glycerin.model.AncestorsTitles;
+import com.metabroadcast.atlas.glycerin.model.AncestorsTitles.Brand;
+import com.metabroadcast.atlas.glycerin.model.AncestorsTitles.Series;
+import com.metabroadcast.atlas.glycerin.model.Brand.MasterBrand;
+import com.metabroadcast.atlas.glycerin.model.Episode;
+import com.metabroadcast.atlas.glycerin.model.Format;
+import com.metabroadcast.atlas.glycerin.model.PidReference;
+import com.metabroadcast.atlas.glycerin.model.Synopses;
+import com.metabroadcast.common.intl.Countries;
+import com.metabroadcast.common.time.Clock;
 
 /**
  * <p>
  * A {@link BaseNitroItemExtractor} for extracting {@link Item}s from
  * {@link Episode} sources.
  * </p>
- *
+ * <p>
  * <p>
  * Creates and {@link Item} or {@link org.atlasapi.media.entity.Episode Atlas
  * Episode} and sets the parent and episode number fields as necessary.
@@ -54,6 +55,7 @@ public final class NitroEpisodeExtractor extends BaseNitroItemExtractor<Episode,
 
     private static final String FILM_FORMAT_ID = "PT007";
     private static final Predicate<Format> IS_FILM_FORMAT = new Predicate<Format>() {
+
         @Override
         public boolean apply(Format input) {
             return FILM_FORMAT_ID.equals(input.getFormatId());
@@ -118,8 +120,9 @@ public final class NitroEpisodeExtractor extends BaseNitroItemExtractor<Episode,
     }
 
     @Override
-    protected Image extractImage(NitroItemSource<Episode> source) {
-        return source.getProgramme().getImage();
+    protected com.metabroadcast.atlas.glycerin.model.Brand.Images.Image extractImage(
+            NitroItemSource<Episode> source) {
+        return source.getProgramme().getImages().getImage();
     }
 
     protected XMLGregorianCalendar extractReleaseDate(NitroItemSource<Episode> source) {
@@ -127,7 +130,8 @@ public final class NitroEpisodeExtractor extends BaseNitroItemExtractor<Episode,
     }
 
     @Override
-    protected void extractAdditionalItemFields(NitroItemSource<Episode> source, Item item, DateTime now) {
+    protected void extractAdditionalItemFields(NitroItemSource<Episode> source, Item item,
+            DateTime now) {
         Episode episode = source.getProgramme();
         if (item.getTitle() == null) {
             item.setTitle(episode.getPresentationTitle());
@@ -180,8 +184,10 @@ public final class NitroEpisodeExtractor extends BaseNitroItemExtractor<Episode,
 
     private void setReleaseDate(Item item, NitroItemSource<Episode> source) {
         XMLGregorianCalendar date = extractReleaseDate(source);
-        LocalDate localDate = new LocalDate(date.getYear(),date.getMonth(),date.getDay());
-        ReleaseDate releaseDate = new ReleaseDate(localDate, Countries.GB, ReleaseDate.ReleaseType.FIRST_BROADCAST);
+        LocalDate localDate = new LocalDate(date.getYear(), date.getMonth(), date.getDay());
+        ReleaseDate releaseDate = new ReleaseDate(localDate,
+                Countries.GB,
+                ReleaseDate.ReleaseType.FIRST_BROADCAST);
         item.setReleaseDates(Lists.newArrayList(releaseDate));
     }
 
@@ -217,7 +223,7 @@ public final class NitroEpisodeExtractor extends BaseNitroItemExtractor<Episode,
 
     private ParentRef getSeriesRef(Episode episode) {
         ParentRef seriesRef = null;
-        if (isBrandSeriesEpisode(episode) || isTopLevelSeriesEpisode(episode)){
+        if (isBrandSeriesEpisode(episode) || isTopLevelSeriesEpisode(episode)) {
             Series topSeries = episode.getAncestorsTitles().getSeries().get(0);
             seriesRef = new ParentRef(BbcFeeds.nitroUriForPid(topSeries.getPid()));
         }

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroGenresExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroGenresExtractor.java
@@ -15,7 +15,7 @@ public class NitroGenresExtractor implements ContentExtractor<List<NitroGenreGro
 
     private static final String PREFIX = "http://www.bbc.co.uk/programmes/genres/";
     private static final String ID_PREFIX = "http://nitro.bbc.co.uk/genres/";
-    
+
     @Override
     public Set<String> extract(List<NitroGenreGroup> genreGroups) {
         ImmutableSet.Builder<String> genres = ImmutableSet.builder();
@@ -25,8 +25,9 @@ public class NitroGenresExtractor implements ContentExtractor<List<NitroGenreGro
         return genres.build();
     }
 
-    private Iterable<String> extractGenres(ImmutableSet.Builder<String> genres, NitroGenreGroup genreGroup) {
-        String parent = null; 
+    private Iterable<String> extractGenres(ImmutableSet.Builder<String> genres,
+            NitroGenreGroup genreGroup) {
+        String parent = null;
         List<NitroGenre> groupGenres = genreGroup.getGenres();
         for (NitroGenre nitroGenre : groupGenres.subList(0, Math.min(groupGenres.size(), 2))) {
             parent = extractGenre(nitroGenre, parent);

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroImageExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroImageExtractor.java
@@ -9,10 +9,10 @@ import org.atlasapi.remotesite.ContentExtractor;
 /**
  * Extracts an {@link Image} from a
  * {@link com.metabroadcast.atlas.glycerin.model.Image} according to the provided dimensions.
- * 
  */
-public class NitroImageExtractor 
-    implements ContentExtractor<com.metabroadcast.atlas.glycerin.model.Brand.Image, Image> {
+public class NitroImageExtractor
+        implements
+        ContentExtractor<com.metabroadcast.atlas.glycerin.model.Brand.Images.Image, Image> {
 
     private final String recipe;
     private final int width;
@@ -21,8 +21,8 @@ public class NitroImageExtractor
     /**
      * Create a new extractor which extracts {@link Image}s with the provided
      * dimensions.
-     * 
-     * @param width - the width of the image
+     *
+     * @param width  - the width of the image
      * @param height - the height of the image
      */
     public NitroImageExtractor(int width, int height) {
@@ -35,7 +35,7 @@ public class NitroImageExtractor
     }
 
     @Override
-    public Image extract(com.metabroadcast.atlas.glycerin.model.Brand.Image source) {
+    public Image extract(com.metabroadcast.atlas.glycerin.model.Brand.Images.Image source) {
         checkNotNull(source, "null image source");
         checkNotNull(source.getTemplateUrl(), "null image template");
 

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroItemSource.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroItemSource.java
@@ -4,34 +4,25 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.List;
 
-import javax.annotation.Nullable;
-
-import org.atlasapi.remotesite.bbc.nitro.v1.NitroFormat;
 import org.atlasapi.remotesite.bbc.nitro.v1.NitroGenreGroup;
 
 import com.google.common.base.Function;
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Multimaps;
 import com.metabroadcast.atlas.glycerin.model.Availability;
 import com.metabroadcast.atlas.glycerin.model.Broadcast;
-import com.metabroadcast.atlas.glycerin.model.Format;
 import com.metabroadcast.atlas.glycerin.model.Version;
 
 /**
  * A source which contains all the data required for extracting an
  * {@link org.atlasapi.media.entity.Item Item}, including {@link Availability}s
  * and {@link Broadcast}s.
- * 
+ *
  * @param <T> - the type of {@link com.metabroadcast.atlas.glycerin.model.Programme Programme}
  */
 public class NitroItemSource<T> {
 
     private static final Function<Broadcast, String> BROADCAST_TO_VERSION_PID = new Function<Broadcast, String>() {
+
         @Override
         public String apply(Broadcast input) {
             return NitroUtil.versionPid(input).getPid();
@@ -39,34 +30,38 @@ public class NitroItemSource<T> {
     };
 
     /**
-     * Create a source for the given programme and availabilities. 
-     * @param programme - the programme.
+     * Create a source for the given programme and availabilities.
+     *
+     * @param programme      - the programme.
      * @param availabilities - the availabilities.
      * @return a {@code NitroItemSource} for the programme and availabilities.
      */
-    public static <T> NitroItemSource<T> valueOf(T programme, Iterable<Availability> availabilities) {
-        return new NitroItemSource<T>(programme, 
-            availabilities, 
-            ImmutableList.<Broadcast>of(),
-            ImmutableList.<NitroGenreGroup>of(),
-            ImmutableList.<Version>of()
+    public static <T> NitroItemSource<T> valueOf(T programme,
+            Iterable<Availability> availabilities) {
+        return new NitroItemSource<T>(programme,
+                availabilities,
+                ImmutableList.<Broadcast>of(),
+                ImmutableList.<NitroGenreGroup>of(),
+                ImmutableList.<Version>of()
         );
     }
 
     /**
-     * Create a source for the given programme, availabilities and broadcasts. 
-     * @param programme - the programme.
+     * Create a source for the given programme, availabilities and broadcasts.
+     *
+     * @param programme      - the programme.
      * @param availabilities - the availabilities.
-     * @param broadcasts - the broadcasts.
-     * @param versions - the versions.
+     * @param broadcasts     - the broadcasts.
+     * @param versions       - the versions.
      * @return a {@code NitroItemSource} for the programme, availabilities and broadcasts.
      */
-    public static <T> NitroItemSource<T> valueOf(T programme, List<Availability> availabilities, List<Broadcast> broadcasts, List<NitroGenreGroup> genres, List<Version> versions) {
-        return new NitroItemSource<T>(programme, 
-            availabilities, 
-            broadcasts,
-            genres,
-            versions
+    public static <T> NitroItemSource<T> valueOf(T programme, List<Availability> availabilities,
+            List<Broadcast> broadcasts, List<NitroGenreGroup> genres, List<Version> versions) {
+        return new NitroItemSource<T>(programme,
+                availabilities,
+                broadcasts,
+                genres,
+                versions
         );
     }
 
@@ -78,7 +73,7 @@ public class NitroItemSource<T> {
 
     private NitroItemSource(T programme, Iterable<Availability> availabilities,
             Iterable<Broadcast> broadcasts,
-            Iterable<NitroGenreGroup> genres, 
+            Iterable<NitroGenreGroup> genres,
             Iterable<Version> versions) {
         this.programme = checkNotNull(programme);
         this.availabilities = ImmutableList.copyOf(availabilities);
@@ -88,15 +83,17 @@ public class NitroItemSource<T> {
     }
 
     /**
-     * Get the programme related to this source. 
+     * Get the programme related to this source.
+     *
      * @return - the programme
      */
     public T getProgramme() {
         return programme;
     }
-    
+
     /**
-     * Get the availabilities related to this source. 
+     * Get the availabilities related to this source.
+     *
      * @return - the availabilities
      */
     public ImmutableList<Availability> getAvailabilities() {
@@ -105,6 +102,7 @@ public class NitroItemSource<T> {
 
     /**
      * Get the broadcasts related to this source.
+     *
      * @return - the broadcasts
      */
     public ImmutableList<Broadcast> getBroadcasts() {
@@ -113,6 +111,7 @@ public class NitroItemSource<T> {
 
     /**
      * Get the genre groups related to this source.
+     *
      * @return - the genre groups
      */
     public ImmutableList<NitroGenreGroup> getGenres() {
@@ -121,6 +120,7 @@ public class NitroItemSource<T> {
 
     /**
      * Get the versions related to this source.
+     *
      * @return - the versions
      */
     public ImmutableList<Version> getVersions() {

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroPersonExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroPersonExtractor.java
@@ -9,11 +9,12 @@ import com.google.common.base.Optional;
 import com.metabroadcast.atlas.glycerin.model.Brand;
 
 public class NitroPersonExtractor implements
-        ContentExtractor<Brand.People.Contribution, Optional<Person>> {
+        ContentExtractor<Brand.Contributions.Contribution, Optional<Person>> {
 
     @Override
-    public Optional<Person> extract(Brand.People.Contribution contribution) {
-        Brand.People.Contribution.ContributorName contributorName = contribution.getContributorName();
+    public Optional<Person> extract(Brand.Contributions.Contribution contribution) {
+        Brand.Contributions.Contribution.Contributor.Name contributorName = contribution
+                .getContributor().getName();
 
         if (contributorName == null) {
             return Optional.absent();
@@ -23,7 +24,7 @@ public class NitroPersonExtractor implements
         person.setCanonicalUri(NitroUtil.uriFor(contribution));
         person.setCurie(NitroUtil.curieFor(contribution));
         person.setPublisher(Publisher.BBC_NITRO);
-        
+
         if (!Strings.isNullOrEmpty(contributorName.getPresentation())) {
             person.setGivenName(contributorName.getPresentation());
         } else {

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroSeriesExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroSeriesExtractor.java
@@ -1,26 +1,25 @@
 package org.atlasapi.remotesite.bbc.nitro.extract;
 
-import com.metabroadcast.atlas.glycerin.model.Brand;
-import com.metabroadcast.atlas.glycerin.model.Brand.Image;
-import com.metabroadcast.atlas.glycerin.model.Brand.MasterBrand;
-import com.metabroadcast.atlas.glycerin.model.Series;
-import com.metabroadcast.atlas.glycerin.model.Synopses;
-import com.metabroadcast.common.time.Clock;
+import java.math.BigInteger;
+
 import org.atlasapi.media.entity.ParentRef;
 import org.atlasapi.remotesite.bbc.BbcFeeds;
 import org.joda.time.DateTime;
 
-import java.math.BigInteger;
+import com.metabroadcast.atlas.glycerin.model.Brand;
+import com.metabroadcast.atlas.glycerin.model.Brand.MasterBrand;
+import com.metabroadcast.atlas.glycerin.model.Series;
+import com.metabroadcast.atlas.glycerin.model.Synopses;
+import com.metabroadcast.common.time.Clock;
 
 /**
  * A {@link NitroContentExtractor} for extracting
  * {org.atlasapi.media.entity.Series Atlas Series} from {@link Series Nitro
  * Series}.
- * 
  */
 public class NitroSeriesExtractor
         extends NitroContentExtractor<Series, org.atlasapi.media.entity.Series> {
-    
+
     public NitroSeriesExtractor(Clock clock) {
         super(clock);
     }
@@ -50,18 +49,20 @@ public class NitroSeriesExtractor
     }
 
     @Override
-    protected Image extractImage(Series source) {
-        return source.getImage();
+    protected Brand.Images.Image extractImage(Series source) {
+        return source.getImages().getImage();
     }
 
     @Override
-    protected void extractAdditionalFields(Series source, org.atlasapi.media.entity.Series content, DateTime now) {
+    protected void extractAdditionalFields(Series source, org.atlasapi.media.entity.Series content,
+            DateTime now) {
         if (source.getSeriesOf() != null) {
             BigInteger position = source.getSeriesOf().getPosition();
             if (position != null) {
                 content.withSeriesNumber(position.intValue());
             }
-            content.setParentRef(new ParentRef(BbcFeeds.nitroUriForPid(source.getSeriesOf().getPid())));
+            content.setParentRef(new ParentRef(BbcFeeds.nitroUriForPid(source.getSeriesOf()
+                    .getPid())));
         }
         BigInteger expectedChildCount = source.getExpectedChildCount();
         if (expectedChildCount != null) {

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroSeriesExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroSeriesExtractor.java
@@ -1,19 +1,16 @@
 package org.atlasapi.remotesite.bbc.nitro.extract;
 
-import java.math.BigInteger;
-
-import javax.annotation.Nullable;
-
-import org.atlasapi.media.entity.ParentRef;
-import org.atlasapi.remotesite.bbc.BbcFeeds;
-import org.joda.time.DateTime;
-
 import com.metabroadcast.atlas.glycerin.model.Brand;
 import com.metabroadcast.atlas.glycerin.model.Brand.Image;
 import com.metabroadcast.atlas.glycerin.model.Brand.MasterBrand;
 import com.metabroadcast.atlas.glycerin.model.Series;
 import com.metabroadcast.atlas.glycerin.model.Synopses;
 import com.metabroadcast.common.time.Clock;
+import org.atlasapi.media.entity.ParentRef;
+import org.atlasapi.remotesite.bbc.BbcFeeds;
+import org.joda.time.DateTime;
+
+import java.math.BigInteger;
 
 /**
  * A {@link NitroContentExtractor} for extracting
@@ -48,8 +45,8 @@ public class NitroSeriesExtractor
         return source.getSynopses();
     }
 
-    @Override protected Brand.People extractPeople(Series series) {
-        return series.getPeople();
+    @Override protected Brand.Contributions extractContributions(Series series) {
+        return series.getContributions();
     }
 
     @Override

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroUtil.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroUtil.java
@@ -1,14 +1,5 @@
 package org.atlasapi.remotesite.bbc.nitro.extract;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.util.Set;
-
-import javax.xml.datatype.XMLGregorianCalendar;
-
-import org.joda.time.DateTime;
-import org.joda.time.chrono.ISOChronology;
-
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -19,9 +10,16 @@ import com.metabroadcast.atlas.glycerin.model.Broadcast;
 import com.metabroadcast.atlas.glycerin.model.PidReference;
 import com.metabroadcast.atlas.glycerin.model.Version;
 import com.metabroadcast.common.time.DateTimeZones;
+import org.joda.time.DateTime;
+import org.joda.time.chrono.ISOChronology;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * Utility methods for extracting Nitro data. 
+ * Utility methods for extracting Nitro data.
  *
  */
 public final class NitroUtil {
@@ -30,13 +28,13 @@ public final class NitroUtil {
     private static final String PERSON_CURIE_PREFIX = "nitro:bbc:person_";
 
     private NitroUtil() {}
-    
-    private static final Set<String> availabilityParentTypes = ImmutableSet.of("episode", "clip"); 
-    private static final Set<String> versionTypes = ImmutableSet.of("version"); 
-    
+
+    private static final Set<String> availabilityParentTypes = ImmutableSet.of("episode", "clip");
+    private static final Set<String> versionTypes = ImmutableSet.of("version");
+
     /**
      * Returns the PID of the episode or clip associated with an availability.
-     * 
+     *
      * @param availability
      *            - the availability from which to extract the PID.
      * @return - the PID of the availability's programme or null if there is
@@ -49,7 +47,7 @@ public final class NitroUtil {
 
     /**
      * Returns the {@link PidReference} of the version associated with an availability.
-     * 
+     *
      * @param availability
      *            - the availability from which to extract the PID.
      * @return - the {@link PidReference} of the availability's version or null if there is
@@ -69,10 +67,10 @@ public final class NitroUtil {
         }
         return parentPid;
     }
-    
+
     /**
      * Returns the {@link PidReference} of the episode or clip associated with an broadcast.
-     * 
+     *
      * @param broadcast
      *            - the broadcast from which to extract the PID.
      * @return - the {@link PidReference} of the broadcast's programme or null if there is
@@ -82,10 +80,10 @@ public final class NitroUtil {
         checkNotNull(broadcast, "null broadcast");
         return refInTypes(broadcast, availabilityParentTypes);
     }
-    
+
     /**
      * Returns the {@link PidReference} of the version associated with a broadcast.
-     * 
+     *
      * @param broadcast
      *            - the broadcast from which to extract the PID.
      * @return - the {@link PidReference} of the broadcast's version or null if there is
@@ -108,7 +106,7 @@ public final class NitroUtil {
         checkNotNull(version, "null version");
         return version.getVersionOf();
     }
-    
+
     private static PidReference refInTypes(Broadcast broadcast, Set<String> types) {
         PidReference parentPid = null;
         for (PidReference pidRef : broadcast.getBroadcastOf()) {
@@ -118,20 +116,20 @@ public final class NitroUtil {
         }
         return parentPid;
     }
-    
+
     /**
      * Converts an {@link XMLGregorianCalendar} to a {@link DateTime}.
-     * 
+     *
      * @param cal - the {@link XMLGregorianCalendar} to convert.
      * @return - {@link DateTime} representing the {@link XMLGregorianCalendar}.
      */
     public static DateTime toDateTime(XMLGregorianCalendar cal) {
         checkNotNull(cal, "null calendar");
         return new DateTime(cal.toGregorianCalendar(), ISOChronology.getInstance())
-            .toDateTime(DateTimeZones.UTC);
+                .toDateTime(DateTimeZones.UTC);
     }
-    
-    
+
+
     public static Iterable<String> toPids(Iterable<PidReference> refs) {
         return Iterables.transform(refs, new Function<PidReference, String>() {
             @Override
@@ -141,12 +139,16 @@ public final class NitroUtil {
         });
     }
 
-    public static String uriFor(Brand.People.Contribution contribution) {
-        return PERSON_URI_PREFIX + contribution.getContributionBy();
+    public static String uriFor(Brand.Contributions.Contribution contribution) {
+        return PERSON_URI_PREFIX + getContributionBy(contribution);
     }
 
-    public static String curieFor(Brand.People.Contribution contribution) {
-        return PERSON_CURIE_PREFIX + contribution.getContributionBy();
+    public static String curieFor(Brand.Contributions.Contribution contribution) {
+        return PERSON_CURIE_PREFIX + getContributionBy(contribution);
     }
-    
+
+    public static String getContributionBy(Brand.Contributions.Contribution contribution) {
+        String href = contribution.getContributor().getHref();
+        return href.substring(href.indexOf("=") + 1);
+    }
 }

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroUtil.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroUtil.java
@@ -1,5 +1,14 @@
 package org.atlasapi.remotesite.bbc.nitro.extract;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Set;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import org.joda.time.DateTime;
+import org.joda.time.chrono.ISOChronology;
+
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -10,24 +19,17 @@ import com.metabroadcast.atlas.glycerin.model.Broadcast;
 import com.metabroadcast.atlas.glycerin.model.PidReference;
 import com.metabroadcast.atlas.glycerin.model.Version;
 import com.metabroadcast.common.time.DateTimeZones;
-import org.joda.time.DateTime;
-import org.joda.time.chrono.ISOChronology;
-
-import javax.xml.datatype.XMLGregorianCalendar;
-import java.util.Set;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Utility methods for extracting Nitro data.
- *
  */
 public final class NitroUtil {
 
     private static final String PERSON_URI_PREFIX = "http://nitro.bbc.co.uk/people/";
     private static final String PERSON_CURIE_PREFIX = "nitro:bbc:person_";
 
-    private NitroUtil() {}
+    private NitroUtil() {
+    }
 
     private static final Set<String> availabilityParentTypes = ImmutableSet.of("episode", "clip");
     private static final Set<String> versionTypes = ImmutableSet.of("version");
@@ -35,10 +37,9 @@ public final class NitroUtil {
     /**
      * Returns the PID of the episode or clip associated with an availability.
      *
-     * @param availability
-     *            - the availability from which to extract the PID.
+     * @param availability - the availability from which to extract the PID.
      * @return - the PID of the availability's programme or null if there is
-     *         none.
+     * none.
      */
     public static String programmePid(Availability availability) {
         checkNotNull(availability, "null availability");
@@ -48,10 +49,9 @@ public final class NitroUtil {
     /**
      * Returns the {@link PidReference} of the version associated with an availability.
      *
-     * @param availability
-     *            - the availability from which to extract the PID.
+     * @param availability - the availability from which to extract the PID.
      * @return - the {@link PidReference} of the availability's version or null if there is
-     *         none.
+     * none.
      */
     public static String versionPid(Availability availability) {
         checkNotNull(availability, "null availability");
@@ -71,10 +71,9 @@ public final class NitroUtil {
     /**
      * Returns the {@link PidReference} of the episode or clip associated with an broadcast.
      *
-     * @param broadcast
-     *            - the broadcast from which to extract the PID.
+     * @param broadcast - the broadcast from which to extract the PID.
      * @return - the {@link PidReference} of the broadcast's programme or null if there is
-     *         none.
+     * none.
      */
     public static PidReference programmePid(Broadcast broadcast) {
         checkNotNull(broadcast, "null broadcast");
@@ -84,10 +83,9 @@ public final class NitroUtil {
     /**
      * Returns the {@link PidReference} of the version associated with a broadcast.
      *
-     * @param broadcast
-     *            - the broadcast from which to extract the PID.
+     * @param broadcast - the broadcast from which to extract the PID.
      * @return - the {@link PidReference} of the broadcast's version or null if there is
-     *         none.
+     * none.
      */
     public static PidReference versionPid(Broadcast broadcast) {
         checkNotNull(broadcast, "null broadcast");
@@ -97,10 +95,9 @@ public final class NitroUtil {
     /**
      * Returns the {@link PidReference} of the programme associated with a version.
      *
-     * @param version
-     *            - the version from which to extract the PID.
+     * @param version - the version from which to extract the PID.
      * @return - the {@link PidReference} of the version's programme or null if there is
-     *         none.
+     * none.
      */
     public static PidReference programmePid(Version version) {
         checkNotNull(version, "null version");
@@ -129,9 +126,9 @@ public final class NitroUtil {
                 .toDateTime(DateTimeZones.UTC);
     }
 
-
     public static Iterable<String> toPids(Iterable<PidReference> refs) {
         return Iterables.transform(refs, new Function<PidReference, String>() {
+
             @Override
             public String apply(PidReference input) {
                 return input.getPid();

--- a/src/main/java/org/atlasapi/remotesite/btvod/BrandUriExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BrandUriExtractor.java
@@ -20,7 +20,8 @@ public class BrandUriExtractor {
     private static final Pattern HD_PATTERN = Pattern.compile("^(.*)\\-\\sHD");
 
     private static final List<Pattern> BRAND_TITLE_FROM_EPISODE_PATTERNS = ImmutableList.of(
-            Pattern.compile("^(.*):?.*S[0-9]+.*S[0-9]+\\-E.*"),  
+            Pattern.compile("^(.*):.*S[0-9]+.*S[0-9]+\\-E.*"),  
+            Pattern.compile("^(.*).*S[0-9]+.*S[0-9]+\\-E.*"),  
             Pattern.compile("^(.*?)-\\s+.*S[0-9]++[\\- ]E.*"),
             Pattern.compile("^(.*).*S[0-9]++[\\- ]E.*"),
             Pattern.compile("^(.*)Season\\s[0-9]+\\s-\\sSeason\\s[0-9]+\\sEpisode\\s[0-9]+.*"),

--- a/src/main/java/org/atlasapi/system/PaContentDeactivationPredicate.java
+++ b/src/main/java/org/atlasapi/system/PaContentDeactivationPredicate.java
@@ -1,0 +1,70 @@
+package org.atlasapi.system;
+
+import com.google.api.client.repackaged.com.google.common.base.Strings;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+import com.google.common.hash.BloomFilter;
+import org.atlasapi.media.entity.Brand;
+import org.atlasapi.media.entity.Container;
+import org.atlasapi.media.entity.Content;
+import org.atlasapi.media.entity.Series;
+
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class PaContentDeactivationPredicate implements Predicate<Content> {
+
+    private static final Predicate<String> HAS_FILM_URI = new Predicate<String>() {
+        @Override
+        public boolean apply(String s) {
+            return !Strings.isNullOrEmpty(s) && s.startsWith("http://pressassociation.com/films/");
+        }
+    };
+
+    private final BloomFilter<Long> activeContentIds;
+
+    public PaContentDeactivationPredicate(BloomFilter<Long> activeContentIds) {
+        this.activeContentIds = checkNotNull(activeContentIds);
+    }
+
+    @Override
+    public boolean apply(Content content) {
+        return (isNotPaFilm(content) &&
+                isNotActiveContentId(content) &&
+                isNotGenericDescription(content) &&
+                isNotSeries(content)) ||
+                isEmptyContainer(content);
+    }
+
+    private boolean isNotSeries(Content content) {
+        return !(content instanceof Series);
+    }
+
+    private boolean isNotGenericDescription(Content content) {
+        return content.getGenericDescription() != null &&
+                !content.getGenericDescription();
+    }
+
+    private boolean isNotActiveContentId(Content content) {
+        return !activeContentIds.mightContain(content.getId());
+    }
+
+    private boolean isNotPaFilm(Content content) {
+        return !Iterables.any(content.getAllUris(), HAS_FILM_URI);
+    }
+
+    private boolean isEmptyContainer(Content content) {
+        if (!(content instanceof Container)) {
+            return false;
+        }
+        if (content instanceof Series) {
+            Series series = (Series) content;
+            return series.getChildRefs().isEmpty();
+        }
+        if (content instanceof Brand) {
+            Brand brand = (Brand) content;
+            return brand.getChildRefs().isEmpty() && brand.getSeriesRefs().isEmpty();
+        }
+        return false;
+    }
+}

--- a/src/test/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroCrewMemberExtractorTest.java
+++ b/src/test/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroCrewMemberExtractorTest.java
@@ -20,7 +20,7 @@ public class NitroCrewMemberExtractorTest {
 
     @Test
     public void testNonActorExtraction() {
-        Brand.People.Contribution contribution = companyContribution();
+        Brand.Contributions.Contribution contribution = companyContribution();
 
         CrewMember crewMember = extractor.extract(contribution).get();
 
@@ -31,7 +31,7 @@ public class NitroCrewMemberExtractorTest {
 
     @Test
     public void testActorExtraction() {
-        Brand.People.Contribution contribution = actorContribution();
+        Brand.Contributions.Contribution contribution = actorContribution();
 
         CrewMember crewMember = extractor.extract(contribution).get();
 
@@ -40,30 +40,44 @@ public class NitroCrewMemberExtractorTest {
         assertEquals("Carey Mulligan", crewMember.name());
     }
 
-    private Brand.People.Contribution companyContribution() {
-        Brand.People.Contribution contribution = new Brand.People.Contribution();
-        contribution.setContributionBy("p029hdv9");
-        contribution.setCreditRole("Production Company");
-        contribution.setCreditRoleId("V20");
+    private Brand.Contributions.Contribution companyContribution() {
+        Brand.Contributions.Contribution contribution = new Brand.Contributions.Contribution();
 
-        Brand.People.Contribution.ContributorName name = new Brand.People.Contribution.ContributorName();
+        Brand.Contributions.Contribution.Contributor contributor = new Brand.Contributions.Contribution.Contributor();
+        contributor.setHref("p029hdv9");
+
+        Brand.Contributions.Contribution.Contributor.Name name = new Brand.Contributions.Contribution.Contributor.Name();
         name.setFamily("So Television");
-        contribution.setContributorName(name);
+        contributor.setName(name);
+
+        contribution.setContributor(contributor);
+
+        Brand.Contributions.Contribution.CreditRole creditRole = new Brand.Contributions.Contribution.CreditRole();
+        creditRole.setId("V20");
+        creditRole.setValue("Production Company");
+        contribution.setCreditRole(creditRole);
 
         return contribution;
     }
 
-    private Brand.People.Contribution actorContribution() {
-        Brand.People.Contribution contribution = new Brand.People.Contribution();
-        contribution.setContributionBy("p01fvgrh");
+    private Brand.Contributions.Contribution actorContribution() {
+        Brand.Contributions.Contribution contribution = new Brand.Contributions.Contribution();
         contribution.setCharacterName("Irene");
-        contribution.setCreditRole("Actor");
-        contribution.setCreditRoleId("ACTOR");
 
-        Brand.People.Contribution.ContributorName name = new Brand.People.Contribution.ContributorName();
+        Brand.Contributions.Contribution.Contributor contributor = new Brand.Contributions.Contribution.Contributor();
+        contributor.setHref("p01fvgrh");
+
+        Brand.Contributions.Contribution.Contributor.Name name = new Brand.Contributions.Contribution.Contributor.Name();
         name.setGiven("Carey");
         name.setFamily("Mulligan");
-        contribution.setContributorName(name);
+        contributor.setName(name);
+
+        contribution.setContributor(contributor);
+
+        Brand.Contributions.Contribution.CreditRole creditRole = new Brand.Contributions.Contribution.CreditRole();
+        creditRole.setId("ACTOR");
+        creditRole.setValue("Actor");
+        contribution.setCreditRole(creditRole);
 
         return contribution;
     }

--- a/src/test/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroEpisodeExtractorTest.java
+++ b/src/test/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroEpisodeExtractorTest.java
@@ -41,8 +41,6 @@ import com.metabroadcast.atlas.glycerin.model.Format;
 import com.metabroadcast.atlas.glycerin.model.FormatsType;
 import com.metabroadcast.atlas.glycerin.model.PidReference;
 import com.metabroadcast.atlas.glycerin.model.Version;
-import com.metabroadcast.atlas.glycerin.model.VersionType;
-import com.metabroadcast.atlas.glycerin.model.VersionTypes;
 import com.metabroadcast.atlas.glycerin.model.WarningText;
 import com.metabroadcast.atlas.glycerin.model.Warnings;
 import com.metabroadcast.common.time.SystemClock;
@@ -442,13 +440,13 @@ public class NitroEpisodeExtractorTest {
         Version version = new Version();
         version.setPid(AUDIO_DESCRIBED_VERSION_PID);
 
-        VersionType type = new VersionType();
+        Version.Types.Type type = new Version.Types.Type();
         type.setId("DubbedAudioDescribed");
 
-        VersionTypes types = new VersionTypes();
-        types.getVersionType().add(type);
+        Version.Types types = new Version.Types();
+        types.getType().add(type);
 
-        version.setVersionTypes(types);
+        version.setTypes(types);
         version.setDuration(DatatypeFactory.newInstance().newDuration(VERSION_DURATION.getMillis()));
 
         return version;
@@ -457,12 +455,12 @@ public class NitroEpisodeExtractorTest {
     private Version signedVersion(String versionPid) throws DatatypeConfigurationException {
         Version version = version(versionPid);
 
-        VersionType type = new VersionType();
+        Version.Types.Type type = new Version.Types.Type();
         type.setId("Signed");
 
-        VersionTypes types = new VersionTypes();
-        types.getVersionType().add(type);
-        version.setVersionTypes(types);
+        Version.Types types = new Version.Types();
+        types.getType().add(type);
+        version.setTypes(types);
 
         return version;
     }

--- a/src/test/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroImageExtractorTest.java
+++ b/src/test/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroImageExtractorTest.java
@@ -12,7 +12,7 @@ public class NitroImageExtractorTest {
     @Test
     public void testImageExtraction() {
         NitroImageExtractor extractor = new NitroImageExtractor(1024, 576);
-        Brand.Image source = new Brand.Image();
+        Brand.Images.Image source = new Brand.Images.Image();
         source.setTemplateUrl("http://hostname/image_$recipe");
 
         Image extracted = extractor.extract(source);

--- a/src/test/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroPersonExtractorTest.java
+++ b/src/test/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroPersonExtractorTest.java
@@ -16,15 +16,18 @@ public class NitroPersonExtractorTest {
 
     @Test
     public void testPersonExtraction() {
-        Brand.People.Contribution contribution = new Brand.People.Contribution();
-        contribution.setContributionBy("p01fvgrh");
+        Brand.Contributions.Contribution contribution = new Brand.Contributions.Contribution();
         contribution.setCharacterName("Irene");
 
-        Brand.People.Contribution.ContributorName name = new Brand.People.Contribution.ContributorName();
+        Brand.Contributions.Contribution.Contributor.Name name = new Brand.Contributions.Contribution.Contributor.Name();
         name.setGiven("Carey");
         name.setFamily("Mulligan");
 
-        contribution.setContributorName(name);
+        Brand.Contributions.Contribution.Contributor contributor = new Brand.Contributions.Contribution.Contributor();
+        contributor.setHref("p01fvgrh");
+        contributor.setName(name);
+
+        contribution.setContributor(contributor);
 
         Optional<Person> optionalPerson = extractor.extract(contribution);
         assertTrue(optionalPerson.isPresent());

--- a/src/test/java/org/atlasapi/remotesite/btvod/BrandUriExtractorTest.java
+++ b/src/test/java/org/atlasapi/remotesite/btvod/BrandUriExtractorTest.java
@@ -1,6 +1,7 @@
 package org.atlasapi.remotesite.btvod;
 
 
+import org.atlasapi.media.entity.Brand;
 import org.atlasapi.remotesite.btvod.model.BtVodEntry;
 import org.junit.Test;
 
@@ -107,6 +108,10 @@ public class BrandUriExtractorTest {
 
         BtVodEntry row18 = episodeEntry();
         row18.setTitle("Brickleberry S2 - HD S2-E13 Aparkalypse - HD");
+        
+        BtVodEntry row19 = episodeEntry();
+        row19.setTitle("Brand Title: S1 S1-E9 Real Title");
+        
 
         assertThat(brandUriExtractor.extractBrandUri(row1).get(), is(URI_PREFIX + "synthesized/brands/cashmere-mafia"));
         assertThat(brandUriExtractor.extractBrandUri(row2).get(), is(URI_PREFIX + "synthesized/brands/brand-title"));

--- a/src/test/java/org/atlasapi/system/PaContentDeactivatorTest.java
+++ b/src/test/java/org/atlasapi/system/PaContentDeactivatorTest.java
@@ -36,6 +36,7 @@ public class PaContentDeactivatorTest {
     private ProgressStore progressStore;
     private Brand activeContent;
     private Brand inactiveContent;
+    private Brand emptyContainer;
 
     @Before
     public void setUp() throws Exception {
@@ -50,7 +51,9 @@ public class PaContentDeactivatorTest {
         inactiveContent = new Brand("20", "20", Publisher.PA);
         inactiveContent.setId(20l);
         inactiveContent.setGenericDescription(false);
-        setupMocks(activeContent, inactiveContent);
+
+        emptyContainer = new Brand("30", "30", Publisher.PA);
+        setupMocks(activeContent, inactiveContent, emptyContainer);
     }
 
     @Test
@@ -65,9 +68,10 @@ public class PaContentDeactivatorTest {
         Thread.sleep(2000);
         assertThat(activeContent.isActivelyPublished(), is(true));
         assertThat(inactiveContent.isActivelyPublished(), is(false));
+        assertThat(emptyContainer.isActivelyPublished(), is(false));
     }
 
-    private void setupMocks(Content activeContent, Content inactiveContent) {
+    private void setupMocks(Content activeContent, Content inactiveContent, Brand emptyContainer) {
         LookupEntry activeLookup = mock(LookupEntry.class);
         when(activeLookup.id()).thenReturn(10l);
 
@@ -83,7 +87,7 @@ public class PaContentDeactivatorTest {
                 ContentCategory.TOP_LEVEL_ITEM
         );
 
-        Iterator<Content> contentIterator = ImmutableList.of(activeContent, inactiveContent).iterator();
+        Iterator<Content> contentIterator = ImmutableList.of(activeContent, inactiveContent, emptyContainer).iterator();
 
         ContentListingCriteria criteria = ContentListingCriteria.defaultCriteria()
                 .forContent(contentCategories)

--- a/src/test/java/org/atlasapi/system/PaContentDeactivatorTest.java
+++ b/src/test/java/org/atlasapi/system/PaContentDeactivatorTest.java
@@ -53,6 +53,7 @@ public class PaContentDeactivatorTest {
         inactiveContent.setGenericDescription(false);
 
         emptyContainer = new Brand("30", "30", Publisher.PA);
+        emptyContainer.setId(30l);
         setupMocks(activeContent, inactiveContent, emptyContainer);
     }
 


### PR DESCRIPTION
Updated:

Nitro extractor to use Contributions instead of People.
the logic for the VersionTypes to use Types from Glycerine model.
the GlycerineNitroContentAdapter to make use of Contributions instead of People.
using Images.Image from the Glycerine.