### PR TITLE
Set partition key for equivalence assertion messages

### DIFF
--- a/src/main/java/org/atlasapi/equiv/handlers/MessageQueueingResultHandler.java
+++ b/src/main/java/org/atlasapi/equiv/handlers/MessageQueueingResultHandler.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.math.BigInteger;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 import org.atlasapi.equiv.results.EquivalenceResult;
@@ -57,7 +56,7 @@ public class MessageQueueingResultHandler<T extends Content>
             for (AdjacentRef adjacentRef : message.getAdjacent()) {
                 log.trace("Subject: {} Adjacent: {}", result.subject().getCanonicalUri(), adjacentRef.toString());
             }
-            sender.sendMessage(message);
+            sender.sendMessage(message, message.getEntityId().getBytes());
         } catch (Exception e) {
             log.error("Failed to send equiv update message: " + result.subject(), e);
         }

--- a/src/test/java/org/atlasapi/equiv/handlers/MessageQueueingResultHandlerTest.java
+++ b/src/test/java/org/atlasapi/equiv/handlers/MessageQueueingResultHandlerTest.java
@@ -11,10 +11,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import kafka.admin.AdminUtils;
-import kafka.utils.TestUtils;
-import kafka.zk.EmbeddedZookeeper;
-
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.atlasapi.equiv.results.EquivalenceResult;
@@ -34,9 +30,6 @@ import org.atlasapi.messaging.v3.MessagingModule;
 import org.junit.Before;
 import org.junit.Test;
 
-import scala.Option;
-import scala.collection.JavaConversions;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -46,6 +39,12 @@ import com.metabroadcast.common.queue.MessageSerializer;
 import com.metabroadcast.common.queue.Worker;
 import com.metabroadcast.common.queue.kafka.KafkaConsumer;
 import com.metabroadcast.common.queue.kafka.KafkaTestBase;
+
+import kafka.admin.AdminUtils;
+import kafka.utils.TestUtils;
+import kafka.zk.EmbeddedZookeeper;
+import scala.Option;
+import scala.collection.JavaConversions;
 
 public class MessageQueueingResultHandlerTest extends KafkaTestBase {
 
@@ -106,7 +105,7 @@ public class MessageQueueingResultHandlerTest extends KafkaTestBase {
                 .build();
         consumer.startAsync().awaitRunning(10, TimeUnit.SECONDS);
 
-        handler.handle(new EquivalenceResult<Item>(subject, scores, combined, strong, desc));
+        handler.handle(new EquivalenceResult<>(subject, scores, combined, strong, desc));
         assertTrue("message not received", latch.await(5, TimeUnit.SECONDS));
         
         ContentEquivalenceAssertionMessage assertionMessage = message.get();

--- a/src/test/java/org/atlasapi/remotesite/pa/PaBaseProgrammeUpdaterTest.java
+++ b/src/test/java/org/atlasapi/remotesite/pa/PaBaseProgrammeUpdaterTest.java
@@ -7,14 +7,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.TestCase;
-
 import org.atlasapi.media.channel.Channel;
 import org.atlasapi.media.channel.ChannelQuery;
 import org.atlasapi.media.channel.ChannelResolver;
 import org.atlasapi.media.entity.Brand;
 import org.atlasapi.media.entity.Broadcast;
-import org.atlasapi.media.entity.Described;
 import org.atlasapi.media.entity.Identified;
 import org.atlasapi.media.entity.Image;
 import org.atlasapi.media.entity.ImageType;
@@ -70,6 +67,8 @@ import com.metabroadcast.common.time.DateTimeZones;
 import com.metabroadcast.common.time.TimeMachine;
 import com.mongodb.ReadPreference;
 
+import junit.framework.TestCase;
+
 @RunWith(JMock.class)
 public class PaBaseProgrammeUpdaterTest extends TestCase {
 
@@ -89,16 +88,18 @@ public class PaBaseProgrammeUpdaterTest extends TestCase {
     
 	private ChannelResolver channelResolver;
 	private ContentBuffer contentBuffer;
-	private MessageSender<ScheduleUpdateMessage> ms
-	    = new MessageSender<ScheduleUpdateMessage>(){
+	private MessageSender<ScheduleUpdateMessage> ms = new MessageSender<ScheduleUpdateMessage>(){
 
-            @Override
-            public void close() throws Exception {
-            }
+        @Override
+        public void close() throws Exception { }
 
-            @Override
-            public void sendMessage(ScheduleUpdateMessage message) throws MessagingException {
-            }};
+        @Override
+        public void sendMessage(ScheduleUpdateMessage message) throws MessagingException { }
+
+        @Override
+        public void sendMessage(ScheduleUpdateMessage scheduleUpdateMessage, byte[] bytes)
+                throws MessagingException { }
+    };
 
     @Override
     @Before
@@ -127,12 +128,12 @@ public class PaBaseProgrammeUpdaterTest extends TestCase {
                 will(returnValue(Optional.<Long>absent()));
             oneOf(scheduleVersionStore).store(channel, scheduleDay, 1);
             oneOf(scheduleVersionStore).get(channel, scheduleDay);
-                will(returnValue(Optional.<Long>of(1L)));
+                will(returnValue(Optional.of(1L)));
             oneOf(scheduleVersionStore).store(channel, scheduleDay, 201202251115L);
             oneOf(scheduleVersionStore).get(channel, scheduleDay);
-                will(returnValue(Optional.<Long>of(201202251115L)));
+                will(returnValue(Optional.of(201202251115L)));
             oneOf(scheduleVersionStore).get(channel, scheduleDay);
-                will(returnValue(Optional.<Long>of(201202251115L)));
+                will(returnValue(Optional.of(201202251115L)));
         }});
 
         TestPaProgrammeUpdater updater = new TestPaProgrammeUpdater(programmeProcessor, channelResolver, log, scheduleWriter, ImmutableList.of(


### PR DESCRIPTION
- Equivalence assertion messages are not idempotent so we need to
guarantee message ordering by ensuring messages about the same
resource are on the same partition