### PR TITLE
Copy topics from variants of VoD items

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodItemExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodItemExtractor.java
@@ -23,18 +23,22 @@ import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.media.entity.Series;
 import org.atlasapi.media.entity.Song;
 import org.atlasapi.media.entity.Specialization;
+import org.atlasapi.media.entity.TopicRef;
 import org.atlasapi.media.entity.Version;
 import org.atlasapi.remotesite.btvod.model.BtVodEntry;
 import org.atlasapi.remotesite.btvod.model.BtVodProductRating;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Function;
 import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.google.common.primitives.Ints;
 import com.metabroadcast.common.intl.Countries;
 import com.metabroadcast.common.scheduling.UpdateProgress;
@@ -180,8 +184,40 @@ public class BtVodItemExtractor implements BtVodDataProcessor<UpdateProgress> {
 
         item.addClips(extractTrailer(row));
         item.addAliases(describedFieldsExtractor.aliasesFrom(row));
+        
+        addMissingTopicRefs(item, row);
+    }
+    
+    private void addMissingTopicRefs(final Item item, BtVodEntry row) {
+        final Set<Long> existingTopicIds = topicIdsOfReferencedTopics(item);
+        
+        VodEntryAndContent vodEntryAndContent = new VodEntryAndContent(row, item);
+        Iterable<TopicRef> additionalTopicRefs = Iterables.filter(describedFieldsExtractor.topicsFrom(vodEntryAndContent),
+                new Predicate<TopicRef>() {
+
+                    @Override
+                    public boolean apply(final TopicRef newTopic) {
+                        return !existingTopicIds.contains(newTopic.getTopic());
+                    }
+                }
+        );
+        
+        item.addTopicRefs(additionalTopicRefs);
     }
 
+    private Set<Long> topicIdsOfReferencedTopics(final Item item) {
+        return Sets.newHashSet(
+                Iterables.transform(item.getTopicRefs(), 
+                                    new Function<TopicRef, Long>() {
+
+                                        @Override
+                                        public Long apply(TopicRef input) {
+                                            return input.getTopic();
+                                        }
+                                    })
+                              );
+    }
+    
     private String itemKeyForDeduping(BtVodEntry row) {
         ParentRef brandRef = getBrandRefOrNull(row);
         String brandUri = brandRef != null ? brandRef.getUri() : "";

--- a/src/test/java/org/atlasapi/remotesite/btvod/BtVodItemExtractorTest.java
+++ b/src/test/java/org/atlasapi/remotesite/btvod/BtVodItemExtractorTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anySet;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
+import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -45,6 +46,7 @@ import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.mockito.ArgumentMatcher;
 import org.mockito.Matchers;
 
 import com.google.common.base.Optional;
@@ -85,6 +87,7 @@ public class BtVodItemExtractorTest {
     private final TopicCreatingTopicResolver topicResolver = mock(TopicCreatingTopicResolver.class);
     private final TopicWriter topicWriter = mock(TopicWriter.class);
     private final BtVodContentMatchingPredicate newTopicContentMatchingPredicate = mock(BtVodContentMatchingPredicate.class);
+    private final BtVodContentMatchingPredicate kidsTopicPredicate = mock(BtVodContentMatchingPredicate.class);
     private final DedupedDescriptionAndImageUpdater descriptionAndImageUpdater =
             mock(DedupedDescriptionAndImageUpdater.class);
 
@@ -121,7 +124,7 @@ public class BtVodItemExtractorTest {
                         topicWriter,
                         Publisher.BT_VOD,
                         newTopicContentMatchingPredicate,
-                        BtVodContentMatchingPredicates.schedulerChannelPredicate("Kids"),
+                        kidsTopicPredicate,
                         BtVodContentMatchingPredicates.schedulerChannelAndOfferingTypePredicate(
                                 "TV", ImmutableSet.of("Season", "Season-EST")
                         ),
@@ -262,6 +265,36 @@ public class BtVodItemExtractorTest {
 
         assertThat(writtenItem.getVersions().size(), is(2));
         assertThat(writtenItem.getClips().size(), is(2));
+    }
+    
+    @Test
+    public void testMergesAndDedupesTopicsAcrossVariants() {
+        BtVodEntry btVodEntrySD = episodeRow(FULL_EPISODE_TITLE, PRODUCT_GUID);
+        ParentRef parentRef = new ParentRef(BRAND_URI);
+        Series series = new Series();
+        series.setCanonicalUri("seriesUri");
+        series.withSeriesNumber(1);
+
+
+        BtVodEntry btVodEntryHD = episodeRow(FULL_EPISODE_TITLE, PRODUCT_GUID);
+        btVodEntryHD.setTitle(FULL_EPISODE_TITLE + " - HD");
+        btVodEntryHD.setGuid(PRODUCT_GUID + "_HD");
+
+        when(seriesProvider.seriesFor(btVodEntrySD)).thenReturn(Optional.of(series));
+        when(seriesProvider.seriesFor(btVodEntryHD)).thenReturn(Optional.of(series));
+
+        when(imageExtractor.imagesFor(Matchers.<BtVodEntry>any())).thenReturn(ImmutableSet.<Image>of());
+        when(btVodBrandProvider.brandRefFor(btVodEntrySD)).thenReturn(Optional.of(parentRef));
+        when(btVodBrandProvider.brandRefFor(btVodEntryHD)).thenReturn(Optional.of(parentRef));
+        when(newTopicContentMatchingPredicate.apply(isA(VodEntryAndContent.class))).thenReturn(true);
+        when(kidsTopicPredicate.apply(argThat(new VodEntryHasGuid(btVodEntryHD.getGuid())))).thenReturn(true);
+
+        itemExtractor.process(btVodEntrySD);
+        itemExtractor.process(btVodEntryHD);
+
+        Item writtenItem = Iterables.getOnlyElement(itemExtractor.getProcessedItems().values());
+
+        assertThat(writtenItem.getTopicRefs().size(), is(2));
     }
 
     @Test
@@ -601,5 +634,24 @@ public class BtVodItemExtractorTest {
         verify(descriptionAndImageUpdater).updateDescriptionsAndImages(
                 eq(item), eq(btVodEntryHD), eq(ImmutableSet.of(hdImage)), anySet()
         );
+    }
+    
+    private static class VodEntryHasGuid extends ArgumentMatcher<VodEntryAndContent> {
+
+        private final String guid;
+        
+        public VodEntryHasGuid(String guid) {
+            this.guid = guid;
+        }
+        
+        @Override
+        public boolean matches(Object argument) {
+            if (!(argument instanceof VodEntryAndContent)) {
+                return false;
+            }
+            VodEntryAndContent vodEntryAndContent = (VodEntryAndContent) argument;
+            
+            return guid.equals(vodEntryAndContent.getBtVodEntry().getGuid());
+        }
     }
 }


### PR DESCRIPTION
Only the merge victim's topics are currently stored; this change
ensure that topics across all variants of an item are stored.