### PR TITLE
Downweigh sequence scoring for BT VOD

### DIFF
--- a/src/main/java/org/atlasapi/equiv/EquivModule.java
+++ b/src/main/java/org/atlasapi/equiv/EquivModule.java
@@ -287,7 +287,7 @@ public class EquivModule {
         ));
         
         EquivalenceUpdater<Item> standardItemUpdater = standardItemUpdater(MoreSets.add(acceptablePublishers, LOVEFILM), 
-                ImmutableSet.of(new TitleMatchingItemScorer(), new SequenceItemScorer())).build();
+                ImmutableSet.of(new TitleMatchingItemScorer(), new SequenceItemScorer(Score.ONE))).build();
         EquivalenceUpdater<Container> topLevelContainerUpdater = topLevelContainerUpdater(MoreSets.add(acceptablePublishers, LOVEFILM));
 
         Set<Publisher> nonStandardPublishers = ImmutableSet.copyOf(Sets.union(
@@ -494,7 +494,7 @@ public class EquivModule {
                         ))
                         .withScorers(ImmutableSet.of(
                             new TitleMatchingItemScorer(),
-                            new SequenceItemScorer()
+                            new SequenceItemScorer(Score.ONE)
                         ))
                         .withCombiner(new RequiredScoreFilteringCombiner<Item>(
                             new NullScoreAwareAveragingCombiner<Item>(),
@@ -585,7 +585,7 @@ public class EquivModule {
             ))
             .withScorers(ImmutableSet.of(
                 new TitleMatchingItemScorer(),
-                new SequenceItemScorer()
+                new SequenceItemScorer(Score.ONE)
             ))
             .withCombiner(new RequiredScoreFilteringCombiner<Item>(
                 new NullScoreAwareAveragingCombiner<Item>(),
@@ -612,14 +612,17 @@ public class EquivModule {
             ))
             .withScorers(ImmutableSet.of(
                 new TitleMatchingItemScorer(),
-                new SequenceItemScorer()
+                // Hierarchies are known to be inconsistent between the BT VoD
+                // catalogue and others, so we want to ascribe less weight 
+                // to sequence scoring
+                new SequenceItemScorer(Score.valueOf(0.5))
             ))
             .withCombiner(new RequiredScoreFilteringCombiner<Item>(
                 new NullScoreAwareAveragingCombiner<Item>(),
                 ImmutableSet.of(TitleMatchingItemScorer.NAME, SequenceItemScorer.SEQUENCE_SCORER)
             ))
             .withFilter(this.<Item>standardFilter())
-            .withExtractor(PercentThresholdEquivalenceExtractor.<Item> moreThanPercent(90))
+            .withExtractor(PercentThresholdEquivalenceExtractor.<Item> moreThanPercent(70))
             .withHandler(new BroadcastingEquivalenceResultHandler<Item>(ImmutableList.of(
                 EpisodeFilteringEquivalenceResultHandler.strict(
                     new LookupWritingEquivalenceHandler<Item>(lookupWriter, acceptablePublishers),
@@ -651,7 +654,7 @@ public class EquivModule {
             Predicate<? super Broadcast> filter) {
         return standardItemUpdater(sources, ImmutableSet.of(
             new TitleMatchingItemScorer(), 
-            new SequenceItemScorer(),
+            new SequenceItemScorer(Score.ONE),
             new TitleSubsetBroadcastItemScorer(contentResolver, titleMismatch, 80/*percent*/),
             new BroadcastAliasScorer(Score.nullScore())
         ), filter).build();

--- a/src/main/java/org/atlasapi/equiv/scorers/SequenceItemScorer.java
+++ b/src/main/java/org/atlasapi/equiv/scorers/SequenceItemScorer.java
@@ -1,5 +1,7 @@
 package org.atlasapi.equiv.scorers;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.Set;
 
 import org.atlasapi.equiv.results.description.ResultDescription;
@@ -16,7 +18,13 @@ import com.google.common.collect.Iterables;
 public class SequenceItemScorer implements EquivalenceScorer<Item> {
 
     public static final String SEQUENCE_SCORER = "Sequence";
+    
+    private final Score matchingScore;
 
+    public SequenceItemScorer(Score matchingScore) {
+        this.matchingScore = checkNotNull(matchingScore);
+    }
+    
     @Override
     public ScoredCandidates<Item> score(Item subject, Set<? extends Item> candidates, ResultDescription desc) {
         Builder<Item> equivalents = DefaultScoredCandidates.fromSource(SEQUENCE_SCORER);
@@ -63,7 +71,7 @@ public class SequenceItemScorer implements EquivalenceScorer<Item> {
         Score score;
         if (nullableSeriesNumbersEqual(subject, candidateEpisode)
             && nonNullEpisodeNumbersEqual(subject, candidateEpisode)) {
-            score = Score.ONE;
+            score = matchingScore;
         } else {
             score = Score.NULL_SCORE;
         }

--- a/src/test/java/org/atlasapi/equiv/scorers/SequenceItemScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/scorers/SequenceItemScorerTest.java
@@ -8,6 +8,7 @@ import java.util.Set;
 
 import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.description.ResultDescription;
+import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
 import org.atlasapi.media.entity.Episode;
 import org.atlasapi.media.entity.Item;
@@ -19,7 +20,7 @@ import com.google.common.collect.ImmutableSet;
 
 public class SequenceItemScorerTest {
 
-    private final SequenceItemScorer scorer = new SequenceItemScorer();
+    private final SequenceItemScorer scorer = new SequenceItemScorer(Score.ONE);
     private final ResultDescription desc = new DefaultDescription();
 
     @Test


### PR DESCRIPTION
Hierarchies are known to mismatch between BT and PA,
so we'll ascribe less value to them.