### PR TITLE
Only take into account next best candidate

### DIFF
--- a/src/main/java/org/atlasapi/equiv/EquivModule.java
+++ b/src/main/java/org/atlasapi/equiv/EquivModule.java
@@ -69,6 +69,7 @@ import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
 import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
 import org.atlasapi.equiv.results.combining.RequiredScoreFilteringCombiner;
 import org.atlasapi.equiv.results.extractors.MusicEquivalenceExtractor;
+import org.atlasapi.equiv.results.extractors.PercentThresholdAboveNextBestMatchEquivalenceExtractor;
 import org.atlasapi.equiv.results.extractors.PercentThresholdEquivalenceExtractor;
 import org.atlasapi.equiv.results.filters.AlwaysTrueFilter;
 import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
@@ -572,7 +573,7 @@ public class EquivModule {
                         TitleMatchingContainerScorer.NAME)
                 )
                 .withFilter(this.<Container>standardFilter())
-                .withExtractor(PercentThresholdEquivalenceExtractor.<Container> moreThanPercent(50))
+                .withExtractor(PercentThresholdAboveNextBestMatchEquivalenceExtractor.<Container> atLeastNTimesGreater(2))
                 .withHandler(containerResultHandlers(acceptablePublishers))
                 .build();
     }
@@ -622,7 +623,7 @@ public class EquivModule {
                 ImmutableSet.of(TitleMatchingItemScorer.NAME, SequenceItemScorer.SEQUENCE_SCORER)
             ))
             .withFilter(this.<Item>standardFilter())
-            .withExtractor(PercentThresholdEquivalenceExtractor.<Item> moreThanPercent(50))
+            .withExtractor(PercentThresholdAboveNextBestMatchEquivalenceExtractor.<Item> atLeastNTimesGreater(2))
             .withHandler(new BroadcastingEquivalenceResultHandler<Item>(ImmutableList.of(
                 EpisodeFilteringEquivalenceResultHandler.strict(
                     new LookupWritingEquivalenceHandler<Item>(lookupWriter, acceptablePublishers),

--- a/src/main/java/org/atlasapi/equiv/results/extractors/PercentThresholdAboveNextBestMatchEquivalenceExtractor.java
+++ b/src/main/java/org/atlasapi/equiv/results/extractors/PercentThresholdAboveNextBestMatchEquivalenceExtractor.java
@@ -1,0 +1,67 @@
+package org.atlasapi.equiv.results.extractors;
+
+import java.util.List;
+
+import org.atlasapi.equiv.results.description.ResultDescription;
+import org.atlasapi.equiv.results.scores.ScoredCandidate;
+
+import com.google.common.base.Optional;
+
+/**
+ * Selects the equivalence with the highest score, so long as its score
+ * is more than threshold times larger than the next highest-scoring
+ * candidate.
+ */
+public class PercentThresholdAboveNextBestMatchEquivalenceExtractor<T> implements EquivalenceExtractor<T> {
+
+    private static final String NAME = "Percent Above Next Best Match Extractor";
+    private final double threshold;
+
+    public static <T> PercentThresholdAboveNextBestMatchEquivalenceExtractor<T> atLeastNTimesGreater(double threshold) {
+        return new PercentThresholdAboveNextBestMatchEquivalenceExtractor<T>(threshold);
+    }
+
+    private PercentThresholdAboveNextBestMatchEquivalenceExtractor(double threshold) {
+        this.threshold = threshold;
+    }
+    
+    @Override
+    public Optional<ScoredCandidate<T>> extract(List<ScoredCandidate<T>> candidates, T subject,
+            ResultDescription desc) {
+        desc.startStage(NAME);
+        
+        if (candidates.isEmpty()) {
+            desc.appendText("no equivalents").finishStage();
+            return Optional.absent();
+        }
+        
+        if (candidates.size() == 1) {
+            return Optional.of(candidates.get(0));
+        }
+        
+        ScoredCandidate<T> strongest = candidates.get(0);
+        ScoredCandidate<T> nextBest = candidates.get(1);
+        
+        if (!strongest.score().isRealScore()) {
+            desc.appendText("%s not extracted. Not a real score.", strongest.candidate());
+            return Optional.absent();
+        }
+        
+        if (!nextBest.score().isRealScore()) {
+            desc.appendText("%s extracted; next best score is not real", strongest.candidate());
+            return Optional.of(strongest);
+        }
+        
+        if ( (strongest.score().asDouble() / nextBest.score().asDouble()) >= threshold) {
+            desc.appendText("%s extracted. Strongest score of %s wins over next best from %s of %s.", strongest.candidate(), strongest.score(), 
+                    nextBest.candidate(), nextBest.score());
+            return Optional.of(strongest);
+        }
+        
+        desc.appendText("%s not extracted. Strongest score of %s doesn't beat next best from %s of %s.", strongest.candidate(), strongest.score(), 
+                    nextBest.candidate(), nextBest.score());
+        
+        return Optional.absent();
+    }
+
+}

--- a/src/test/java/org/atlasapi/equiv/results/extractors/PercentThresholdAboveNextBestMatchEquivalenceExtractorTest.java
+++ b/src/test/java/org/atlasapi/equiv/results/extractors/PercentThresholdAboveNextBestMatchEquivalenceExtractorTest.java
@@ -1,0 +1,61 @@
+package org.atlasapi.equiv.results.extractors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.atlasapi.equiv.results.description.DefaultDescription;
+import org.atlasapi.equiv.results.scores.Score;
+import org.atlasapi.equiv.results.scores.ScoredCandidate;
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Publisher;
+import org.junit.Test;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+
+
+public class PercentThresholdAboveNextBestMatchEquivalenceExtractorTest {
+
+    @Test
+    public void testExtractsWhenStrongBeatsNextBestByThreshold() {
+
+        PercentThresholdAboveNextBestMatchEquivalenceExtractor<Item> extractor = new PercentThresholdAboveNextBestMatchEquivalenceExtractor<Item>(2.0);
+        
+        ScoredCandidate<Item> strong = ScoredCandidate.valueOf(new Item("test1","cur1",Publisher.BBC), Score.valueOf(1.0));
+        Optional<ScoredCandidate<Item>> extract = extractor.extract(ImmutableList.<ScoredCandidate<Item>>of(
+                strong,
+                ScoredCandidate.valueOf(new Item("test2","cur2",Publisher.BBC), Score.valueOf(0.5))
+        ), null, new DefaultDescription());
+        
+        assertTrue("Strong extracted", extract.isPresent());
+        assertEquals(extract.get(), strong);
+        
+    } 
+    
+    @Test
+    public void testDoesntExtractWhenStrongBeatsNextBestByThreshold() {
+
+        PercentThresholdAboveNextBestMatchEquivalenceExtractor<Item> extractor = new PercentThresholdAboveNextBestMatchEquivalenceExtractor<Item>(2.0);
+        
+        ScoredCandidate<Item> strong = ScoredCandidate.valueOf(new Item("test1","cur1",Publisher.BBC), Score.valueOf(1.0));
+        Optional<ScoredCandidate<Item>> extract = extractor.extract(ImmutableList.<ScoredCandidate<Item>>of(
+                strong,
+                ScoredCandidate.valueOf(new Item("test2","cur2",Publisher.BBC), Score.valueOf(0.6))
+        ), null, new DefaultDescription());
+        
+        assertFalse("Strong should not be extracted", extract.isPresent());
+    } 
+    
+    @Test
+    public void testExtractsWhenOnlyOneCandidate() {
+
+        PercentThresholdAboveNextBestMatchEquivalenceExtractor<Item> extractor = new PercentThresholdAboveNextBestMatchEquivalenceExtractor<Item>(2.0);
+        
+        ScoredCandidate<Item> strong = ScoredCandidate.valueOf(new Item("test1","cur1",Publisher.BBC), Score.valueOf(1.0));
+        Optional<ScoredCandidate<Item>> extract = extractor.extract(ImmutableList.<ScoredCandidate<Item>>of(strong), null, new DefaultDescription());
+        
+        assertTrue("Strong extracted", extract.isPresent());
+        assertEquals(extract.get(), strong);
+    } 
+}


### PR DESCRIPTION
Previously, we took the sum of all candidates with a threshold
for the strongest candidate to beat based on that. However,
with many candidates this strategy falls down. Instead, we'll
look at the second strongest candidate and ensure the
strongest candidate is at least n times greater than it.

We're only including this as part of BT VOD equivalence
in the first instance, but may roll out more widely if it
proves a good general strategy.