### PR TITLE
Require exact title match on vod content brands

### DIFF
--- a/src/main/java/org/atlasapi/equiv/EquivModule.java
+++ b/src/main/java/org/atlasapi/equiv/EquivModule.java
@@ -89,6 +89,7 @@ import org.atlasapi.equiv.results.filters.SpecializationFilter;
 import org.atlasapi.equiv.results.persistence.FileEquivalenceResultStore;
 import org.atlasapi.equiv.results.persistence.RecentEquivalenceResultStore;
 import org.atlasapi.equiv.results.scores.Score;
+import org.atlasapi.equiv.results.scores.ScoreThreshold;
 import org.atlasapi.equiv.scorers.BroadcastAliasScorer;
 import org.atlasapi.equiv.scorers.ContainerHierarchyMatchingScorer;
 import org.atlasapi.equiv.scorers.CrewMemberScorer;
@@ -144,6 +145,7 @@ import com.metabroadcast.common.time.DateTimeZones;
 @Import({KafkaMessagingModule.class})
 public class EquivModule {
 
+    private static double DEFAULT_EXACT_TITLE_MATCH_SCORE = 2;
 	private @Value("${equiv.results.directory}") String equivResultsDirectory;
 	private @Value("${messaging.destination.equiv.assert}") String equivAssertDest;
 	private @Value("${equiv.excludedUris}") String excludedUris;
@@ -252,7 +254,7 @@ public class EquivModule {
     private EquivalenceUpdater<Container> topLevelContainerUpdater(Set<Publisher> publishers) {
         return ContentEquivalenceUpdater.<Container> builder()
             .withGenerators(ImmutableSet.of(
-                TitleSearchGenerator.create(searchResolver, Container.class, publishers),
+                TitleSearchGenerator.create(searchResolver, Container.class, publishers, DEFAULT_EXACT_TITLE_MATCH_SCORE),
                 ScalingEquivalenceGenerator.scale(
                     new ContainerChildEquivalenceGenerator(contentResolver, equivSummaryStore),
                     20)
@@ -441,7 +443,7 @@ public class EquivModule {
         Set<Publisher> itunesAndMusicPublishers = Sets.union(musicPublishers, ImmutableSet.of(ITUNES));
         ContentEquivalenceUpdater<Item> muiscPublisherUpdater = ContentEquivalenceUpdater.<Item>builder()
             .withGenerator(
-                new TitleSearchGenerator<Item>(searchResolver, Song.class, itunesAndMusicPublishers, new SongTitleTransform(), 100)
+                new TitleSearchGenerator<Item>(searchResolver, Song.class, itunesAndMusicPublishers, new SongTitleTransform(), 100, DEFAULT_EXACT_TITLE_MATCH_SCORE)
             ).withScorer(new CrewMemberScorer(new SongCrewMemberExtractor()))
             .withCombiner(new NullScoreAwareAveragingCombiner<Item>())
             .withFilter(AlwaysTrueFilter.<Item>get())
@@ -538,7 +540,7 @@ public class EquivModule {
     private EquivalenceUpdater<Container> facebookContainerEquivalenceUpdater(Set<Publisher> facebookAcceptablePublishers) {
         return ContentEquivalenceUpdater.<Container> builder()
             .withGenerators(ImmutableSet.of(
-                    TitleSearchGenerator.create(searchResolver, Container.class, facebookAcceptablePublishers),
+                    TitleSearchGenerator.create(searchResolver, Container.class, facebookAcceptablePublishers, DEFAULT_EXACT_TITLE_MATCH_SCORE),
                     aliasResolvingGenerator(contentResolver, Container.class)
             ))
             .withScorers(ImmutableSet.<EquivalenceScorer<Container>> of())
@@ -554,7 +556,7 @@ public class EquivModule {
 
     private EquivalenceUpdater<Container> vodContainerUpdater(Set<Publisher> acceptablePublishers) {
         return ContentEquivalenceUpdater.<Container> builder()
-            .withGenerator(TitleSearchGenerator.create(searchResolver, Container.class, acceptablePublishers)
+            .withGenerator(TitleSearchGenerator.create(searchResolver, Container.class, acceptablePublishers, DEFAULT_EXACT_TITLE_MATCH_SCORE)
             )
             .withScorers(ImmutableSet.of(
                 new TitleMatchingContainerScorer(),
@@ -566,7 +568,8 @@ public class EquivModule {
             ))
             .withCombiner(new RequiredScoreFilteringCombiner<Container>(
                 new NullScoreAwareAveragingCombiner<Container>(),
-                TitleMatchingContainerScorer.NAME)
+                TitleMatchingContainerScorer.NAME,
+                ScoreThreshold.greaterThanOrEqual(DEFAULT_EXACT_TITLE_MATCH_SCORE))
             )
             .withFilter(this.<Container>standardFilter())
             .withExtractor(PercentThresholdEquivalenceExtractor.<Container> moreThanPercent(90))
@@ -576,7 +579,7 @@ public class EquivModule {
 
     private EquivalenceUpdater<Container> btTveVodContainerUpdater(Set<Publisher> acceptablePublishers) {
         return ContentEquivalenceUpdater.<Container> builder()
-                .withGenerator(TitleSearchGenerator.create(searchResolver, Container.class, acceptablePublishers)
+                .withGenerator(TitleSearchGenerator.create(searchResolver, Container.class, acceptablePublishers, DEFAULT_EXACT_TITLE_MATCH_SCORE)
                 )
                 .withScorers(ImmutableSet.of(
                         new TitleMatchingContainerScorer(),
@@ -655,7 +658,7 @@ public class EquivModule {
     private EquivalenceUpdater<Container> broadcastItemContainerEquivalenceUpdater(Set<Publisher> sources) {
         return ContentEquivalenceUpdater.<Container> builder()
             .withGenerators(ImmutableSet.of(
-                TitleSearchGenerator.create(searchResolver, Container.class, sources),
+                TitleSearchGenerator.create(searchResolver, Container.class, sources, DEFAULT_EXACT_TITLE_MATCH_SCORE),
                 new ContainerChildEquivalenceGenerator(contentResolver, equivSummaryStore)
             ))
             .withScorers(ImmutableSet.of(new TitleMatchingContainerScorer()))

--- a/src/main/java/org/atlasapi/equiv/generators/ContentTitleScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/ContentTitleScorer.java
@@ -13,13 +13,14 @@ import com.google.common.base.Function;
 
 public final class ContentTitleScorer<T extends Content> {
     
-    private static final double EXACT_MATCH_SCORE = 2;
     private final Function<String, String> titleTransform;
     private final String name;
+    private final double exactMatchScore;
 
-    public ContentTitleScorer(String name, Function<String, String> titleTransform) {
+    public ContentTitleScorer(String name, Function<String, String> titleTransform, double exactMatchScore) {
         this.name = name;
         this.titleTransform = titleTransform;
+        this.exactMatchScore = exactMatchScore;
     }
 
     public ScoredCandidates<T> scoreCandidates(T content, Iterable<? extends T> candidates, ResultDescription desc) {
@@ -72,7 +73,7 @@ public final class ContentTitleScorer<T extends Content> {
         int commonPrefix = commonPrefixLength(shorter, longer);
         int difference = longer.length() - commonPrefix;
         if (difference == 0) {
-            return EXACT_MATCH_SCORE;
+            return exactMatchScore;
         }
         return 1.0 / (Math.exp(Math.pow(difference, 2)) + 8*difference);
     }

--- a/src/main/java/org/atlasapi/equiv/generators/TitleSearchGenerator.java
+++ b/src/main/java/org/atlasapi/equiv/generators/TitleSearchGenerator.java
@@ -31,8 +31,8 @@ public class TitleSearchGenerator<T extends Content> implements EquivalenceGener
     private final static float TITLE_WEIGHTING = 1.0f;
     public final static String NAME = "Title";
     
-    public static final <T extends Content> TitleSearchGenerator<T> create(SearchResolver searchResolver, Class<? extends T> cls, Iterable<Publisher> publishers) {
-        return new TitleSearchGenerator<T>(searchResolver, cls, publishers);
+    public static final <T extends Content> TitleSearchGenerator<T> create(SearchResolver searchResolver, Class<? extends T> cls, Iterable<Publisher> publishers, double exactMatchScore) {
+        return new TitleSearchGenerator<T>(searchResolver, cls, publishers, exactMatchScore);
     }
     
     private final SearchResolver searchResolver;
@@ -42,17 +42,18 @@ public class TitleSearchGenerator<T extends Content> implements EquivalenceGener
     private final ContentTitleScorer<T> titleScorer;
     private final int searchLimit;
 
-    public TitleSearchGenerator(SearchResolver searchResolver, Class<? extends T> cls, Iterable<Publisher> publishers) {
-        this(searchResolver, cls, publishers, Functions.<String>identity(), 20);
+    public TitleSearchGenerator(SearchResolver searchResolver, Class<? extends T> cls, Iterable<Publisher> publishers, double exactMatchScore) {
+        this(searchResolver, cls, publishers, Functions.<String>identity(), 20, exactMatchScore);
     }
     
-    public TitleSearchGenerator(SearchResolver searchResolver, Class<? extends T> cls, Iterable<Publisher> publishers, Function<String,String> titleTransform, int searchLimit) {
+    public TitleSearchGenerator(SearchResolver searchResolver, Class<? extends T> cls, Iterable<Publisher> publishers, Function<String,String> titleTransform, int searchLimit,
+            double exactMatchScore) {
         this.searchResolver = searchResolver;
         this.cls = cls;
         this.searchLimit = searchLimit;
         this.searchPublishers = ImmutableSet.copyOf(publishers);
         this.titleTransform = titleTransform;
-        this.titleScorer = new ContentTitleScorer<T>(NAME, titleTransform);
+        this.titleScorer = new ContentTitleScorer<T>(NAME, titleTransform, exactMatchScore);
     }
 
     @Override

--- a/src/test/java/org/atlasapi/equiv/generators/ContentTitleScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/generators/ContentTitleScorerTest.java
@@ -21,7 +21,8 @@ import com.google.common.base.Functions;
 
 public class ContentTitleScorerTest {
 
-    private final ContentTitleScorer<Container> scorer = new ContentTitleScorer<Container>("Title", Functions.<String>identity());
+    private static final double EXACT_MATCH_SCORE = 2;
+    private final ContentTitleScorer<Container> scorer = new ContentTitleScorer<Container>("Title", Functions.<String>identity(), EXACT_MATCH_SCORE);
 
     private final ResultDescription desc = new DefaultDescription();
 
@@ -32,7 +33,7 @@ public class ContentTitleScorerTest {
     @Test
     public void testScore() {
         scoreLt(0.01, score("biker", "nothing"));
-        score(2, score("biker", "biker"));
+        score(EXACT_MATCH_SCORE, score("biker", "biker"));
         scoreLt(0.1, score("biker", "bike"));
         scoreLt(0.1, score("biker", "bikers"));
     }
@@ -46,17 +47,17 @@ public class ContentTitleScorerTest {
     
     @Test
     public void testScoreWithAmpersands() {
-        score(2, score("Rosencrantz & Guildenstern Are Dead", "Rosencrantz and Guildenstern Are Dead"));
-        score(2, score("Bill & Ben", "Bill and Ben"));
+        score(EXACT_MATCH_SCORE, score("Rosencrantz & Guildenstern Are Dead", "Rosencrantz and Guildenstern Are Dead"));
+        score(EXACT_MATCH_SCORE, score("Bill & Ben", "Bill and Ben"));
     }
     
     @Test
     public void testScoreWithCommonPrefix() {
-        score(2, score("The Great Escape", "The Great Escape"));
+        score(EXACT_MATCH_SCORE, score("The Great Escape", "The Great Escape"));
         scoreLt(0.1, score("The Great Escape", "Italian Job"));
         
-        score(2, score("The Great Escape", "Great Escape"));
-        score(2, score("the Great Escape", "Great Escape"));
+        score(EXACT_MATCH_SCORE, score("The Great Escape", "Great Escape"));
+        score(EXACT_MATCH_SCORE, score("the Great Escape", "Great Escape"));
         scoreLt(0.1, score("Theatreland", "The atreland"));
         scoreLt(0.1, score("theatreland", "the atreland"));
     }

--- a/src/test/java/org/atlasapi/equiv/generators/TitleSearchGeneratorTest.java
+++ b/src/test/java/org/atlasapi/equiv/generators/TitleSearchGeneratorTest.java
@@ -43,7 +43,7 @@ public class TitleSearchGeneratorTest {
             }
         };
         
-        TitleSearchGenerator<Container> generator = TitleSearchGenerator.create(searchResolver, Container.class, Publisher.all());
+        TitleSearchGenerator<Container> generator = TitleSearchGenerator.create(searchResolver, Container.class, Publisher.all(), 2);
         ScoredCandidates<Container> generated = generator.generate(subject, new DefaultDescription());
         
         assertTrue(generated.candidates().keySet().size() == 1);


### PR DESCRIPTION
Where a dataset may be incomplete, we shouldn't fuzzy
match on titles, since there may not be a match to win
out against a partial title match.