### PR TITLE
Propagate CP tags up hierarchies

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodModule.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodModule.java
@@ -298,7 +298,9 @@ public class BtVodModule {
                         topicFor(btVodAppCategoryNamespaceFor(envName, conf), BT_VOD_TV_BOXSETS_TOPIC, publisher),
                         topicFor(btVodAppCategoryNamespaceFor(envName, conf), BT_VOD_CATCHUP_TOPIC, publisher)
                 ),
-                ImmutableSet.of(String.format(BT_VOD_KEYWORD_NAMESPACE_FORMAT, envName, conf)),
+                ImmutableSet.of(String.format(BT_VOD_KEYWORD_NAMESPACE_FORMAT, envName, conf),
+                                String.format(BT_VOD_CONTENT_PROVIDER_NAMESPACE_FORMAT, envName, conf)
+                               ),
                 seriesUriExtractor(uriPrefix),
                 versionsExtractor(uriPrefix, envName, conf),
                 describedFieldsExtractor(


### PR DESCRIPTION
A CP tag on an item or season needs to be present on a
brand so the item is navigable from a brand list.

Corrects a problem with AMC content, where some wasn't
being surfaced.