### PR TITLE
Containers must require a title score, not child score

### DIFF
--- a/src/main/java/org/atlasapi/equiv/EquivModule.java
+++ b/src/main/java/org/atlasapi/equiv/EquivModule.java
@@ -664,7 +664,7 @@ public class EquivModule {
             .withScorers(ImmutableSet.of(new TitleMatchingContainerScorer(DEFAULT_EXACT_TITLE_MATCH_SCORE)))
             .withCombiner(new RequiredScoreFilteringCombiner<Container>(
                 new NullScoreAwareAveragingCombiner<Container>(),
-                ContainerChildEquivalenceGenerator.NAME))
+                    TitleMatchingContainerScorer.NAME))
             .withFilter(this.<Container>standardFilter())
             .withExtractor(PercentThresholdEquivalenceExtractor.<Container> moreThanPercent(90))
             .withHandler(containerResultHandlers(sources))


### PR DESCRIPTION
BUGFIX: A container shouldn't require a child item
equivalence score to be matched; instead, they should
require a title score.

There may be no child matches, but if there is a title
match thay should suffice. In cases where there
is no schedule matching, requiring a child match before
a container match is allowed leads to a circular
dependency resulting in a failure to match ever.