### PR TITLE
Normalize spacing around back-to-back delimeters

### DIFF
--- a/src/main/java/org/atlasapi/equiv/scorers/TitleMatchingItemScorer.java
+++ b/src/main/java/org/atlasapi/equiv/scorers/TitleMatchingItemScorer.java
@@ -144,6 +144,7 @@ public class TitleMatchingItemScorer implements EquivalenceScorer<Item> {
     private String replaceSpecialChars(String title) {
         return title.replaceAll(" & ", " and ")
                     .replaceAll("fc ", "")
+                    .replaceAll("\\s?\\/\\s?", "-") // normalize spacing around back-to-back titles
                     .replaceAll("[^A-Za-z0-9\\s']+", "-")
                     .replace(" ", "-");
                     

--- a/src/test/java/org/atlasapi/equiv/scorers/TitleMatchingItemScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/scorers/TitleMatchingItemScorerTest.java
@@ -78,6 +78,14 @@ public class TitleMatchingItemScorerTest extends TestCase {
         score(0, scorer.score(itemWithTitle("B&Q"), of(itemWithTitle("BandQ")), desc));
 
     }
+
+    @Test
+    public void testNormalizeBackToBacksSpacing() {
+
+        DefaultDescription desc = new DefaultDescription();
+
+        score(2, scorer.score(itemWithTitle("Foo / Bar"), of(itemWithTitle("Foo/Bar")), desc));
+    }
     
     @Test
     public void testMatchingWithThePrefix() {


### PR DESCRIPTION
A '/' is used as a delimeter around back-to-back titles.
In some cases there are surrounding spaces, in others not.
These are now normalized, to not having spaces, to allow
a positive match.

An attempt was made to remove all spacing as part of this
change; however, abbreviations for sports teams makes use
of the position of spaces to allow abbrevations to match
full names, so spaces need to be considered to avoid
mis-matches.