### PR TITLE
Move to programme_formats from formats

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/ContentMerger.java
+++ b/src/main/java/org/atlasapi/remotesite/ContentMerger.java
@@ -96,6 +96,15 @@ public class ContentMerger {
             Film currentFilm = (Film) current;
             Film extractedFilm = (Film) extracted;
             currentFilm.setYear(extractedFilm.getYear());
+        } else (if current instanceof Item && extracted instanceof Film) {
+
+            // The type is switching from Item to Film; we must use the extracted
+            // Film as a basis of saving, but retain those fields that have been
+            // merged already onto current, according to the employed merge strategy
+            extracted.setVersions(current.getVersions());
+            extracted.setAliases(current.getAliases());
+            extracted.setTopicRefs(current.getTopicRefs());
+            current = extracted;
         }
         current.setReleaseDates(extracted.getReleaseDates());
         return current;

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroEpisodeExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroEpisodeExtractor.java
@@ -86,11 +86,11 @@ public final class NitroEpisodeExtractor extends BaseNitroItemExtractor<Episode,
     }
 
     private boolean isFilmFormat(Episode episode) {
-        if (episode.getFormats() == null) {
+        if (episode.getProgrammeFormats() == null) {
             return false;
         }
 
-        return Iterables.any(episode.getFormats().getFormat(), IS_FILM_FORMAT);
+        return Iterables.any(episode.getProgrammeFormats().getFormat(), IS_FILM_FORMAT);
     }
 
     private boolean isEpisode(Episode episode) {


### PR DESCRIPTION
The latter was deprecated and removed. We must also support switching from type Item to type Film, since there will be a number of Items becoming Films.