### PR TITLE
Added BT genre mapping to MB tags and storing them as TopicRefs.

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/btvod/AbstractBtVodSeriesExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/AbstractBtVodSeriesExtractor.java
@@ -92,7 +92,7 @@ public abstract class AbstractBtVodSeriesExtractor implements BtVodDataProcessor
     private void setFields(Series series, BtVodEntry row) {
         VodEntryAndContent vodEntryAndContent = new VodEntryAndContent(row, series);
         series.addTopicRefs(describedFieldsExtractor.topicsFrom(vodEntryAndContent));
-        series.addTopicRefs(btVodTagMap.map(series.getGenres()));
+        series.addTopicRefs(btVodTagMap.mapGenresToTopicRefs(series.getGenres()));
     }
 
     @Override

--- a/src/main/java/org/atlasapi/remotesite/btvod/AbstractBtVodSeriesExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/AbstractBtVodSeriesExtractor.java
@@ -1,20 +1,21 @@
 package org.atlasapi.remotesite.btvod;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.Map;
 import java.util.Set;
 
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.media.entity.Series;
 import org.atlasapi.remotesite.btvod.model.BtVodEntry;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import com.metabroadcast.common.scheduling.UpdateProgress;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
-import com.metabroadcast.common.scheduling.UpdateProgress;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public abstract class AbstractBtVodSeriesExtractor implements BtVodDataProcessor<UpdateProgress> {
 
@@ -27,6 +28,7 @@ public abstract class AbstractBtVodSeriesExtractor implements BtVodDataProcessor
     private final Set<String> processedRows;
     private final BtVodDescribedFieldsExtractor describedFieldsExtractor;
     private final BtVodSeriesUriExtractor seriesUriExtractor;
+    private final BtVodTagMap btVodTagMap;
 
     private UpdateProgress progress = UpdateProgress.START;
 
@@ -36,7 +38,8 @@ public abstract class AbstractBtVodSeriesExtractor implements BtVodDataProcessor
             BtVodContentListener listener,
             Set<String> processedRows,
             BtVodDescribedFieldsExtractor describedFieldsExtractor,
-            BtVodSeriesUriExtractor seriesUriExtractor
+            BtVodSeriesUriExtractor seriesUriExtractor,
+            BtVodTagMap btVodTagMap
     ) {
         this.processedRows = checkNotNull(processedRows);
         this.listener = checkNotNull(listener);
@@ -47,6 +50,7 @@ public abstract class AbstractBtVodSeriesExtractor implements BtVodDataProcessor
         //      Added as a collaborator for Alias extraction, but should be used more
         //      widely
         this.describedFieldsExtractor = checkNotNull(describedFieldsExtractor);
+        this.btVodTagMap = btVodTagMap;
     }
 
     @Override
@@ -88,6 +92,7 @@ public abstract class AbstractBtVodSeriesExtractor implements BtVodDataProcessor
     private void setFields(Series series, BtVodEntry row) {
         VodEntryAndContent vodEntryAndContent = new VodEntryAndContent(row, series);
         series.addTopicRefs(describedFieldsExtractor.topicsFrom(vodEntryAndContent));
+        series.addTopicRefs(btVodTagMap.map(series.getGenres()));
     }
 
     @Override

--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodBrandExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodBrandExtractor.java
@@ -40,19 +40,22 @@ public class BtVodBrandExtractor implements BtVodDataProcessor<UpdateProgress> {
     private final BtVodDescribedFieldsExtractor describedFieldExtractor;
     private final BrandUriExtractor brandUriExtractor;
     private UpdateProgress progress = UpdateProgress.START;
+    private final BtVodTagMap btVodTagMap;
 
     public BtVodBrandExtractor(
             Publisher publisher,
             BtVodContentListener listener,
             Set<String> processedRows,
             BtVodDescribedFieldsExtractor describedFieldExtractor,
-            BrandUriExtractor brandUriExtractor
+            BrandUriExtractor brandUriExtractor,
+            BtVodTagMap btVodTagMap
     ) {
         this.listener = checkNotNull(listener);
         this.publisher = checkNotNull(publisher);
         this.processedRows = checkNotNull(processedRows);
         this.brandUriExtractor = checkNotNull(brandUriExtractor);
         this.describedFieldExtractor = checkNotNull(describedFieldExtractor);
+        this.btVodTagMap = btVodTagMap;
     }
 
     @Override
@@ -124,6 +127,7 @@ public class BtVodBrandExtractor implements BtVodDataProcessor<UpdateProgress> {
 
         VodEntryAndContent vodEntryAndContent = new VodEntryAndContent(row, brand);
         brand.addTopicRefs(describedFieldExtractor.topicsFrom(vodEntryAndContent));
+        brand.addTopicRefs(btVodTagMap.map(brand.getGenres()));
         return brand;
     }
 

--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodBrandExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodBrandExtractor.java
@@ -127,7 +127,7 @@ public class BtVodBrandExtractor implements BtVodDataProcessor<UpdateProgress> {
 
         VodEntryAndContent vodEntryAndContent = new VodEntryAndContent(row, brand);
         brand.addTopicRefs(describedFieldExtractor.topicsFrom(vodEntryAndContent));
-        brand.addTopicRefs(btVodTagMap.map(brand.getGenres()));
+        brand.addTopicRefs(btVodTagMap.mapGenresToTopicRefs(brand.getGenres()));
         return brand;
     }
 

--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodExplicitSeriesExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodExplicitSeriesExtractor.java
@@ -1,7 +1,5 @@
 package org.atlasapi.remotesite.btvod;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.Map;
 import java.util.Set;
 
@@ -12,11 +10,14 @@ import org.atlasapi.media.entity.Version;
 import org.atlasapi.remotesite.btvod.model.BtVodEntry;
 import org.atlasapi.remotesite.btvod.model.BtVodProductRating;
 
+import com.metabroadcast.common.intl.Countries;
+
 import com.google.api.client.util.Maps;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
-import com.metabroadcast.common.intl.Countries;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class BtVodExplicitSeriesExtractor extends AbstractBtVodSeriesExtractor {
 
@@ -39,7 +40,8 @@ public class BtVodExplicitSeriesExtractor extends AbstractBtVodSeriesExtractor {
             BtVodVersionsExtractor versionsExtractor,
             TitleSanitiser titleSanitiser,
             ImageExtractor imageExtractor,
-            DedupedDescriptionAndImageUpdater descriptionAndImageUpdater
+            DedupedDescriptionAndImageUpdater descriptionAndImageUpdater,
+            BtVodTagMap btVodTagMap
     ) {
         super(
                 btVodBrandProvider, 
@@ -47,7 +49,8 @@ public class BtVodExplicitSeriesExtractor extends AbstractBtVodSeriesExtractor {
                 listener, 
                 processedRows, 
                 describedFieldsExtractor, 
-                seriesUriExtractor
+                seriesUriExtractor,
+                btVodTagMap
         );
         this.titleSanitiser = checkNotNull(titleSanitiser);
         this.versionsExtractor = checkNotNull(versionsExtractor);

--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodSynthesizedSeriesExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodSynthesizedSeriesExtractor.java
@@ -1,8 +1,5 @@
 package org.atlasapi.remotesite.btvod;
 
-import static org.atlasapi.remotesite.btvod.BtVodProductType.EPISODE;
-import static org.atlasapi.remotesite.btvod.BtVodProductType.HELP;
-
 import java.util.Map;
 import java.util.Set;
 
@@ -13,6 +10,9 @@ import org.atlasapi.remotesite.btvod.model.BtVodEntry;
 import com.google.api.client.util.Maps;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+
+import static org.atlasapi.remotesite.btvod.BtVodProductType.EPISODE;
+import static org.atlasapi.remotesite.btvod.BtVodProductType.HELP;
 
 
 public class BtVodSynthesizedSeriesExtractor extends AbstractBtVodSeriesExtractor {
@@ -30,7 +30,8 @@ public class BtVodSynthesizedSeriesExtractor extends AbstractBtVodSeriesExtracto
             BtVodDescribedFieldsExtractor describedFieldsExtractor,
             Set<String> processedRows,
             BtVodSeriesUriExtractor seriesUriExtractor,
-            Set<String> explicitSeriesIds
+            Set<String> explicitSeriesIds,
+            BtVodTagMap btVodTagMap
     ) {
         super(
                 btVodBrandProvider,
@@ -38,7 +39,8 @@ public class BtVodSynthesizedSeriesExtractor extends AbstractBtVodSeriesExtracto
                 listener,
                 processedRows,
                 describedFieldsExtractor,
-                seriesUriExtractor
+                seriesUriExtractor,
+                btVodTagMap
         );
 
         this.explicitSeriesIds = ImmutableSet.copyOf(explicitSeriesIds);

--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodTagMap.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodTagMap.java
@@ -18,7 +18,7 @@ import static com.google.gson.internal.$Gson$Preconditions.checkNotNull;
 
 /** BT VOD genre map for MetaBroadcast tags.
  *
- * This class is used in BtVodDescribedFieldsExtractor for mapping the BT VOD genres to
+ * This class is used for mapping the BT VOD genres to
  * MetaBroadcast tags for the described object. This is done so that we can use BT VOD
  * content in the content prioritization algorithm. This further would allow us to filter
  * the BT VOD content by the priority.
@@ -26,7 +26,7 @@ import static com.google.gson.internal.$Gson$Preconditions.checkNotNull;
 public class BtVodTagMap {
 
     private final ImmutableMap<String, String> btVodTagMap;
-    private final String BT_VOD_NAMESPACE = "vod.bt.com";
+    private final String BT_VOD_NAMESPACE = "gb:btvod:prod:";
     private final String METABROADCAST_TAG = "http://metabroadcast.com/tags/";
     private TopicStore topicStore;
     private MongoSequentialIdGenerator idGenerator;
@@ -133,7 +133,7 @@ public class BtVodTagMap {
      * @param genres - BT VOD content genres that are used for mapping with MetaBroadcast tags.
      * @return set of MetaBroadcast tags as TopicRef objects for the BT VOD content.
      */
-    public Set<TopicRef> map(Set<String> genres) {
+    public Set<TopicRef> mapGenresToTopicRefs(Set<String> genres) {
         Set<String> tags = Sets.newHashSet();
         for (String genre : genres) {
             if (genre.contains("http://vod.bt.com/genres/")) {
@@ -147,11 +147,6 @@ public class BtVodTagMap {
         return getTopicRefFromTags(tags);
     }
 
-    /** This method is used for creating a set of TopicRefs from mapped tags.
-     * This is done because we store MetaBroadcast tags as TopicRefs to the BT VOD content.
-     * @param mappedTags - mapped tags for the BT VOD content.
-     * @return set of MetaBroadcast tags as TopicRef objects for the BT VOD content.
-     */
     private Set<TopicRef> getTopicRefFromTags(Set<String> mappedTags) {
         ImmutableSet<String> tags = ImmutableSet.copyOf(mappedTags);
         if(tags.isEmpty()) {
@@ -174,7 +169,7 @@ public class BtVodTagMap {
      * @param topicRefBuilder ImmutableSet that holds all mapped tags TopicRefs
      * @param tag used for creating a TopicRef object.
      */
-    public void addTopicRef(ImmutableSet.Builder<TopicRef> topicRefBuilder, String tag) {
+    private void addTopicRef(ImmutableSet.Builder<TopicRef> topicRefBuilder, String tag) {
         Maybe<Topic> resolvedTopic = resolveTopic(tag);
         if (resolvedTopic.hasValue()) {
             Topic topic = resolvedTopic.requireValue();
@@ -190,7 +185,7 @@ public class BtVodTagMap {
         } else {
             Topic topic = new Topic(
                     idGenerator.generateRaw(),
-                    BT_VOD_NAMESPACE,
+                    BT_VOD_NAMESPACE + tag,
                     METABROADCAST_TAG + tag);
             topic.setPublisher(Publisher.BT_VOD);
             topic.setTitle(tag);
@@ -212,7 +207,7 @@ public class BtVodTagMap {
      * @param tag is used for looking up Topic in db
      * @return Maybe<Topic> resolved tag as a Topic from db
      */
-    public Maybe<Topic> resolveTopic(String tag) {
-        return topicStore.topicFor(Publisher.BT_VOD, BT_VOD_NAMESPACE, METABROADCAST_TAG + tag);
+    private Maybe<Topic> resolveTopic(String tag) {
+        return topicStore.topicFor(Publisher.BT_VOD, BT_VOD_NAMESPACE + tag, METABROADCAST_TAG + tag);
     }
 }

--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodTagMap.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodTagMap.java
@@ -1,0 +1,218 @@
+package org.atlasapi.remotesite.btvod;
+
+import java.util.Set;
+
+import org.atlasapi.media.entity.Publisher;
+import org.atlasapi.media.entity.Topic;
+import org.atlasapi.media.entity.TopicRef;
+import org.atlasapi.persistence.ids.MongoSequentialIdGenerator;
+import org.atlasapi.persistence.topic.TopicStore;
+
+import com.metabroadcast.common.base.Maybe;
+
+import com.google.api.client.util.Sets;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import static com.google.gson.internal.$Gson$Preconditions.checkNotNull;
+
+/** BT VOD genre map for MetaBroadcast tags.
+ *
+ * This class is used in BtVodDescribedFieldsExtractor for mapping the BT VOD genres to
+ * MetaBroadcast tags for the described object. This is done so that we can use BT VOD
+ * content in the content prioritization algorithm. This further would allow us to filter
+ * the BT VOD content by the priority.
+ */
+public class BtVodTagMap {
+
+    private final ImmutableMap<String, String> btVodTagMap;
+    private final String BT_VOD_NAMESPACE = "vod.bt.com";
+    private final String METABROADCAST_TAG = "http://metabroadcast.com/tags/";
+    private TopicStore topicStore;
+    private MongoSequentialIdGenerator idGenerator;
+
+    public BtVodTagMap(TopicStore topicStore, MongoSequentialIdGenerator idGenerator) {
+        this.topicStore = checkNotNull(topicStore);
+        this.idGenerator = checkNotNull(idGenerator);
+        ImmutableMap.Builder<String, String> mapBuilder = ImmutableMap.builder();
+
+        // Film genre mapping
+        mapBuilder.put("http://vod.bt.com/genres/Film", "films");
+        mapBuilder.put("http://vod.bt.com/genres/Short Film", "films");
+        mapBuilder.put("http://vod.bt.com/genres/Action", "action");
+        mapBuilder.put("http://vod.bt.com/genres/Suspense", "action");
+        mapBuilder.put("http://vod.bt.com/genres/Family", "family");
+        mapBuilder.put("http://vod.bt.com/genres/Horror", "horror");
+        mapBuilder.put("http://vod.bt.com/genres/Zombie", "horror");
+        mapBuilder.put("http://vod.bt.com/genres/Monsters", "horror");
+        mapBuilder.put("http://vod.bt.com/genres/Gore", "horror");
+        mapBuilder.put("http://vod.bt.com/genres/Indie", "indie");
+        mapBuilder.put("http://vod.bt.com/genres/Romance", "romance");
+        mapBuilder.put("http://vod.bt.com/genres/Supernatural", "scifi");
+        mapBuilder.put("http://vod.bt.com/genres/Sci-Fi", "scifi");
+        mapBuilder.put("http://vod.bt.com/genres/Comedy", "comedy");
+        mapBuilder.put("http://vod.bt.com/genres/Drama", "drama");
+        mapBuilder.put("http://vod.bt.com/genres/Melodrama", "drama");
+        mapBuilder.put("http://vod.bt.com/genres/Thriller", "thriller");
+        mapBuilder.put("http://vod.bt.com/genres/War", "war");
+
+        // Factual genre mapping
+        mapBuilder.put("http://vod.bt.com/genres/Documentary", "factual");
+        mapBuilder.put("http://vod.bt.com/genres/History", "history-biogs");
+        mapBuilder.put("http://vod.bt.com/genres/Biopic", "history-biogs");
+        mapBuilder.put("http://vod.bt.com/genres/Biography", "history-biogs");
+        mapBuilder.put("http://vod.bt.com/genres/Educational", "learning");
+        mapBuilder.put("http://vod.bt.com/genres/Nature", "nature-environment");
+        mapBuilder.put("http://vod.bt.com/genres/People & Culture", "people-society");
+        mapBuilder.put("http://vod.bt.com/genres/Cult", "religion-ethics");
+        mapBuilder.put("http://vod.bt.com/genres/Science & Technology", "science-tech");
+
+        // Lifestyle genre mapping
+        mapBuilder.put("http://vod.bt.com/genres/Lifestyle", "lifestyle");
+        mapBuilder.put("http://vod.bt.com/genres/Food", "food-drink");
+        mapBuilder.put("http://vod.bt.com/genres/Home", "home-garden");
+        mapBuilder.put("http://vod.bt.com/genres/Garden", "home-garden");
+        mapBuilder.put("http://vod.bt.com/genres/Fashion", "shopping-fashion");
+
+        // Sports genre mapping
+        mapBuilder.put("http://vod.bt.com/genres/Sport", "sport");
+        mapBuilder.put("http://vod.bt.com/genres/Cricket", "cricket");
+        mapBuilder.put("http://vod.bt.com/genres/Football", "football");
+        mapBuilder.put("http://vod.bt.com/genres/Archive Football", "football");
+        mapBuilder.put("http://vod.bt.com/genres/Motorsport", "motorsport");
+        mapBuilder.put("http://vod.bt.com/genres/Moto GP", "motorsport");
+        mapBuilder.put("http://vod.bt.com/genres/Sports News", "news-roundups");
+        mapBuilder.put("http://vod.bt.com/genres/Rugby", "rugby-league");
+        mapBuilder.put("http://vod.bt.com/genres/Sports Documentary", "sports-events");
+        mapBuilder.put("http://vod.bt.com/genres/Tennis", "tennis");
+        mapBuilder.put("http://vod.bt.com/genres/Extreme Sports", "winter-extreme-sports");
+        mapBuilder.put("http://vod.bt.com/genres/Winter Sports", "winter-extreme-sports");
+
+        // Childrens genre mapping
+        mapBuilder.put("http://vod.bt.com/genres/Junior Girl and Boy", "childrens");
+        mapBuilder.put("http://vod.bt.com/genres/Kids", "childrens");
+        mapBuilder.put("http://vod.bt.com/genres/Children's", "childrens");
+        mapBuilder.put("http://vod.bt.com/genres/Adventure", "action-adventure");
+        mapBuilder.put("http://vod.bt.com/genres/Pre-school", "pre-school");
+        mapBuilder.put("http://vod.bt.com/genres/Preschool", "pre-school");
+
+        // Comedy genre mapping
+        mapBuilder.put("http://vod.bt.com/genres/Animation", "animated");
+        mapBuilder.put("http://vod.bt.com/genres/Anime", "animated");
+        mapBuilder.put("http://vod.bt.com/genres/Sitcoms", "sitcom-sketch");
+        mapBuilder.put("http://vod.bt.com/genres/Stand-Up", "stand-up");
+        mapBuilder.put("http://vod.bt.com/genres/Teen", "teen");
+        mapBuilder.put("http://vod.bt.com/genres/Youth", "teen");
+
+        // Drama genre mapping
+        mapBuilder.put("http://vod.bt.com/genres/Crime", "crime");
+        mapBuilder.put("http://vod.bt.com/genres/Police", "crime");
+        mapBuilder.put("http://vod.bt.com/genres/Detective", "crime");
+        mapBuilder.put("http://vod.bt.com/genres/Period", "historical-period");
+        mapBuilder.put("http://vod.bt.com/genres/Medical", "medical");
+
+        // Entertainment genre mapping
+        mapBuilder.put("http://vod.bt.com/genres/Entertainment", "entertainment");
+        mapBuilder.put("http://vod.bt.com/genres/Talk Show", "chat-shows");
+        mapBuilder.put("http://vod.bt.com/genres/Celebrity", "celeb-reality");
+        mapBuilder.put("http://vod.bt.com/genres/Reality", "celeb-reality");
+
+        // Music genre mapping
+        mapBuilder.put("http://vod.bt.com/genres/Music", "music");
+        mapBuilder.put("http://vod.bt.com/genres/Karaoke", "music");
+
+        // News genre mapping
+        mapBuilder.put("http://vod.bt.com/genres/News", "news-weather");
+
+        btVodTagMap = mapBuilder.build();
+    }
+
+    /** This method maps BT VOD content genres with MetaBroadcast tags.
+     * This is done to get MetaBroadcast tags for a specific BT VOD content. After that the
+     * BT VOD content tags are added to the BT VOD content topicRef field.
+     * @param genres - BT VOD content genres that are used for mapping with MetaBroadcast tags.
+     * @return set of MetaBroadcast tags as TopicRef objects for the BT VOD content.
+     */
+    public Set<TopicRef> map(Set<String> genres) {
+        Set<String> tags = Sets.newHashSet();
+        for (String genre : genres) {
+            if (genre.contains("http://vod.bt.com/genres/")) {
+                String tag = btVodTagMap.get(genre);
+                if (tag != null) {
+                    tags.add(tag);
+                }
+            }
+        }
+
+        return getTopicRefFromTags(tags);
+    }
+
+    /** This method is used for creating a set of TopicRefs from mapped tags.
+     * This is done because we store MetaBroadcast tags as TopicRefs to the BT VOD content.
+     * @param mappedTags - mapped tags for the BT VOD content.
+     * @return set of MetaBroadcast tags as TopicRef objects for the BT VOD content.
+     */
+    private Set<TopicRef> getTopicRefFromTags(Set<String> mappedTags) {
+        ImmutableSet<String> tags = ImmutableSet.copyOf(mappedTags);
+        if(tags.isEmpty()) {
+            return ImmutableSet.of();
+        }
+
+        ImmutableSet.Builder<TopicRef> topicRefBuilder = ImmutableSet.builder();
+        for (String tag : tags) {
+            addTopicRef(topicRefBuilder, tag);
+        }
+
+        return topicRefBuilder.build();
+    }
+
+    /** Used for adding TopicRef objects to the topicRefBuilder
+     *
+     * This method either creates TopicRef from existing Topic in the database,
+     * or generates a new topic id to create a new Topic in a case where
+     * Topic doesn't exist in the database.
+     * @param topicRefBuilder ImmutableSet that holds all mapped tags TopicRefs
+     * @param tag used for creating a TopicRef object.
+     */
+    public void addTopicRef(ImmutableSet.Builder<TopicRef> topicRefBuilder, String tag) {
+        Maybe<Topic> resolvedTopic = resolveTopic(tag);
+        if (resolvedTopic.hasValue()) {
+            Topic topic = resolvedTopic.requireValue();
+
+            topic.setPublisher(Publisher.BT_VOD);
+            topic.setTitle(tag);
+            topic.setType(Topic.Type.UNKNOWN);
+            topicStore.write(topic);
+
+            topicRefBuilder.add(new TopicRef(
+                    topic, 0f, false, TopicRef.Relationship.ABOUT, 0)
+            );
+        } else {
+            Topic topic = new Topic(
+                    idGenerator.generateRaw(),
+                    BT_VOD_NAMESPACE,
+                    METABROADCAST_TAG + tag);
+            topic.setPublisher(Publisher.BT_VOD);
+            topic.setTitle(tag);
+            topic.setType(Topic.Type.UNKNOWN);
+            topicStore.write(topic);
+
+            topicRefBuilder.add(new TopicRef(
+                    topic, 0f, false, TopicRef.Relationship.ABOUT, 0)
+            );
+        }
+    }
+
+    /** Resolves given tag to a possible Topic object
+     *
+     * This method is used to resolve Topic from a tag by making a call to
+     * the topic Store. If topic exists would return topic wrapped in Maybe.
+     * If there is no topic with given tag, would return empty value wrapped
+     * in Maybe.
+     * @param tag is used for looking up Topic in db
+     * @return Maybe<Topic> resolved tag as a Topic from db
+     */
+    public Maybe<Topic> resolveTopic(String tag) {
+        return topicStore.topicFor(Publisher.BT_VOD, BT_VOD_NAMESPACE, METABROADCAST_TAG + tag);
+    }
+}

--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodUpdater.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodUpdater.java
@@ -45,6 +45,7 @@ public class BtVodUpdater extends ScheduledTask {
     private final BtMpxVodClient mpxClient;
     private final TopicQueryResolver topicQueryResolver;
     private final BtVodEntryMatchingPredicate kidsPredicate;
+    private final BtVodTagMap btVodTagMap;
 
     public BtVodUpdater(
             ContentWriter contentWriter,
@@ -63,7 +64,8 @@ public class BtVodUpdater extends ScheduledTask {
             BtVodDescribedFieldsExtractor describedFieldsExtractor,
             BtMpxVodClient mpxClient,
             TopicQueryResolver topicQueryResolver,
-            BtVodEntryMatchingPredicate kidsPredicate
+            BtVodEntryMatchingPredicate kidsPredicate,
+            BtVodTagMap btVodTagMap
     ) {
         this.contentWriter = checkNotNull(contentWriter);
         this.newFeedContentMatchingPredicate = checkNotNull(newFeedContentMatchingPredicate);
@@ -82,6 +84,7 @@ public class BtVodUpdater extends ScheduledTask {
         this.mpxClient = checkNotNull(mpxClient);
         this.topicQueryResolver = checkNotNull(topicQueryResolver);
         this.kidsPredicate = checkNotNull(kidsPredicate);
+        this.btVodTagMap = checkNotNull(btVodTagMap);
     }
 
     @Override
@@ -154,7 +157,8 @@ public class BtVodUpdater extends ScheduledTask {
                 listeners,
                 processedRows,
                 describedFieldsExtractor,
-                brandUriExtractor
+                brandUriExtractor,
+                btVodTagMap
         );
 
         vodData.processData(brandExtractor);
@@ -215,7 +219,9 @@ public class BtVodUpdater extends ScheduledTask {
                 versionsExtractor,
                 new TitleSanitiser(),
                 imageExtractor,
-                new DedupedDescriptionAndImageUpdater()
+                new DedupedDescriptionAndImageUpdater(),
+                btVodTagMap
+
         );
 
         vodData.processData(explicitSeriesExtractor);
@@ -244,7 +250,8 @@ public class BtVodUpdater extends ScheduledTask {
                     describedFieldsExtractor,
                     processedRows,
                     seriesUriExtractor,
-                    explicitSeriesExtractor.getExplicitSeries().keySet()
+                    explicitSeriesExtractor.getExplicitSeries().keySet(),
+                    btVodTagMap
                 );
 
         vodData.processData(synthesizedSeriesExtractor);

--- a/src/test/java/org/atlasapi/remotesite/btvod/BtVodBrandExtractorTest.java
+++ b/src/test/java/org/atlasapi/remotesite/btvod/BtVodBrandExtractorTest.java
@@ -49,6 +49,7 @@ public class BtVodBrandExtractorTest {
     private final TopicWriter topicWriter = mock(TopicWriter.class);
     private final BrandUriExtractor brandUriExtractor = new BrandUriExtractor(URI_PREFIX, new TitleSanitiser());
     private final BtVodContentMatchingPredicate newTopicContentMatchingPredicate = mock(BtVodContentMatchingPredicate.class);
+    private final BtVodTagMap btVodTagMap = mock(BtVodTagMap.class);
 
     private final BtVodDescribedFieldsExtractor describedFieldsExtractor = new BtVodDescribedFieldsExtractor(
             topicResolver,
@@ -76,7 +77,8 @@ public class BtVodBrandExtractorTest {
             contentListener,
             Sets.<String>newHashSet(),
             describedFieldsExtractor,
-            brandUriExtractor
+            brandUriExtractor,
+            btVodTagMap
     );
     
     @Test

--- a/src/test/java/org/atlasapi/remotesite/btvod/BtVodExplicitSeriesExtractorTest.java
+++ b/src/test/java/org/atlasapi/remotesite/btvod/BtVodExplicitSeriesExtractorTest.java
@@ -1,15 +1,5 @@
 package org.atlasapi.remotesite.btvod;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.anySet;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import java.util.Set;
 
 import org.atlasapi.media.entity.Alias;
@@ -25,18 +15,29 @@ import org.atlasapi.remotesite.btvod.model.BtVodEntry;
 import org.atlasapi.remotesite.btvod.model.BtVodPlproduct$productTag;
 import org.atlasapi.remotesite.btvod.model.BtVodProductRating;
 import org.atlasapi.remotesite.btvod.model.BtVodProductScope;
-import org.hamcrest.CoreMatchers;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Matchers;
+
+import com.metabroadcast.common.intl.Countries;
 
 import com.google.api.client.util.Sets;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.metabroadcast.common.intl.Countries;
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Matchers;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anySet;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class BtVodExplicitSeriesExtractorTest {
 
@@ -58,6 +59,7 @@ public class BtVodExplicitSeriesExtractorTest {
             mock(DedupedDescriptionAndImageUpdater.class);
 
     private final TopicRef newTopic = mock(TopicRef.class);
+    private final BtVodTagMap btVodTagMap = mock(BtVodTagMap.class);
 
     private BtVodExplicitSeriesExtractor seriesExtractor;
 
@@ -80,7 +82,8 @@ public class BtVodExplicitSeriesExtractorTest {
                 ),
                 new TitleSanitiser(),
                 imageExtractor,
-                descriptionAndImageUpdater
+                descriptionAndImageUpdater,
+                btVodTagMap
         );
     }
 

--- a/src/test/java/org/atlasapi/remotesite/btvod/BtVodSynthesizedSeriesExtractorTest.java
+++ b/src/test/java/org/atlasapi/remotesite/btvod/BtVodSynthesizedSeriesExtractorTest.java
@@ -1,12 +1,6 @@
 package org.atlasapi.remotesite.btvod;
 
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import org.atlasapi.media.entity.ParentRef;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.media.entity.Series;
@@ -18,13 +12,19 @@ import org.atlasapi.remotesite.btvod.contentgroups.BtVodContentMatchingPredicate
 import org.atlasapi.remotesite.btvod.model.BtVodEntry;
 import org.atlasapi.remotesite.btvod.model.BtVodPlproduct$productTag;
 import org.atlasapi.remotesite.btvod.model.BtVodProductScope;
-import org.junit.Test;
 
 import com.google.api.client.util.Sets;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class BtVodSynthesizedSeriesExtractorTest {
 
@@ -48,6 +48,7 @@ public class BtVodSynthesizedSeriesExtractorTest {
     private final TopicWriter topicWriter = mock(TopicWriter.class);
     private final BtVodContentMatchingPredicate newTopicContentMatchingPredicate = mock(BtVodContentMatchingPredicate.class);
     private final BtVodSeriesUriExtractor seriesUriExtractor = mock(BtVodSeriesUriExtractor.class);
+    private final BtVodTagMap btVodTagMap = mock(BtVodTagMap.class);
 
     private final BtVodDescribedFieldsExtractor describedFieldsExtractor = new BtVodDescribedFieldsExtractor(
             topicResolver,
@@ -84,7 +85,8 @@ public class BtVodSynthesizedSeriesExtractorTest {
             describedFieldsExtractor, 
             Sets.<String>newHashSet(),
             seriesUriExtractor,
-            ImmutableSet.of(SERIES_GUID)
+            ImmutableSet.of(SERIES_GUID),
+            btVodTagMap
     );
 
     @Test

--- a/src/test/java/org/atlasapi/remotesite/btvod/BtVodTagMapTest.java
+++ b/src/test/java/org/atlasapi/remotesite/btvod/BtVodTagMapTest.java
@@ -1,0 +1,60 @@
+package org.atlasapi.remotesite.btvod;
+
+import java.util.Set;
+
+import org.atlasapi.media.entity.Publisher;
+import org.atlasapi.media.entity.Topic;
+import org.atlasapi.persistence.ids.MongoSequentialIdGenerator;
+import org.atlasapi.persistence.topic.TopicStore;
+
+import com.metabroadcast.common.base.Maybe;
+
+import com.google.common.collect.Sets;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class BtVodTagMapTest {
+
+    private final String BT_VOD_NAMESPACE = "vod.bt.com";
+    private final String METABROADCAST_TAG = "http://metabroadcast.com/tags/";
+    private TopicStore topicStore = mock(TopicStore.class);
+    private MongoSequentialIdGenerator idGenerator = mock(MongoSequentialIdGenerator.class);
+    private BtVodTagMap btVodTagMap;
+
+    @Before
+    public void setUp() throws Exception {
+        this.btVodTagMap = new BtVodTagMap(topicStore, idGenerator);
+    }
+
+    @Test
+    public void testPaTagMappingForKnownTopic() {
+        Set<String> genres = Sets.newHashSet();
+        genres.add("http://vod.bt.com/genres/Zombie");
+        String tag = "horror";
+
+        when(topicStore.topicFor(Publisher.BT_VOD, BT_VOD_NAMESPACE, METABROADCAST_TAG + tag))
+                .thenReturn(Maybe.fromPossibleNullValue(new Topic(20l,
+                        BT_VOD_NAMESPACE, METABROADCAST_TAG + tag)));
+
+        assertEquals(btVodTagMap.map(genres).size(), 1);
+        assertEquals(btVodTagMap.map(genres).iterator().next().getTopic().longValue(), 20l);
+    }
+
+    @Test
+    public void testPaTagMappingForUnknownTopic() {
+        Set<String> genres = Sets.newHashSet();
+        genres.add("http://vod.bt.com/genres/Zombie");
+        String tag = "horror";
+
+        when(topicStore.topicFor(Publisher.BT_VOD, BT_VOD_NAMESPACE, METABROADCAST_TAG + tag))
+                .thenReturn(Maybe.<Topic>nothing());
+        when(idGenerator.generateRaw()).thenReturn(10l);
+
+        assertEquals(btVodTagMap.map(genres).size(), 1);
+        assertEquals(btVodTagMap.map(genres).iterator().next().getTopic().longValue(), 10l);
+    }
+}

--- a/src/test/java/org/atlasapi/remotesite/btvod/BtVodTagMapTest.java
+++ b/src/test/java/org/atlasapi/remotesite/btvod/BtVodTagMapTest.java
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.when;
 
 public class BtVodTagMapTest {
 
-    private final String BT_VOD_NAMESPACE = "vod.bt.com";
+    private final String BT_VOD_NAMESPACE = "gb:btvod:prod:";
     private final String METABROADCAST_TAG = "http://metabroadcast.com/tags/";
     private TopicStore topicStore = mock(TopicStore.class);
     private MongoSequentialIdGenerator idGenerator = mock(MongoSequentialIdGenerator.class);
@@ -36,12 +36,12 @@ public class BtVodTagMapTest {
         genres.add("http://vod.bt.com/genres/Zombie");
         String tag = "horror";
 
-        when(topicStore.topicFor(Publisher.BT_VOD, BT_VOD_NAMESPACE, METABROADCAST_TAG + tag))
+        when(topicStore.topicFor(Publisher.BT_VOD, BT_VOD_NAMESPACE + tag, METABROADCAST_TAG + tag))
                 .thenReturn(Maybe.fromPossibleNullValue(new Topic(20l,
-                        BT_VOD_NAMESPACE, METABROADCAST_TAG + tag)));
+                        BT_VOD_NAMESPACE + tag, METABROADCAST_TAG + tag)));
 
-        assertEquals(btVodTagMap.map(genres).size(), 1);
-        assertEquals(btVodTagMap.map(genres).iterator().next().getTopic().longValue(), 20l);
+        assertEquals(btVodTagMap.mapGenresToTopicRefs(genres).size(), 1);
+        assertEquals(btVodTagMap.mapGenresToTopicRefs(genres).iterator().next().getTopic().longValue(), 20l);
     }
 
     @Test
@@ -50,11 +50,11 @@ public class BtVodTagMapTest {
         genres.add("http://vod.bt.com/genres/Zombie");
         String tag = "horror";
 
-        when(topicStore.topicFor(Publisher.BT_VOD, BT_VOD_NAMESPACE, METABROADCAST_TAG + tag))
+        when(topicStore.topicFor(Publisher.BT_VOD, BT_VOD_NAMESPACE + tag, METABROADCAST_TAG + tag))
                 .thenReturn(Maybe.<Topic>nothing());
         when(idGenerator.generateRaw()).thenReturn(10l);
 
-        assertEquals(btVodTagMap.map(genres).size(), 1);
-        assertEquals(btVodTagMap.map(genres).iterator().next().getTopic().longValue(), 10l);
+        assertEquals(btVodTagMap.mapGenresToTopicRefs(genres).size(), 1);
+        assertEquals(btVodTagMap.mapGenresToTopicRefs(genres).iterator().next().getTopic().longValue(), 10l);
     }
 }


### PR DESCRIPTION
Added BT genre mapping to MB tags and storing them as TopicRefs.
Added tests.
In BtVodModule changed the TopicWriter to TopicStore, this was done because I need to do a lookup for the Topic to make use of existing topic when creating and storing MB tag as a TopicRef. Also TopicStore extends TopicWriter and TopicLookupResolver, where TopicLookupResolver can be used for Topic lookup.