### PR TITLE
Split equivalence result files into multiple directories

### DIFF
--- a/src/main/java/org/atlasapi/equiv/results/persistence/FileEquivalenceResultStore.java
+++ b/src/main/java/org/atlasapi/equiv/results/persistence/FileEquivalenceResultStore.java
@@ -13,14 +13,20 @@ import org.atlasapi.equiv.results.EquivalenceResult;
 import org.atlasapi.media.entity.Content;
 
 import com.google.common.base.Function;
+import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
+/**
+ * Filesystem-based store for equivalence results. New files will be stored in a
+ * hashed directory structure to avoid a single directory with too many files in it, but
+ * an attempt will also be made to read directly from the root directory for old results.
+ */
 public class FileEquivalenceResultStore implements EquivalenceResultStore {
 
     private StoredEquivalenceResultTranslator translator = new StoredEquivalenceResultTranslator();
-    private final File directory;
+    private final File baseDirectory;
     
     public FileEquivalenceResultStore(File directory) {
         if(!directory.isDirectory()) {
@@ -29,7 +35,7 @@ public class FileEquivalenceResultStore implements EquivalenceResultStore {
         if(!directory.exists()) {
             throw new IllegalArgumentException("Directory does not exist");
         }
-        this.directory = directory;
+        this.baseDirectory = directory;
     }
     
     @Override
@@ -37,7 +43,9 @@ public class FileEquivalenceResultStore implements EquivalenceResultStore {
             EquivalenceResult<T> result) {
         StoredEquivalenceResult storedEquivalenceResult = translator.toStoredEquivalenceResult(result);
         try {
-            ObjectOutputStream os = new ObjectOutputStream(new FileOutputStream(fileFromCanonicalUri(result.subject().getCanonicalUri())));
+            String filename = filenameFor(result.subject().getCanonicalUri());
+            ObjectOutputStream os = new ObjectOutputStream(
+                    new FileOutputStream(new File(directoryFor(filename), filename)));
             os.writeObject(storedEquivalenceResult);
             os.close();
         } catch (FileNotFoundException e) {
@@ -51,20 +59,31 @@ public class FileEquivalenceResultStore implements EquivalenceResultStore {
 
     @Override
     public StoredEquivalenceResult forId(String canonicalUri) {
-        File file = fileFromCanonicalUri(canonicalUri);
-        if(!file.exists()) {
-            return null;
+        String filename = filenameFor(canonicalUri);
+
+        Optional<StoredEquivalenceResult> resultInHashedDirectory = resultFor(new File(directoryFor(filename), filename));
+        if (resultInHashedDirectory.isPresent()) {
+            return resultInHashedDirectory.get();
         }
-        
+
+        Optional<StoredEquivalenceResult> resultInBaseDirectory = resultFor(new File(baseDirectory, filename));
+        return resultInBaseDirectory.orNull();
+    }
+
+    private Optional<StoredEquivalenceResult> resultFor(File file) {
+        if(!file.exists()) {
+            return Optional.absent();
+        }
+
         try {
             ObjectInputStream is = new ObjectInputStream(new FileInputStream(file));
-            return (StoredEquivalenceResult) is.readObject();
+            return Optional.of((StoredEquivalenceResult) is.readObject());
         } catch (IOException e) {
             Throwables.propagate(e);
         } catch (ClassNotFoundException e) {
             Throwables.propagate(e);
         }
-        return null;
+        return Optional.absent();
     }
 
     @Override
@@ -78,9 +97,23 @@ public class FileEquivalenceResultStore implements EquivalenceResultStore {
             
         }));
     }
-    
-    private File fileFromCanonicalUri(String canonicalUri) {
-        return new File(directory, canonicalUri.replace('/', '-'));
+
+    private String filenameFor(String canonicalUri) {
+        return canonicalUri.replace('/', '-');
+    }
+
+    private File directoryFor(String filename) {
+
+        // Inspired by http://michaelandrews.typepad.com/the_technical_times/2009/10/creating-a-hashed-directory-structure.html
+        int hashcode = filename.hashCode();
+        int mask = 255;
+        int firstDir = hashcode & mask;
+        int secondDir = (hashcode >> 8) & mask;
+
+        File firstPath = new File(baseDirectory, String.format("%03d", firstDir));
+        File secondPath = new File(firstPath, String.format("%03d", secondDir));
+
+        return secondPath;
     }
 
 }


### PR DESCRIPTION
Putting all equivalence results in the same directory causes
fun and games with lots of files in the directory. Instead, we
will hash the filename and create a two-directory deep
structure to split the files up.

We'll attempt to find a results file from both the base
directory and the new hash structure, so that old results can
still be retrieved.