### PR TITLE
Update images and description from source of equal priority as existing

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/btvod/HierarchyDescriptionAndImageUpdater.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/HierarchyDescriptionAndImageUpdater.java
@@ -5,16 +5,18 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import javax.annotation.Nonnull;
+
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Episode;
 import org.atlasapi.media.entity.Image;
 import org.atlasapi.media.entity.Series;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.Ordering;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 
 public class HierarchyDescriptionAndImageUpdater {
 
@@ -140,7 +142,10 @@ public class HierarchyDescriptionAndImageUpdater {
 
     private boolean isHigherPriority(MetadataSource source,
             Optional<MetadataSource> existingSource) {
-        return !existingSource.isPresent() || source.compareTo(existingSource.get()) > 0;
+        // We return true on equality as well because we may see the same source multiple times
+        // as different BT VoD entries get deduped in it and each time which images and descriptions
+        // have been kept as part of the deduping process may have changed
+        return !existingSource.isPresent() || source.compareTo(existingSource.get()) >= 0;
     }
 
     private enum MetadataSourceType {
@@ -199,7 +204,7 @@ public class HierarchyDescriptionAndImageUpdater {
          * the lowest series/episode number or from the oldest collection
          */
         @Override
-        public int compareTo(MetadataSource that) {
+        public int compareTo(@Nonnull MetadataSource that) {
             return ComparisonChain.start()
                     .compare(
                             this.sourceType.getPriority(),

--- a/src/test/java/org/atlasapi/remotesite/btvod/HierarchyDescriptionAndImageUpdaterTest.java
+++ b/src/test/java/org/atlasapi/remotesite/btvod/HierarchyDescriptionAndImageUpdaterTest.java
@@ -1,8 +1,5 @@
 package org.atlasapi.remotesite.btvod;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-
 import java.util.Set;
 
 import org.atlasapi.media.entity.Brand;
@@ -10,14 +7,17 @@ import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Episode;
 import org.atlasapi.media.entity.Image;
 import org.atlasapi.media.entity.Series;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 @RunWith(MockitoJUnitRunner.class)
 public class HierarchyDescriptionAndImageUpdaterTest {
@@ -225,6 +225,23 @@ public class HierarchyDescriptionAndImageUpdaterTest {
         updater.update(brand, episode);
         checkDescriptionsSource(brand, collection);
         checkImagesSource(brand, collection);
+    }
+
+    @Test
+    public void testUpdateFromSeriesIfBrandHasDescriptionsAndImagesFromSeriesWithSameSeriesNumber()
+            throws Exception {
+        Brand brand = getBrand("uri", null, null);
+
+        Series firstSeries = getSeries("firstSeries", "firstSeriesL", 5, firstImage);
+        Series secondSeries = getSeries("secondSeries", "secondSeriesL", 5, secondImage);
+
+        updater.update(brand, firstSeries);
+        checkDescriptionsSource(brand, firstSeries);
+        checkImagesSource(brand, firstSeries);
+
+        updater.update(brand, secondSeries);
+        checkDescriptionsSource(brand, secondSeries);
+        checkImagesSource(brand, secondSeries);
     }
 
     private Brand getBrand(String uri, String description, String longDescription,


### PR DESCRIPTION
- We may see the same source multiple times as different BT VoD entries
get deduped in it and each time which images and descriptions have been
kept as part of the deduping process may have changed so we must
update every time we see a metadata source of equal priority as the
existing one because it will be the same one with potentially more up
to date metadata