### PR TITLE
Create PA recent updater to re-ingest even successfully processed files

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/pa/PaRecentUpdater.java
+++ b/src/main/java/org/atlasapi/remotesite/pa/PaRecentUpdater.java
@@ -1,5 +1,6 @@
 package org.atlasapi.remotesite.pa;
 
+import java.io.File;
 import java.util.concurrent.ExecutorService;
 
 import org.atlasapi.feeds.upload.FileUploadResult;
@@ -7,30 +8,55 @@ import org.atlasapi.feeds.upload.persistence.FileUploadResultStore;
 import org.atlasapi.media.channel.ChannelResolver;
 import org.atlasapi.remotesite.pa.data.PaProgrammeDataStore;
 import org.atlasapi.remotesite.pa.persistence.PaScheduleVersionStore;
-import org.joda.time.DateTime;
+
+import com.metabroadcast.common.time.DateTimeZones;
 
 import com.google.common.base.Optional;
-import com.metabroadcast.common.time.DateTimeZones;
+import com.google.common.base.Predicate;
+import org.joda.time.DateTime;
 
 public class PaRecentUpdater extends PaBaseProgrammeUpdater implements Runnable {
        
     private final PaProgrammeDataStore fileManager;
-    final FileUploadResultStore fileUploadResultStore;
+    private final FileUploadResultStore fileUploadResultStore;
+    private final boolean ignoreProcessedFiles;
     
-    public PaRecentUpdater(ExecutorService executor, PaChannelProcessor channelProcessor, PaProgrammeDataStore fileManager, ChannelResolver channelResolver, FileUploadResultStore fileUploadResultStore, PaScheduleVersionStore paScheduleVersionStore) {
+    public PaRecentUpdater(ExecutorService executor, PaChannelProcessor channelProcessor,
+            PaProgrammeDataStore fileManager, ChannelResolver channelResolver,
+            FileUploadResultStore fileUploadResultStore,
+            PaScheduleVersionStore paScheduleVersionStore, boolean ignoreProcessedFiles) {
         super(executor, channelProcessor, fileManager, channelResolver, Optional.of(paScheduleVersionStore));
         this.fileManager = fileManager;
         this.fileUploadResultStore = fileUploadResultStore;
+        this.ignoreProcessedFiles = ignoreProcessedFiles;
     }
     
     @Override
     public void runTask() {
         final Long since = new DateTime(DateTimeZones.UTC).minusDays(10).getMillis();
-        this.processFiles(fileManager.localTvDataFiles(new UnprocessedFileFilter(fileUploadResultStore, SERVICE, since)));
+        Predicate<File> filter = getFileSelectionPredicate(since);
+        this.processFiles(fileManager.localTvDataFiles(filter));
     }
-    
-    @Override 
+
+    @Override
     protected void storeResult(FileUploadResult result) {
         fileUploadResultStore.store(result.filename(), result);
+    }
+
+    private Predicate<File> getFileSelectionPredicate(final Long since) {
+        if (ignoreProcessedFiles) {
+            return new UnprocessedFileFilter(
+                    fileUploadResultStore,
+                    SERVICE,
+                    since
+            );
+        } else {
+            return new Predicate<File>() {
+                @Override
+                public boolean apply(File input) {
+                    return input.lastModified() > since;
+                }
+            };
+        }
     }
 }


### PR DESCRIPTION
- This is needed in case a file ingest fails, but mistakenly reports
itself as having successfully finished