### PR TITLE
Reverse schedule equivalence job

### DIFF
--- a/src/main/java/org/atlasapi/equiv/update/tasks/ScheduleEquivalenceUpdateTask.java
+++ b/src/main/java/org/atlasapi/equiv/update/tasks/ScheduleEquivalenceUpdateTask.java
@@ -14,6 +14,8 @@ import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.media.entity.Schedule;
 import org.atlasapi.media.entity.Schedule.ScheduleChannel;
 import org.atlasapi.persistence.content.ScheduleResolver;
+
+import com.google.common.collect.Lists;
 import org.joda.time.LocalDate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -96,8 +98,15 @@ public class ScheduleEquivalenceUpdateTask extends ScheduledTask {
                     ));
                 }
                 ScheduleChannel scheduleChannel = channelItr.next();
-                
-                Iterator<Item> channelItems = scheduleChannel.items().iterator();
+
+                // It's better to run in reverse order, since the furthest point in the schedule
+                // is likely to have not been run before, and if run last it's more subject
+                // to job interruptions.
+                //
+                // If we were to run forwards, we would first recompute days which have been
+                // computed before, rather than first running days at the end of the schedule for
+                // the first time.
+                Iterator<Item> channelItems = Lists.reverse(scheduleChannel.items()).iterator();
                 while (channelItems.hasNext() && shouldContinue()) {
                     Item scheduleItem = channelItems.next();
                     progress = progress.reduce(process(scheduleItem));


### PR DESCRIPTION
Instead of running forwards from t to t+n, we will run from t+n
backwards to t. This ensure we don't starve the far end of the
schedule where equivalence may never have been run, in the case
jobs are interrupted.