### PR TITLE
Require masterAgreementServiceType OTG

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodVersionsExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodVersionsExtractor.java
@@ -76,7 +76,8 @@ public class BtVodVersionsExtractor {
         
         locations.addAll(createLocations(row, btTvServiceId, aliases));
         
-        if (hasServiceTypeOtg(row)) {
+        if (hasServiceTypeOtg(row)
+                && hasMasterAgreementServiceTypeOtg(row)) {
             locations.addAll(createLocations(row, btTvOtgServiceId, aliases));
         }
 
@@ -210,8 +211,8 @@ public class BtVodVersionsExtractor {
         return row.getServiceTypes().contains(OTG_PLATFORM);
     }
 
-    private boolean isItemTvodPlayoutAllowed(BtVodEntry row) {
-        return !Boolean.FALSE.equals(Boolean.valueOf(row.getMasterAgreementOtgTvodPlay()));
+    private boolean hasMasterAgreementServiceTypeOtg(BtVodEntry row) {
+        return row.getMasterAgreementServiceTypes().contains(OTG_PLATFORM);
     }
 
     private Optional<Location> createLocation(BtVodEntry row, Interval availability,

--- a/src/main/java/org/atlasapi/remotesite/btvod/model/BtVodEntry.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/model/BtVodEntry.java
@@ -13,7 +13,7 @@ public class BtVodEntry {
     private static final String SCHEDULER_CHANNEL = "schedulerChannel";
     private static final String TRAILER_SERVICE_TYPE_SCHEME = "trailerServiceType";
     private static final String SERVICE_TYPE_SCHEME = "serviceType";
-    private static final String MASTER_AGREEMENT_OTG_TVOD_PLAY_SCHEME = "masterAgreementOtgTvodPlay";
+    private static final String MASTER_AGREEMENT_SERVICE_TYPE = "masterAgreementServiceType";
     private static final String KEYWORD = "keyword";
     
     private String id;
@@ -150,8 +150,8 @@ public class BtVodEntry {
         return productTags(SUBSCRIPTION_PRODUCT_SCHEME);
     }
 
-    public String getMasterAgreementOtgTvodPlay() {
-        return productTag(MASTER_AGREEMENT_OTG_TVOD_PLAY_SCHEME);
+    public ImmutableSet<String> getMasterAgreementServiceTypes() {
+        return productTags(MASTER_AGREEMENT_SERVICE_TYPE);
     }
 
     public ImmutableSet<String> getKeywordTags() {


### PR DESCRIPTION
Ingest rules did not correctly specify when content is available
to play. The presence of the masterAgreementServiceType:OTG is
also required (i.e. serviceType:OTG AND
masterAgreementServiceType:OTG required). This means only content
with both these tags are playable on TVE (they may still be present
in the feed though because they are playable on a STB).