### PR TITLE
Ingest revised repeat flag from PA

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/pa/PaProgrammeProcessor.java
+++ b/src/main/java/org/atlasapi/remotesite/pa/PaProgrammeProcessor.java
@@ -742,13 +742,22 @@ public class PaProgrammeProcessor implements PaProgDataProcessor, PaProgDataUpda
     }
 
     //If the repeat flag is "yes" it's definitely a repeat. If it's "no" 
-    // then we can't be sure so ingest it as null.  
+    // then we can't be sure, since the PA aren't making any assertion; effectively, it's a null
+    // so we'll ingest as such
     private Boolean isRepeat(Channel channel, Attr attr) {
         Boolean repeat = getBooleanValue(attr.getRepeat());
-        if (Boolean.FALSE.equals(repeat)) {
-            return null;
+
+        // revised repeat means that a broadcast is a repeat, but has been edited since the
+        // original broadcast. In Atlas we do not make such a distinction, we coalesce
+        // PA's repeat and revised repeat flag into a single field
+        Boolean revisedRepeat = getBooleanValue(attr.getRevisedRepeat());
+
+        if (Boolean.TRUE.equals(revisedRepeat)
+                || Boolean.TRUE.equals(repeat)) {
+            return true;
         }
-        return repeat;
+
+        return null;
     }
 
     private void addBroadcast(Version version, Broadcast newBroadcast) {

--- a/src/main/resources/TVListings.dtd
+++ b/src/main/resources/TVListings.dtd
@@ -239,6 +239,7 @@ person_id: A unique id for this person
 	stereo: the programme in stereo.
 	subtitles: the programme carries Teletext or Ceefax subtitles.
 	repeat: the programme a repeat.
+	revised repeat: the programme a revised repeat.
 	bw: the programme broadcast in Black and White.
 	premiere: this a broadcast premiere.
     new_episode: this is the first showing of this programme on this channel.
@@ -268,6 +269,7 @@ person_id: A unique id for this person
 	stereo (yes | no) "no"
 	subtitles (yes | no) "no"
 	repeat (yes | no) "no"
+	revised_repeat (yes | no) "no"
 	bw (yes | no) "no"
 	premiere (yes | no) "no"
 	new_episode (yes | no) "no"

--- a/src/test/java/org/atlasapi/remotesite/pa/PaProgrammeProcessorTest.java
+++ b/src/test/java/org/atlasapi/remotesite/pa/PaProgrammeProcessorTest.java
@@ -264,6 +264,29 @@ public class PaProgrammeProcessorTest {
     }
 
     @Test
+    public void testSetsRepeatFlagFromRevisedRepeat() {
+        Film film = new Film("http://pressassociation.com/films/5", "pa:f-5", Publisher.PA);
+        Version version = new Version();
+        version.setProvider(Publisher.PA);
+        film.addVersion(version);
+
+        Brand expectedItemBrand = new Brand("http://pressassociation.com/brands/5", "pa:b-5", Publisher.PA);
+        Series expectedItemSeries= new Series("http://pressassociation.com/series/5-6", "pa:s-5-6", Publisher.PA);
+        setupContentResolver(ImmutableSet.<Identified>of(film, expectedItemBrand, expectedItemSeries));
+
+        ProgData progData = setupProgData();
+        progData.getAttr().setRevisedRepeat("yes");
+
+        ContentHierarchyAndSummaries hierarchy = progProcessor.process(progData, channel, UTC, Timestamp.of(0)).get();
+
+        Broadcast broadcast = Iterables.getOnlyElement(
+                Iterables.getOnlyElement(hierarchy.getItem().getVersions()).getBroadcasts()
+        );
+
+        assertTrue(broadcast.getRepeat());
+    }
+
+    @Test
     public void testGetTitleAndDescriptionForNewFilm() throws Exception {
         String brandUri = "http://pressassociation.com/brands/5";
         String expectedUri = "http://pressassociation.com/films/5";


### PR DESCRIPTION
Revised repeat means that a broadcast is a repeat, but has
been edited since the original broadcast. In Atlas we do not
make such a distinction, we coalesce PA's repeat and revised
repeat flag into a single field.