### PR TITLE
Use PA film field to decide type of film

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/pa/PaProgrammeProcessor.java
+++ b/src/main/java/org/atlasapi/remotesite/pa/PaProgrammeProcessor.java
@@ -501,13 +501,6 @@ public class PaProgrammeProcessor implements PaProgDataProcessor, PaProgDataUpda
         } else {
             film = getBasicFilm(progData);
         }
-        film.addAlias(PaHelper.getFilmAlias(identifierFor(progData)));
-        Optional<String> rtFilmIdentifier = rtFilmIdentifierFor(progData);
-        if (rtFilmIdentifier.isPresent()) {
-            film.addAlias(PaHelper.getRtFilmAlias(rtFilmIdentifier.get()));
-        }
-
-        film.setAliasUrls(ImmutableSet.of(PaHelper.getAlias(progData.getProgId())));
 
         if (progData.getFilmYear() != null && MoreStrings.containsOnlyAsciiDigits(progData.getFilmYear())) {
             film.setYear(Integer.parseInt(progData.getFilmYear()));
@@ -551,6 +544,25 @@ public class PaProgrammeProcessor implements PaProgDataProcessor, PaProgDataUpda
         episode.setPeople(people(progData));
 
         setCertificate(progData, episode);
+
+        // Adding a film alias only used to happen when type was film. Previously this was
+        // decided based on the existence of the field rt_filmnumber. That's faulty, though,
+        // so we changed it to use the film flag. In order to maintain backward-compatibilty
+        // and only set the film alias when a rt_filmnumber value exists, we make that
+        // check here.
+
+        if (!Strings.isNullOrEmpty(progData.getRtFilmnumber())) {
+            episode.addAlias(PaHelper.getFilmAlias(identifierFor(progData)));
+        }
+
+        Optional<String> rtFilmIdentifier = rtFilmIdentifierFor(progData);
+        if (rtFilmIdentifier.isPresent()) {
+            episode.addAlias(PaHelper.getRtFilmAlias(rtFilmIdentifier.get()));
+        }
+
+        episode.setAliasUrls(ImmutableSet.of(PaHelper.getAlias(progData.getProgId())));
+
+
     }
 
     private Broadcast addBroadcast(ProgData progData, Item item, Channel channel,
@@ -857,7 +869,7 @@ public class PaProgrammeProcessor implements PaProgDataProcessor, PaProgDataUpda
         if (MediaType.AUDIO.equals(channel.getMediaType())) {
             return Specialization.RADIO;
         }
-        return Strings.isNullOrEmpty(progData.getRtFilmnumber()) ? Specialization.TV : Specialization.FILM;
+        return getBooleanValue(progData.getAttr().getFilm()) ? Specialization.FILM : Specialization.TV;
     }
 
     protected static DateTime getTransmissionTime(String date, String time, DateTimeZone zone) {


### PR DESCRIPTION
Instead of using rt_filmnumber, which isn't solely
set on films, we'll use the film flag as provided by PA to
decide if an Item is a Film or not.