### PR TITLE
Updated Opta event group titles for UEFA Champions and Europa leagues

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/opta/events/OptaEventsUtility.java
+++ b/src/main/java/org/atlasapi/remotesite/opta/events/OptaEventsUtility.java
@@ -206,12 +206,12 @@ public class OptaEventsUtility extends EventsUtility<OptaSportType> {
             .put(OptaSportType.FOOTBALL_CHAMPIONS_LEAGUE, ImmutableMap.of(
                     "Football", "http://dbpedia.org/resources/Football", 
                     "Association Football", "http://dbpedia.org/resources/Association_football", 
-                    "Premier League", "http://dbpedia.org/resources/UEFA_Champions_League"
+                    "UEFA Champions League", "http://dbpedia.org/resources/UEFA_Champions_League"
             ))
             .put(OptaSportType.FOOTBALL_EUROPA_LEAGUE, ImmutableMap.of(
                     "Football", "http://dbpedia.org/resources/Football", 
                     "Association Football", "http://dbpedia.org/resources/Association_football", 
-                    "Premier League", "http://dbpedia.org/resources/UEFA_Europa_League"
+                    "UEFA Europa League", "http://dbpedia.org/resources/UEFA_Europa_League"
             ))
             .put(OptaSportType.FOOTBALL_FA_CUP, ImmutableMap.of(
                     "Football", "http://dbpedia.org/resources/Football",


### PR DESCRIPTION
Updated Opta event group titles for UEFA Champions and Europa leagues, this is done as we are currently getting the wrong titles for event groups on event queries to Atlas.