### PR TITLE
Update aliases for MPX ingester

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodBrandProvider.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodBrandProvider.java
@@ -1,7 +1,5 @@
 package org.atlasapi.remotesite.btvod;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.Map;
 
 import org.atlasapi.media.entity.Brand;
@@ -13,6 +11,8 @@ import org.atlasapi.remotesite.btvod.model.BtVodEntry;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class BtVodBrandProvider {
 
@@ -42,14 +42,12 @@ public class BtVodBrandProvider {
         this.listener = checkNotNull(listener);
     }
 
-
     public Optional<Brand> brandFor(BtVodEntry row) {
         Optional<String> brandUri = brandUriExtractor.extractBrandUri(row);
         if (brandUri.isPresent() && brands.containsKey(brandUri.get())) {
             return Optional.of(brands.get(brandUri.get()));
         }
         return Optional.absent();
-
     }
 
     public Optional<ParentRef> brandRefFor(BtVodEntry row) {
@@ -69,7 +67,7 @@ public class BtVodBrandProvider {
         }
         Brand brand = brandOptional.get();
 
-        descriptionAndImageUpdater.update(brand, series);
+        descriptionAndImageUpdater.update(brand, series, seriesRow);
         certificateUpdater.updateCertificates(brand, series);
         topicUpdater.updateTopics(brand, series.getTopicRefs());
 
@@ -83,7 +81,7 @@ public class BtVodBrandProvider {
         }
         Brand brand = brandOptional.get();
 
-        descriptionAndImageUpdater.update(brand, episode);
+        descriptionAndImageUpdater.update(brand, episode, episodeRow);
         certificateUpdater.updateCertificates(brand, episode);
         topicUpdater.updateTopics(brand, episode.getTopicRefs());
 

--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodDescribedFieldsExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodDescribedFieldsExtractor.java
@@ -1,7 +1,5 @@
 package org.atlasapi.remotesite.btvod;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -10,7 +8,6 @@ import java.util.concurrent.ExecutionException;
 
 import org.atlasapi.media.entity.Alias;
 import org.atlasapi.media.entity.Described;
-import org.atlasapi.media.entity.Image;
 import org.atlasapi.media.entity.Priority;
 import org.atlasapi.media.entity.PriorityScoreReasons;
 import org.atlasapi.media.entity.Publisher;
@@ -30,6 +27,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 
 public class BtVodDescribedFieldsExtractor {
 
@@ -39,6 +38,10 @@ public class BtVodDescribedFieldsExtractor {
 
     private final String guidAliasNamespace;
     private final String idAliasNamespace;
+
+    private final String synthesisedFromGuidAliasNamespace;
+    private final String synthesisedFromIdAliasNamespace;
+
     private final String contentProviderTopicNamespace;
     private final String genreTopicNamespace;
     private final String keywordTopicNamespace;
@@ -158,7 +161,9 @@ public class BtVodDescribedFieldsExtractor {
             Topic tvBoxsetTopic,
             Topic subCatchupTopic,
             String guidAliasNamespace,
+            String synthesisedFromGuidAliasNamespace,
             String idAliasNamespace,
+            String synthesisedFromIdAliasNamespace,
             String contentProviderTopicNamespace,
             String genreTopicNamespace,
             String keywordTopicNamespace
@@ -181,6 +186,10 @@ public class BtVodDescribedFieldsExtractor {
 
         this.guidAliasNamespace = checkNotNull(guidAliasNamespace);
         this.idAliasNamespace = checkNotNull(idAliasNamespace);
+
+        this.synthesisedFromGuidAliasNamespace = checkNotNull(synthesisedFromGuidAliasNamespace);
+        this.synthesisedFromIdAliasNamespace = checkNotNull(synthesisedFromIdAliasNamespace);
+
         this.contentProviderTopicNamespace = checkNotNull(contentProviderTopicNamespace);
         this.genreTopicNamespace = checkNotNull(genreTopicNamespace);
         this.keywordTopicNamespace = checkNotNull(keywordTopicNamespace);
@@ -236,8 +245,6 @@ public class BtVodDescribedFieldsExtractor {
             }
             described.setGenres(genres.build());
         }
-        
-        described.setAliases(aliasesFrom(row));
     }
 
     public Set<String> btGenreStringsFrom(BtVodEntry row) {
@@ -335,16 +342,17 @@ public class BtVodDescribedFieldsExtractor {
         return topicRefBuilder.build();
     }
 
-    public Iterable<Alias> aliasesFrom(BtVodEntry row) {
+    public Iterable<Alias> explicitAliasesFrom(BtVodEntry row) {
         return ImmutableSet.of(
                 new Alias(guidAliasNamespace, row.getGuid()),
                 new Alias(idAliasNamespace, row.getId()));
     }
 
-    private Iterable<Image> createImages(BtVodEntry row) {
-        // images are of poor quality, so not useful to save
-        // return imageExtractor.extractImages(row.getProductImages());
-        return ImmutableSet.of();
+    public Iterable<Alias> synthesisedAliasesFrom(BtVodEntry row) {
+        return ImmutableSet.of(
+                new Alias(synthesisedFromGuidAliasNamespace, row.getGuid()),
+                new Alias(synthesisedFromIdAliasNamespace, row.getId())
+        );
     }
 
     private String cacheKey(String namespace, String value) {

--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodExplicitSeriesExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodExplicitSeriesExtractor.java
@@ -79,7 +79,7 @@ public class BtVodExplicitSeriesExtractor extends AbstractBtVodSeriesExtractor {
 
         series.addVersions(currentVersions);
 
-        series.addAliases(getDescribedFieldsExtractor().aliasesFrom(row));
+        series.addAliases(getDescribedFieldsExtractor().explicitAliasesFrom(row));
         series.setTitle(titleSanitiser.sanitiseTitle(row.getTitle()));
         getDescribedFieldsExtractor().setDescribedFieldsFrom(row, series);
 

--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodItemExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodItemExtractor.java
@@ -1,13 +1,5 @@
 package org.atlasapi.remotesite.btvod;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.atlasapi.remotesite.btvod.BtVodProductType.COLLECTION;
-import static org.atlasapi.remotesite.btvod.BtVodProductType.EPISODE;
-import static org.atlasapi.remotesite.btvod.BtVodProductType.FILM;
-import static org.atlasapi.remotesite.btvod.BtVodProductType.HELP;
-import static org.atlasapi.remotesite.btvod.BtVodProductType.MUSIC;
-import static org.atlasapi.remotesite.btvod.BtVodProductType.SEASON;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -27,8 +19,9 @@ import org.atlasapi.media.entity.TopicRef;
 import org.atlasapi.media.entity.Version;
 import org.atlasapi.remotesite.btvod.model.BtVodEntry;
 import org.atlasapi.remotesite.btvod.model.BtVodProductRating;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import com.metabroadcast.common.intl.Countries;
+import com.metabroadcast.common.scheduling.UpdateProgress;
 
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
@@ -40,8 +33,16 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.primitives.Ints;
-import com.metabroadcast.common.intl.Countries;
-import com.metabroadcast.common.scheduling.UpdateProgress;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.atlasapi.remotesite.btvod.BtVodProductType.COLLECTION;
+import static org.atlasapi.remotesite.btvod.BtVodProductType.EPISODE;
+import static org.atlasapi.remotesite.btvod.BtVodProductType.FILM;
+import static org.atlasapi.remotesite.btvod.BtVodProductType.HELP;
+import static org.atlasapi.remotesite.btvod.BtVodProductType.MUSIC;
+import static org.atlasapi.remotesite.btvod.BtVodProductType.SEASON;
 
 
 public class BtVodItemExtractor implements BtVodDataProcessor<UpdateProgress> {
@@ -183,7 +184,7 @@ public class BtVodItemExtractor implements BtVodDataProcessor<UpdateProgress> {
         item.addVersions(versions);
 
         item.addClips(extractTrailer(row));
-        item.addAliases(describedFieldsExtractor.aliasesFrom(row));
+        item.addAliases(describedFieldsExtractor.explicitAliasesFrom(row));
         
         addMissingTopicRefs(item, row);
     }
@@ -318,6 +319,7 @@ public class BtVodItemExtractor implements BtVodDataProcessor<UpdateProgress> {
         }
 
         describedFieldsExtractor.setDescribedFieldsFrom(row, item);
+        item.setAliases(describedFieldsExtractor.explicitAliasesFrom(row));
 
         Set<Version> versions = versionsExtractor.createVersions(row);
         descriptionAndImageUpdater.updateDescriptionsAndImages(

--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodSeriesProvider.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodSeriesProvider.java
@@ -1,7 +1,5 @@
 package org.atlasapi.remotesite.btvod;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.Map;
 
 import org.atlasapi.media.entity.Episode;
@@ -15,6 +13,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableTable;
 import com.google.common.collect.Table;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class BtVodSeriesProvider {
 
@@ -93,7 +93,7 @@ public class BtVodSeriesProvider {
         }
         Series series = seriesOptional.get();
 
-        descriptionAndImageUpdater.update(series, episode);
+        descriptionAndImageUpdater.update(series, episode, episodeRow);
         certificateUpdater.updateCertificates(series, episode);
         topicUpdater.updateTopics(series, episode.getTopicRefs());
 

--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodSynthesizedSeriesExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodSynthesizedSeriesExtractor.java
@@ -76,7 +76,9 @@ public class BtVodSynthesizedSeriesExtractor extends AbstractBtVodSeriesExtracto
     }
 
     @Override
-    protected void setAdditionalFields(Series series, BtVodEntry row) {}
+    protected void setAdditionalFields(Series series, BtVodEntry row) {
+        series.addAliases(getDescribedFieldsExtractor().synthesisedAliasesFrom(row));
+    }
 
     public Map<String, Series> getSynthesizedSeries() {
         return ImmutableMap.copyOf(synthesizedSeries);

--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodUpdater.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodUpdater.java
@@ -47,6 +47,9 @@ public class BtVodUpdater extends ScheduledTask {
     private final BtVodEntryMatchingPredicate kidsPredicate;
     private final BtVodTagMap btVodTagMap;
 
+    private final String btVodDescriptionsGuidAliasNamespace;
+    private final String btVodImagesGuidAliasNamespace;
+
     public BtVodUpdater(
             ContentWriter contentWriter,
             BtVodData vodData,
@@ -65,7 +68,9 @@ public class BtVodUpdater extends ScheduledTask {
             BtMpxVodClient mpxClient,
             TopicQueryResolver topicQueryResolver,
             BtVodEntryMatchingPredicate kidsPredicate,
-            BtVodTagMap btVodTagMap
+            BtVodTagMap btVodTagMap,
+            String btVodDescriptionsGuidAliasNamespace,
+            String btVodImagesGuidAliasNamespace
     ) {
         this.contentWriter = checkNotNull(contentWriter);
         this.newFeedContentMatchingPredicate = checkNotNull(newFeedContentMatchingPredicate);
@@ -85,6 +90,8 @@ public class BtVodUpdater extends ScheduledTask {
         this.topicQueryResolver = checkNotNull(topicQueryResolver);
         this.kidsPredicate = checkNotNull(kidsPredicate);
         this.btVodTagMap = checkNotNull(btVodTagMap);
+        this.btVodDescriptionsGuidAliasNamespace = checkNotNull(btVodDescriptionsGuidAliasNamespace);
+        this.btVodImagesGuidAliasNamespace = checkNotNull(btVodImagesGuidAliasNamespace);
     }
 
     @Override
@@ -179,7 +186,10 @@ public class BtVodUpdater extends ScheduledTask {
                 brandUriExtractor,
                 brandExtractor.getProcessedBrands(),
                 brandExtractor.getParentGuidToBrand(),
-                new HierarchyDescriptionAndImageUpdater(),
+                new HierarchyDescriptionAndImageUpdater(
+                        btVodDescriptionsGuidAliasNamespace,
+                        btVodImagesGuidAliasNamespace
+                ),
                 new CertificateUpdater(),
                 topicUpdater,
                 listeners
@@ -274,7 +284,10 @@ public class BtVodUpdater extends ScheduledTask {
                 explicitSeriesExtractor.getExplicitSeries(),
                 synthesizedSeriesExtractor.getSynthesizedSeries(),
                 seriesUriExtractor,
-                new HierarchyDescriptionAndImageUpdater(),
+                new HierarchyDescriptionAndImageUpdater(
+                        btVodDescriptionsGuidAliasNamespace,
+                        btVodImagesGuidAliasNamespace
+                ),
                 new CertificateUpdater(),
                 brandProvider,
                 topicUpdater,

--- a/src/test/java/org/atlasapi/remotesite/btvod/BtVodBrandProviderTest.java
+++ b/src/test/java/org/atlasapi/remotesite/btvod/BtVodBrandProviderTest.java
@@ -1,14 +1,16 @@
 package org.atlasapi.remotesite.btvod;
 
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import org.atlasapi.media.entity.Brand;
 import org.atlasapi.media.entity.Episode;
 import org.atlasapi.media.entity.Image;
 import org.atlasapi.media.entity.Series;
 import org.atlasapi.media.entity.TopicRef;
 import org.atlasapi.remotesite.btvod.model.BtVodEntry;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
@@ -16,10 +18,8 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class BtVodBrandProviderTest {
@@ -69,14 +69,14 @@ public class BtVodBrandProviderTest {
     public void testUpdateDescriptionsAndImagesFromSeries() throws Exception {
         brandProvider.updateBrandFromSeries(seriesRow, series);
 
-        verify(descriptionAndImageUpdater).update(brand, series);
+        verify(descriptionAndImageUpdater).update(brand, series, seriesRow);
     }
 
     @Test
     public void testUpdateDescriptionsAndImagesFromEpisode() throws Exception {
-        brandProvider.updateBrandFromEpisode(seriesRow, episode);
+        brandProvider.updateBrandFromEpisode(episodeRow, episode);
 
-        verify(descriptionAndImageUpdater).update(brand, episode);
+        verify(descriptionAndImageUpdater).update(brand, episode, episodeRow);
     }
 
     @Test

--- a/src/test/java/org/atlasapi/remotesite/btvod/BtVodItemExtractorTest.java
+++ b/src/test/java/org/atlasapi/remotesite/btvod/BtVodItemExtractorTest.java
@@ -1,16 +1,5 @@
 package org.atlasapi.remotesite.btvod;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anySet;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isA;
-import static org.mockito.Matchers.argThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Set;
@@ -40,6 +29,13 @@ import org.atlasapi.remotesite.btvod.model.BtVodProductPricingPlan;
 import org.atlasapi.remotesite.btvod.model.BtVodProductPricingTier;
 import org.atlasapi.remotesite.btvod.model.BtVodProductRating;
 import org.atlasapi.remotesite.btvod.model.BtVodProductScope;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeConstants;
 import org.joda.time.DateTimeZone;
@@ -49,12 +45,16 @@ import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Matchers;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anySet;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 
 public class BtVodItemExtractorTest {
@@ -73,6 +73,8 @@ public class BtVodItemExtractorTest {
     private static final Topic NEW_TOPIC = new Topic(123L);
     private static final String BT_VOD_GUID_NAMESPACE = "guid namespace";
     private static final String BT_VOD_ID_NAMESPACE = "id namespace";
+    private static final String BT_VOD_SYNTHESISED_FROM_GUID_ALIAS_NAMESPACE = "synth guid namespace";
+    private static final String BT_VOD_SYNTHESISED_FROM_ID_ALIAS_NAMESPACE = "synth id namespace";
     private static final String BT_VOD_CONTENT_PROVIDER_NAMESPACE = "content provider namespace";
     private static final String BT_VOD_GENRE_NAMESPACE = "genre namespace";
     private static final String BT_VOD_KEYWORD_NAMESPACE = "keyword namespace";
@@ -134,7 +136,9 @@ public class BtVodItemExtractorTest {
                         new Topic(345L),
                         new Topic(456L),
                         BT_VOD_GUID_NAMESPACE,
+                        BT_VOD_SYNTHESISED_FROM_GUID_ALIAS_NAMESPACE,
                         BT_VOD_ID_NAMESPACE,
+                        BT_VOD_SYNTHESISED_FROM_ID_ALIAS_NAMESPACE,
                         BT_VOD_CONTENT_PROVIDER_NAMESPACE,
                         BT_VOD_GENRE_NAMESPACE,
                         BT_VOD_KEYWORD_NAMESPACE

--- a/src/test/java/org/atlasapi/remotesite/btvod/BtVodSeriesProviderTest.java
+++ b/src/test/java/org/atlasapi/remotesite/btvod/BtVodSeriesProviderTest.java
@@ -1,25 +1,25 @@
 package org.atlasapi.remotesite.btvod;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import org.atlasapi.media.entity.Episode;
 import org.atlasapi.media.entity.ParentRef;
 import org.atlasapi.media.entity.Series;
 import org.atlasapi.media.entity.TopicRef;
 import org.atlasapi.remotesite.btvod.model.BtVodEntry;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class BtVodSeriesProviderTest {
@@ -113,7 +113,7 @@ public class BtVodSeriesProviderTest {
 
         seriesProvider.updateSeriesFromEpisode(episodeRow, episode);
 
-        verify(descriptionAndImageUpdater).update(EXPLICIT_SERIES, episode);
+        verify(descriptionAndImageUpdater).update(EXPLICIT_SERIES, episode, episodeRow);
     }
 
     @Test


### PR DESCRIPTION
- When synthesising brand/series added guid/id of MPX row that
created it as an alias with 'synthesised' namespace
- When updating images/descriptions from the hierarchy add alias
with the guid of the row that propagated its images/descriptions