### PR TITLE
Change namespace for Opta competition event groups

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/bt/events/BtEventsUtility.java
+++ b/src/main/java/org/atlasapi/remotesite/bt/events/BtEventsUtility.java
@@ -1,14 +1,16 @@
 package org.atlasapi.remotesite.bt.events;
 
+import java.util.List;
 import java.util.Map;
 
 import org.atlasapi.persistence.topic.TopicStore;
 import org.atlasapi.remotesite.events.EventsUtility;
 import org.atlasapi.remotesite.opta.events.model.OptaSportType;
-import org.joda.time.DateTime;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.joda.time.DateTime;
 
 
 public final class BtEventsUtility extends EventsUtility<BtSportType> {
@@ -52,14 +54,27 @@ public final class BtEventsUtility extends EventsUtility<BtSportType> {
             .put("Sepang Circuit", "http://dbpedia.org/resources/Sepang_Circuit")
             .put("Comunitat Valenciana", "http://dbpedia.org/resources/Circuit_Ricardo_Tormo")
             .build();
-    private static final Map<BtSportType, Map<String, String>> EVENT_GROUPS_LOOKUP = ImmutableMap.<BtSportType, Map<String, String>>builder()
-            .put(BtSportType.UFC, ImmutableMap.of(
-                    "UFC", "http://dbpedia.org/resources/UFC"
+    private static final Map<BtSportType, List<EventGroup>> EVENT_GROUPS_LOOKUP = ImmutableMap.
+            <BtSportType, List<EventGroup>>builder()
+            .put(BtSportType.UFC, ImmutableList.of(
+                    EventGroup.ofDefaultNs(
+                            "UFC",
+                            "http://dbpedia.org/resources/UFC"
+                    )
             ))
-            .put(BtSportType.MOTO_GP, ImmutableMap.of(
-                    "Moto GP", "http://dbpedia.org/resources/Moto_gp", 
-                    "Motorsport", "http://dbpedia.org/resources/Motorsport",
-                    "Grand Prix motorcycle racing", "http://dbpedia.org/resources/Grand_Prix_motorcycle_racing"
+            .put(BtSportType.MOTO_GP, ImmutableList.of(
+                    EventGroup.ofDefaultNs(
+                            "Moto GP",
+                            "http://dbpedia.org/resources/Moto_gp"
+                    ),
+                    EventGroup.ofDefaultNs(
+                            "Motorsport",
+                            "http://dbpedia.org/resources/Motorsport"
+                    ),
+                    EventGroup.ofDefaultNs(
+                            "Grand Prix motorcycle racing",
+                            "http://dbpedia.org/resources/Grand_Prix_motorcycle_racing"
+                    )
             ))
             .build();
 
@@ -94,7 +109,7 @@ public final class BtEventsUtility extends EventsUtility<BtSportType> {
     }
 
     @Override
-    public Optional<Map<String, String>> fetchEventGroupUrls(BtSportType sport) {
+    public Optional<List<EventGroup>> fetchEventGroupUrls(BtSportType sport) {
         return Optional.fromNullable(EVENT_GROUPS_LOOKUP.get(sport));
     }
 

--- a/src/main/java/org/atlasapi/remotesite/opta/events/OptaEventsUtility.java
+++ b/src/main/java/org/atlasapi/remotesite/opta/events/OptaEventsUtility.java
@@ -1,22 +1,29 @@
 package org.atlasapi.remotesite.opta.events;
 
+import java.util.List;
 import java.util.Map;
 
+import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.persistence.topic.TopicStore;
 import org.atlasapi.remotesite.events.EventsUtility;
 import org.atlasapi.remotesite.opta.events.model.OptaSportType;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
-
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableMap;
 
 
 public class OptaEventsUtility extends EventsUtility<OptaSportType> {
     
     private static final String EVENT_URI_BASE = "http://optasports.com/events/";
     private static final String TEAM_URI_BASE = "http://optasports.com/teams/";
+
+    private static final String COMPETITION_NAMESPACE = "com:optasports:competition";
+    private static final Publisher COMPETITION_EVENT_GROUP_PUBLISHER = Publisher.OPTA;
+
     private static final Map<OptaSportType, Duration> DURATION_MAPPING = 
             ImmutableMap.<OptaSportType, Duration>builder()
                 .put(OptaSportType.RUGBY_AVIVA_PREMIERSHIP, Duration.standardMinutes(100))
@@ -183,40 +190,143 @@ public class OptaEventsUtility extends EventsUtility<OptaSportType> {
             .put("Volksparkstadion", "http://dbpedia.org/resources/Volksparkstadion")
             .put("WWK ARENA", "http://dbpedia.org/resources/WWK_ARENA")
             .build();
-    private static final Map<OptaSportType, Map<String, String>> EVENT_GROUPS_LOOKUP = ImmutableMap.<OptaSportType, Map<String, String>>builder()
-            .put(OptaSportType.RUGBY_AVIVA_PREMIERSHIP, ImmutableMap.of(
-                    "English Premiership (rugby union)", "http://dbpedia.org/resources/English_Premiership_(rugby_union)", 
-                    "Rugby Football", "http://dbpedia.org/resources/Rugby_football"
+    private static final Map<OptaSportType, List<EventGroup>> EVENT_GROUPS_LOOKUP = ImmutableMap.
+            <OptaSportType, List<EventGroup>>builder()
+            .put(OptaSportType.RUGBY_AVIVA_PREMIERSHIP, ImmutableList.of(
+                    EventGroup.ofDefaultNs(
+                            "Rugby Football",
+                            "http://dbpedia.org/resources/Rugby_football"
+                    ),
+                    EventGroup.ofDefaultNs(
+                            "English Premiership (rugby union)",
+                            "http://dbpedia.org/resources/English_Premiership_(rugby_union)"
+                    ),
+                    EventGroup.of(
+                            "English Premiership (rugby union)",
+                            COMPETITION_NAMESPACE,
+                            "http://optasports.com/competition/English_Premiership_(rugby_union)",
+                            COMPETITION_EVENT_GROUP_PUBLISHER
+                    )
+                ))
+            .put(OptaSportType.FOOTBALL_SCOTTISH_PREMIER_LEAGUE, ImmutableList.of(
+                    EventGroup.ofDefaultNs(
+                            "Football",
+                            "http://dbpedia.org/resources/Football"
+                    ),
+                    EventGroup.ofDefaultNs(
+                            "Association Football",
+                            "http://dbpedia.org/resources/Association_football"
+                    ),
+                    EventGroup.ofDefaultNs(
+                            "Scottish Premier League",
+                            "http://dbpedia.org/resources/Scottish_Premier_League"
+                    ),
+                    EventGroup.of(
+                            "Scottish Premier League",
+                            COMPETITION_NAMESPACE,
+                            "http://optasports.com/competition/Scottish_Premier_League",
+                            COMPETITION_EVENT_GROUP_PUBLISHER
+                    )
             ))
-            .put(OptaSportType.FOOTBALL_SCOTTISH_PREMIER_LEAGUE, ImmutableMap.of(
-                    "Football", "http://dbpedia.org/resources/Football", 
-                    "Association Football", "http://dbpedia.org/resources/Association_football", 
-                    "Scottish Premier League", "http://dbpedia.org/resources/Scottish_Premier_League"
+            .put(OptaSportType.FOOTBALL_GERMAN_BUNDESLIGA, ImmutableList.of(
+                    EventGroup.ofDefaultNs(
+                            "Football",
+                            "http://dbpedia.org/resources/Football"
+                    ),
+                    EventGroup.ofDefaultNs(
+                            "Association Football",
+                            "http://dbpedia.org/resources/Association_football"
+                    ),
+                    EventGroup.ofDefaultNs(
+                            "German Bundesliga",
+                            "http://dbpedia.org/resources/German_Bundesliga"
+                    ),
+                    EventGroup.of(
+                            "German Bundesliga",
+                            COMPETITION_NAMESPACE,
+                            "http://optasports.com/competition/German_Bundesliga",
+                            COMPETITION_EVENT_GROUP_PUBLISHER
+                    )
             ))
-            .put(OptaSportType.FOOTBALL_GERMAN_BUNDESLIGA, ImmutableMap.of(
-                    "Football", "http://dbpedia.org/resources/Football", 
-                    "Association Football", "http://dbpedia.org/resources/Association_football", 
-                    "German Bundesliga", "http://dbpedia.org/resources/German_Bundesliga"
+            .put(OptaSportType.FOOTBALL_PREMIER_LEAGUE, ImmutableList.of(
+                    EventGroup.ofDefaultNs(
+                            "Football",
+                            "http://dbpedia.org/resources/Football"
+                    ),
+                    EventGroup.ofDefaultNs(
+                            "Association Football",
+                            "http://dbpedia.org/resources/Association_football"
+                    ),
+                    EventGroup.ofDefaultNs(
+                            "Premier League",
+                            "http://dbpedia.org/resources/Premier_League"
+                    ),
+                    EventGroup.of(
+                            "Premier League",
+                            COMPETITION_NAMESPACE,
+                            "http://optasports.com/competition/Premier_League",
+                            COMPETITION_EVENT_GROUP_PUBLISHER
+                    )
             ))
-            .put(OptaSportType.FOOTBALL_PREMIER_LEAGUE, ImmutableMap.of(
-                    "Football", "http://dbpedia.org/resources/Football", 
-                    "Association Football", "http://dbpedia.org/resources/Association_football", 
-                    "Premier League", "http://dbpedia.org/resources/Premier_League"
+            .put(OptaSportType.FOOTBALL_CHAMPIONS_LEAGUE, ImmutableList.of(
+                    EventGroup.ofDefaultNs(
+                            "Football",
+                            "http://dbpedia.org/resources/Football"
+                    ),
+                    EventGroup.ofDefaultNs(
+                            "Association Football",
+                            "http://dbpedia.org/resources/Association_football"
+                    ),
+                    EventGroup.ofDefaultNs(
+                            "UEFA Champions League",
+                            "http://dbpedia.org/resources/UEFA_Champions_League"
+                    ),
+                    EventGroup.of(
+                            "UEFA Champions League",
+                            COMPETITION_NAMESPACE,
+                            "http://optasports.com/competition/UEFA_Champions_League",
+                            COMPETITION_EVENT_GROUP_PUBLISHER
+                    )
             ))
-            .put(OptaSportType.FOOTBALL_CHAMPIONS_LEAGUE, ImmutableMap.of(
-                    "Football", "http://dbpedia.org/resources/Football", 
-                    "Association Football", "http://dbpedia.org/resources/Association_football", 
-                    "UEFA Champions League", "http://dbpedia.org/resources/UEFA_Champions_League"
+            .put(OptaSportType.FOOTBALL_EUROPA_LEAGUE, ImmutableList.of(
+                    EventGroup.ofDefaultNs(
+                            "Football",
+                            "http://dbpedia.org/resources/Football"
+                    ),
+                    EventGroup.ofDefaultNs(
+                            "Association Football",
+                            "http://dbpedia.org/resources/Association_football"
+                    ),
+                    EventGroup.ofDefaultNs(
+                            "UEFA Europa League",
+                            "http://dbpedia.org/resources/UEFA_Europa_League"
+                    ),
+                    EventGroup.of(
+                            "UEFA Europa League",
+                            COMPETITION_NAMESPACE,
+                            "http://optasports.com/competition/UEFA_Europa_League",
+                            COMPETITION_EVENT_GROUP_PUBLISHER
+                    )
             ))
-            .put(OptaSportType.FOOTBALL_EUROPA_LEAGUE, ImmutableMap.of(
-                    "Football", "http://dbpedia.org/resources/Football", 
-                    "Association Football", "http://dbpedia.org/resources/Association_football", 
-                    "UEFA Europa League", "http://dbpedia.org/resources/UEFA_Europa_League"
-            ))
-            .put(OptaSportType.FOOTBALL_FA_CUP, ImmutableMap.of(
-                    "Football", "http://dbpedia.org/resources/Football",
-                    "Association Football", "http://dbpedia.org/resources/Association_football",
-                    "FA Cup", "http://dbpedia.org/resources/FA_Cup"
+            .put(OptaSportType.FOOTBALL_FA_CUP, ImmutableList.of(
+                    EventGroup.ofDefaultNs(
+                            "Football",
+                            "http://dbpedia.org/resources/Football"
+                    ),
+                    EventGroup.ofDefaultNs(
+                            "Association Football",
+                            "http://dbpedia.org/resources/Association_football"
+                    ),
+                    EventGroup.ofDefaultNs(
+                            "FA Cup",
+                            "http://dbpedia.org/resources/FA_Cup"
+                    ),
+                    EventGroup.of(
+                            "FA Cup",
+                            COMPETITION_NAMESPACE,
+                            "http://optasports.com/competition/FA_Cup",
+                            COMPETITION_EVENT_GROUP_PUBLISHER
+                    )
             ))
             .build();
     private final ImmutableMap<OptaSportType, OptaSportConfiguration> config;
@@ -246,8 +356,6 @@ public class OptaEventsUtility extends EventsUtility<OptaSportType> {
      * with a value, and others weren't. So as to reference the 
      * previously-created teams, we'll strip the prefix. This is configured
      * on a sport-by-sport basis; see {@link OptaEventsModule}.
-     * 
-     * @param prefixToStripFromId 
      */
     private String normalizeTeamId(String id, Optional<String> prefixToStrip) {
         if (prefixToStrip.isPresent()
@@ -273,7 +381,7 @@ public class OptaEventsUtility extends EventsUtility<OptaSportType> {
     }
 
     @Override
-    public Optional<Map<String, String>> fetchEventGroupUrls(OptaSportType sport) {
+    public Optional<List<EventGroup>> fetchEventGroupUrls(OptaSportType sport) {
         return Optional.fromNullable(EVENT_GROUPS_LOOKUP.get(sport));
     }
 

--- a/src/test/java/org/atlasapi/remotesite/events/EventsUtilityTest.java
+++ b/src/test/java/org/atlasapi/remotesite/events/EventsUtilityTest.java
@@ -1,22 +1,25 @@
 package org.atlasapi.remotesite.events;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.atlasapi.media.entity.Topic;
 import org.atlasapi.persistence.topic.TopicStore;
 import org.atlasapi.remotesite.opta.events.model.OptaSportType;
+
+import com.metabroadcast.common.base.Maybe;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 import org.joda.time.DateTime;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
-import com.metabroadcast.common.base.Maybe;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 
 public class EventsUtilityTest {
@@ -74,8 +77,10 @@ public class EventsUtilityTest {
     private EventsUtility<OptaSportType> createEventUtil(TopicStore topicStore) {
         return new EventsUtility<OptaSportType>(topicStore) {
             
-            Map<OptaSportType, Map<String, String>> groupMapping = ImmutableMap.of(
-                    OptaSportType.RUGBY_AVIVA_PREMIERSHIP, (Map<String, String>)ImmutableMap.of("Sport", "sport uri")
+            Map<OptaSportType, List<EventGroup>> groupMapping = ImmutableMap.of(
+                    OptaSportType.RUGBY_AVIVA_PREMIERSHIP, (List<EventGroup>) ImmutableList.of(
+                            EventGroup.ofDefaultNs("Sport", "sport uri")
+                    )
             );
             
             @Override
@@ -97,7 +102,7 @@ public class EventsUtilityTest {
             }
             
             @Override
-            public Optional<Map<String, String>> fetchEventGroupUrls(OptaSportType sport) {
+            public Optional<List<EventGroup>> fetchEventGroupUrls(OptaSportType sport) {
                 return Optional.fromNullable(groupMapping.get(sport));
             }
         };


### PR DESCRIPTION
- This is so that API users can distinguish which event group
contains the competition title by its namespace