### PR TITLE
Fix logic for MPX images and descriptions aliases

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodModule.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodModule.java
@@ -70,8 +70,10 @@ public class BtVodModule {
             BT_VOD_NAMESPACES_PREFIX + "id:%s:%s";
     private static final String BT_VOD_SYNTHESISED_FROM_ID_ALIAS_NAMESPACE_FORMAT =
             BT_VOD_NAMESPACES_PREFIX + "synthesisedFrom:id:%s:%s";
-    private static final String BT_VOD_DESCRIPTIONS_GUID_ALIAS_NAMESPACE_FORMAT =
-            BT_VOD_NAMESPACES_PREFIX + "descriptions:guid:%s:%s";
+    private static final String BT_VOD_DESCRIPTION_GUID_ALIAS_NAMESPACE_FORMAT =
+            BT_VOD_NAMESPACES_PREFIX + "description:guid:%s:%s";
+    private static final String BT_VOD_LONG_DESCRIPTION_GUID_ALIAS_NAMESPACE_FORMAT =
+            BT_VOD_NAMESPACES_PREFIX + "longDescription:guid:%s:%s";
     private static final String BT_VOD_IMAGES_GUID_ALIAS_NAMESPACE_FORMAT =
             BT_VOD_NAMESPACES_PREFIX + "images:guid:%s:%s";
 
@@ -225,7 +227,12 @@ public class BtVodModule {
                 BtVodEntryMatchingPredicates.schedulerChannelPredicate(KIDS_CATEGORY),
                 new BtVodTagMap(topicStore, new MongoSequentialIdGenerator(mongo, "topics")),
                 String.format(
-                        BT_VOD_DESCRIPTIONS_GUID_ALIAS_NAMESPACE_FORMAT,
+                        BT_VOD_DESCRIPTION_GUID_ALIAS_NAMESPACE_FORMAT,
+                        BT_VOD_UPDATER_ENV,
+                        BT_VOD_UPDATER_CONFIG
+                ),
+                String.format(
+                        BT_VOD_LONG_DESCRIPTION_GUID_ALIAS_NAMESPACE_FORMAT,
                         BT_VOD_UPDATER_ENV,
                         BT_VOD_UPDATER_CONFIG
                 ),
@@ -346,7 +353,8 @@ public class BtVodModule {
                 topicQueryResolver,
                 BtVodEntryMatchingPredicates.schedulerChannelPredicate(KIDS_CATEGORY),
                 new BtVodTagMap(topicStore, new MongoSequentialIdGenerator(mongo, "topics")),
-                String.format(BT_VOD_DESCRIPTIONS_GUID_ALIAS_NAMESPACE_FORMAT, envName, conf),
+                String.format(BT_VOD_DESCRIPTION_GUID_ALIAS_NAMESPACE_FORMAT, envName, conf),
+                String.format(BT_VOD_LONG_DESCRIPTION_GUID_ALIAS_NAMESPACE_FORMAT, envName, conf),
                 String.format(BT_VOD_IMAGES_GUID_ALIAS_NAMESPACE_FORMAT, envName, conf)
         ).withName(
                 String.format(

--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodUpdater.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodUpdater.java
@@ -47,7 +47,8 @@ public class BtVodUpdater extends ScheduledTask {
     private final BtVodEntryMatchingPredicate kidsPredicate;
     private final BtVodTagMap btVodTagMap;
 
-    private final String btVodDescriptionsGuidAliasNamespace;
+    private final String btVodDescriptionGuidAliasNamespace;
+    private final String btVodLongDescriptionGuidAliasNamespace;
     private final String btVodImagesGuidAliasNamespace;
 
     public BtVodUpdater(
@@ -69,7 +70,8 @@ public class BtVodUpdater extends ScheduledTask {
             TopicQueryResolver topicQueryResolver,
             BtVodEntryMatchingPredicate kidsPredicate,
             BtVodTagMap btVodTagMap,
-            String btVodDescriptionsGuidAliasNamespace,
+            String btVodDescriptionGuidAliasNamespace,
+            String btVodLongDescriptionsGuidAliasNamespace,
             String btVodImagesGuidAliasNamespace
     ) {
         this.contentWriter = checkNotNull(contentWriter);
@@ -90,7 +92,10 @@ public class BtVodUpdater extends ScheduledTask {
         this.topicQueryResolver = checkNotNull(topicQueryResolver);
         this.kidsPredicate = checkNotNull(kidsPredicate);
         this.btVodTagMap = checkNotNull(btVodTagMap);
-        this.btVodDescriptionsGuidAliasNamespace = checkNotNull(btVodDescriptionsGuidAliasNamespace);
+        this.btVodDescriptionGuidAliasNamespace =
+                checkNotNull(btVodDescriptionGuidAliasNamespace);
+        this.btVodLongDescriptionGuidAliasNamespace =
+                checkNotNull(btVodLongDescriptionsGuidAliasNamespace);
         this.btVodImagesGuidAliasNamespace = checkNotNull(btVodImagesGuidAliasNamespace);
     }
 
@@ -187,7 +192,8 @@ public class BtVodUpdater extends ScheduledTask {
                 brandExtractor.getProcessedBrands(),
                 brandExtractor.getParentGuidToBrand(),
                 new HierarchyDescriptionAndImageUpdater(
-                        btVodDescriptionsGuidAliasNamespace,
+                        btVodDescriptionGuidAliasNamespace,
+                        btVodLongDescriptionGuidAliasNamespace,
                         btVodImagesGuidAliasNamespace
                 ),
                 new CertificateUpdater(),
@@ -285,7 +291,8 @@ public class BtVodUpdater extends ScheduledTask {
                 synthesizedSeriesExtractor.getSynthesizedSeries(),
                 seriesUriExtractor,
                 new HierarchyDescriptionAndImageUpdater(
-                        btVodDescriptionsGuidAliasNamespace,
+                        btVodDescriptionGuidAliasNamespace,
+                        btVodLongDescriptionGuidAliasNamespace,
                         btVodImagesGuidAliasNamespace
                 ),
                 new CertificateUpdater(),


### PR DESCRIPTION
- The description, long description and images of a brand or series
could have come from different items so we should have separate aliases
for each
- The decision of which images and descriptions a content
should have is taken elsewhere. Therefore when an update source comes
that has the same priority as the existing source we should check the
actual metadata has changed before applying it and updating the alias