### PR TITLE
Create canonical URIs for Films based on their prodId rather than RT

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/pa/PaHelper.java
+++ b/src/main/java/org/atlasapi/remotesite/pa/PaHelper.java
@@ -9,7 +9,9 @@ public class PaHelper {
     private static final String RT_FILM_ALIAS = "rt:filmid";
     
     public static String getFilmUri(String id) {
-        return PA_BASE_URL + "films/" + id;
+        //previously film ids were generated from rtfilmnumber, now we will be using progId
+        //since they have different numberspace, we will save films under /episode/progId
+        return getEpisodeUri(id);
     }
     
     public static Alias getProgIdAlias(String id) {
@@ -29,7 +31,11 @@ public class PaHelper {
     public static String getEpisodeUri(String id) {
         return PA_BASE_URL + "episodes/" + id;
     }
-    
+
+    public static String getFilmRtAlias(String rtFilmNumber) {
+        return PA_BASE_URL + "films/" + rtFilmNumber;
+    }
+
     public static Alias getEpisodeAlias(String id) {
         return new Alias(PA_BASE_ALIAS + "episode", id);
     }
@@ -58,9 +64,10 @@ public class PaHelper {
         return new Alias(PA_BASE_ALIAS + "series", id + "-" + seriesNumber);
     }
     
-    public static String getFilmCurie(String id) {
-        return "pa:f-" + id;
+    public static String getEpisodeCurie(String id) {
+        return "pa:e-" + id;
     }
+
     
     public static String getBroadcastId(String slotId) {
         return "pa:" + slotId;

--- a/src/main/java/org/atlasapi/remotesite/pa/PaProgrammeProcessor.java
+++ b/src/main/java/org/atlasapi/remotesite/pa/PaProgrammeProcessor.java
@@ -486,33 +486,22 @@ public class PaProgrammeProcessor implements PaProgDataProcessor, PaProgDataUpda
     }
 
     private Item getBasicFilmWithoutBroadcast(ProgData progData, DateTimeZone zone, Timestamp updatedAt) {
-        String rtFilmAlias = PaHelper.getFilmRtAlias(progData.getRtFilmnumber());
+        String filmAlias = PaHelper.getAlias(progData.getProgId());
         String filmUri = PaHelper.getFilmUri(identifierFor(progData));
-        ResolvedContent possiblePreviousData = contentResolver.findByCanonicalUris(ImmutableList.of(rtFilmAlias, filmUri));
+        Maybe<Identified> possiblePreviousData = contentResolver.findByUris(ImmutableList.of(
+                filmAlias,
+                filmUri
+        )).getFirstValue();
 
         Film film;
-        Maybe<Identified> oldFilm = possiblePreviousData.get(rtFilmAlias);
-        Maybe<Identified> newFilm = possiblePreviousData.get(filmUri);
-        if (oldFilm.hasValue()) {
-            Identified previous = oldFilm.requireValue();
+        if (possiblePreviousData.hasValue()) {
+            Identified previous = possiblePreviousData.requireValue();
             if (previous instanceof Film) {
                 film = (Film) previous;
             } else {
                 film = new Film();
                 Item.copyTo((Episode) previous, film);
             }
-            film.addAlias(PaHelper.getProgIdAlias(progData.getProgId()));
-            film.addAliasUrl(filmUri);
-        } else if (newFilm.hasValue()) {
-            Identified previous = newFilm.requireValue();
-            if (previous instanceof Film) {
-                film = (Film) previous;
-            } else {
-                film = new Film();
-                Item.copyTo((Episode) previous, film);
-            }
-            film.addAlias(PaHelper.getProgIdAlias(progData.getProgId()));
-            film.addAliasUrl(rtFilmAlias);
         } else {
             film = getBasicFilm(progData);
         }
@@ -849,8 +838,6 @@ public class PaProgrammeProcessor implements PaProgDataProcessor, PaProgDataUpda
     
     private Film getBasicFilm(ProgData progData) {
         Film film = new Film(PaHelper.getFilmUri(identifierFor(progData)), PaHelper.getEpisodeCurie(identifierFor(progData)), Publisher.PA);
-        film.addAliasUrl(PaHelper.getFilmRtAlias(progData.getRtFilmnumber()));
-        film.addAlias(PaHelper.getProgIdAlias(progData.getProgId()));
         setBasicDetails(progData, film);
         
         return film;

--- a/src/test/java/org/atlasapi/remotesite/pa/PaProgrammeProcessorTest.java
+++ b/src/test/java/org/atlasapi/remotesite/pa/PaProgrammeProcessorTest.java
@@ -297,7 +297,7 @@ public class PaProgrammeProcessorTest {
 
         when(contentResolver.findByCanonicalUris(ImmutableList.of(brandUri)))
                 .thenReturn(ResolvedContent.builder().build());
-        when(contentResolver.findByCanonicalUris(ImmutableList.of(PaHelper.getFilmRtAlias("5"), expectedUri)))
+        when(contentResolver.findByUris(ImmutableList.of("http://pressassociation.com/1", expectedUri)))
                 .thenReturn(ResolvedContent.builder().build());
 
         String expectedTitle = "Prog title";
@@ -329,7 +329,7 @@ public class PaProgrammeProcessorTest {
 
         when(contentResolver.findByCanonicalUris(ImmutableList.of(brandUri)))
                 .thenReturn(ResolvedContent.builder().build());
-        setupContentResolverForFilm(film, PaHelper.getFilmRtAlias("5"));
+        setupContentResolverForFilm(film, "http://pressassociation.com/1");
 
         String expectedTitle = "Prog title";
         String expectedDescription = "Prog description";
@@ -360,7 +360,7 @@ public class PaProgrammeProcessorTest {
 
         when(contentResolver.findByCanonicalUris(ImmutableList.of(brandUri)))
                 .thenReturn(ResolvedContent.builder().build());
-        setupContentResolverForFilm(film, PaHelper.getFilmRtAlias("5"));
+        setupContentResolverForFilm(film, "http://pressassociation.com/1");
 
         ProgData progData = setupProgFilm("Prog title", "Prog description");
 
@@ -383,7 +383,7 @@ public class PaProgrammeProcessorTest {
 
         when(contentResolver.findByCanonicalUris(ImmutableList.of(brandUri)))
                 .thenReturn(ResolvedContent.builder().build());
-        when(contentResolver.findByCanonicalUris(ImmutableList.of(PaHelper.getFilmRtAlias("5"), expectedUri)))
+        when(contentResolver.findByUris(ImmutableList.of("http://pressassociation.com/1", expectedUri)))
                 .thenReturn(ResolvedContent.builder().build());
 
         ProgData progData = setupProgFilm("Prog title", "Prog description");
@@ -435,9 +435,9 @@ public class PaProgrammeProcessorTest {
         String brandUri = "http://pressassociation.com/brands/5";
         when(contentResolver.findByCanonicalUris(ImmutableList.of(brandUri)))
                 .thenReturn(ResolvedContent.builder().build());
-        when(contentResolver.findByCanonicalUris(ImmutableList.of(
-                    "http://pressassociation.com/films/5",
-                    "http://pressassociation.com/episodes/1"
+        when(contentResolver.findByUris(ImmutableList.of(
+                "http://pressassociation.com/1",
+                "http://pressassociation.com/episodes/1"
                 ))).thenReturn(ResolvedContent.builder().build());
 
         Optional<ContentHierarchyWithoutBroadcast> processed = progProcessor.process(
@@ -465,8 +465,8 @@ public class PaProgrammeProcessorTest {
 
         when(contentResolver.findByCanonicalUris(ImmutableList.of(brandUri)))
                 .thenReturn(ResolvedContent.builder().build());
-        when(contentResolver.findByCanonicalUris(ImmutableList.of(
-                "http://pressassociation.com/films/5",
+        when(contentResolver.findByUris(ImmutableList.of(
+                "http://pressassociation.com/1",
                 "http://pressassociation.com/episodes/1"
         ))).thenReturn(ResolvedContent.builder()
                 .put("http://pressassociation.com/films/5", film)
@@ -500,8 +500,8 @@ public class PaProgrammeProcessorTest {
 
         when(contentResolver.findByCanonicalUris(ImmutableList.of(brandUri)))
                 .thenReturn(ResolvedContent.builder().build());
-        when(contentResolver.findByCanonicalUris(ImmutableList.of(
-                "http://pressassociation.com/films/5",
+        when(contentResolver.findByUris(ImmutableList.of(
+                "http://pressassociation.com/1",
                 "http://pressassociation.com/episodes/1"
         ))).thenReturn(ResolvedContent.builder()
                 .put("http://pressassociation.com/episodes/1", film)
@@ -520,6 +520,42 @@ public class PaProgrammeProcessorTest {
         assertThat(written.getAliases(), hasItem(new Alias("gb:pressassociation:prod:prog_id","1")));
 
     }
+
+    @Test
+    public void testResolvesFilmByAlias() {
+        Channel channel = new Channel(METABROADCAST, "c", "c", true, VIDEO, "c");
+        ProgData progData = setupProgFilm("title", "film");
+
+        Film film = new Film();
+        Version version = new Version();
+        version.setProvider(Publisher.PA);
+        film.addVersion(version);
+
+        String brandUri = "http://pressassociation.com/brands/5";
+
+        when(contentResolver.findByCanonicalUris(ImmutableList.of(brandUri)))
+                .thenReturn(ResolvedContent.builder().build());
+        when(contentResolver.findByUris(ImmutableList.of(
+                "http://pressassociation.com/1",
+                "http://pressassociation.com/episodes/1"
+        ))).thenReturn(ResolvedContent.builder()
+                .put("http://pressassociation.com/episodes/1", film)
+                .build()
+        );
+
+        Optional<ContentHierarchyAndSummaries> processed = progProcessor.process(
+                progData,
+                channel,
+                UTC,
+                Timestamp.of(0)
+        );
+
+        Item written = processed.get().getItem();
+
+        assertThat(written.getAliases(), hasItem(new Alias("gb:pressassociation:prod:prog_id","1")));
+        assertThat(written.getAliasUrls(), hasItem("http://pressassociation.com/1"));
+    }
+
 
     private ProgData setupProgData() {
         ProgData inputProgData = new ProgData();
@@ -599,7 +635,7 @@ public class PaProgrammeProcessorTest {
     }
 
     private void setupContentResolverForFilm(Identified film, String alias) {
-        when(contentResolver.findByCanonicalUris(ImmutableList.of(alias, film.getCanonicalUri())))
+        when(contentResolver.findByUris(ImmutableList.of(alias, film.getCanonicalUri())))
                 .thenReturn(ResolvedContent.builder()
                         .put(film.getCanonicalUri(), film)
                         .build()

--- a/src/test/java/org/atlasapi/remotesite/pa/PaProgrammeProcessorTest.java
+++ b/src/test/java/org/atlasapi/remotesite/pa/PaProgrammeProcessorTest.java
@@ -3,9 +3,11 @@ package org.atlasapi.remotesite.pa;
 import java.util.Iterator;
 
 import org.atlasapi.media.channel.Channel;
+import org.atlasapi.media.entity.Alias;
 import org.atlasapi.media.entity.Brand;
 import org.atlasapi.media.entity.Broadcast;
 import org.atlasapi.media.entity.Described;
+import org.atlasapi.media.entity.Episode;
 import org.atlasapi.media.entity.Film;
 import org.atlasapi.media.entity.Identified;
 import org.atlasapi.media.entity.Image;
@@ -19,6 +21,7 @@ import org.atlasapi.persistence.content.ContentWriter;
 import org.atlasapi.persistence.content.ResolvedContent;
 import org.atlasapi.persistence.logging.AdapterLog;
 import org.atlasapi.persistence.logging.NullAdapterLog;
+import org.atlasapi.remotesite.pa.archives.ContentHierarchyWithoutBroadcast;
 import org.atlasapi.remotesite.pa.listings.bindings.Attr;
 import org.atlasapi.remotesite.pa.listings.bindings.Billing;
 import org.atlasapi.remotesite.pa.listings.bindings.Billings;
@@ -30,6 +33,7 @@ import org.atlasapi.remotesite.pa.listings.bindings.Season;
 import com.metabroadcast.common.base.Maybe;
 import com.metabroadcast.common.time.Timestamp;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -200,7 +204,7 @@ public class PaProgrammeProcessorTest {
 
     @Test
     public void testPaSummaries() {
-        Film film = new Film("http://pressassociation.com/films/5", "pa:f-5", Publisher.PA);
+        Episode film = new Episode("http://pressassociation.com/episodes/1", "pa:f-5", Publisher.PA);
 
         Brand expectedItemBrand = new Brand("http://pressassociation.com/brands/5", "pa:b-5", Publisher.PA);
         Series expectedItemSeries= new Series("http://pressassociation.com/series/5-6", "pa:s-5-6", Publisher.PA);
@@ -228,14 +232,14 @@ public class PaProgrammeProcessorTest {
 
     @Test
     public void testDoesntSetGenericDescriptionFlagIfNotGeneric() {
-        Film film = new Film("http://pressassociation.com/films/5", "pa:f-5", Publisher.PA);
+        Episode episode = new Episode("http://pressassociation.com/episodes/1", "pa:f-5", Publisher.PA);
         Version version = new Version();
         version.setProvider(Publisher.PA);
-        film.addVersion(version);
+        episode.addVersion(version);
         
         Brand expectedItemBrand = new Brand("http://pressassociation.com/brands/5", "pa:b-5", Publisher.PA);
         Series expectedItemSeries= new Series("http://pressassociation.com/series/5-6", "pa:s-5-6", Publisher.PA);
-        setupContentResolver(ImmutableSet.<Identified>of(film, expectedItemBrand, expectedItemSeries));
+        setupContentResolver(ImmutableSet.<Identified>of(episode, expectedItemBrand, expectedItemSeries));
         
         ProgData progData = setupProgData();
         progData.setGeneric(null);
@@ -247,14 +251,14 @@ public class PaProgrammeProcessorTest {
 
     @Test
     public void testSetsGenericDescriptionFlagIfGeneric() {
-        Film film = new Film("http://pressassociation.com/films/5", "pa:f-5", Publisher.PA);
+        Episode episode = new Episode("http://pressassociation.com/episodes/1", "pa:f-5", Publisher.PA);
         Version version = new Version();
         version.setProvider(Publisher.PA);
-        film.addVersion(version);
+        episode.addVersion(version);
         
         Brand expectedItemBrand = new Brand("http://pressassociation.com/brands/5", "pa:b-5", Publisher.PA);
         Series expectedItemSeries= new Series("http://pressassociation.com/series/5-6", "pa:s-5-6", Publisher.PA);
-        setupContentResolver(ImmutableSet.<Identified>of(film, expectedItemBrand, expectedItemSeries));
+        setupContentResolver(ImmutableSet.<Identified>of(episode, expectedItemBrand, expectedItemSeries));
         
         ProgData progData = setupProgData();
         progData.setGeneric("1");
@@ -265,14 +269,14 @@ public class PaProgrammeProcessorTest {
 
     @Test
     public void testSetsRepeatFlagFromRevisedRepeat() {
-        Film film = new Film("http://pressassociation.com/films/5", "pa:f-5", Publisher.PA);
+        Episode episode = new Episode("http://pressassociation.com/episodes/1", "pa:f-5", Publisher.PA);
         Version version = new Version();
         version.setProvider(Publisher.PA);
-        film.addVersion(version);
+        episode.addVersion(version);
 
         Brand expectedItemBrand = new Brand("http://pressassociation.com/brands/5", "pa:b-5", Publisher.PA);
         Series expectedItemSeries= new Series("http://pressassociation.com/series/5-6", "pa:s-5-6", Publisher.PA);
-        setupContentResolver(ImmutableSet.<Identified>of(film, expectedItemBrand, expectedItemSeries));
+        setupContentResolver(ImmutableSet.<Identified>of(episode, expectedItemBrand, expectedItemSeries));
 
         ProgData progData = setupProgData();
         progData.getAttr().setRevisedRepeat("yes");
@@ -289,11 +293,11 @@ public class PaProgrammeProcessorTest {
     @Test
     public void testGetTitleAndDescriptionForNewFilm() throws Exception {
         String brandUri = "http://pressassociation.com/brands/5";
-        String expectedUri = "http://pressassociation.com/films/5";
+        String expectedUri = "http://pressassociation.com/episodes/1";
 
         when(contentResolver.findByCanonicalUris(ImmutableList.of(brandUri)))
                 .thenReturn(ResolvedContent.builder().build());
-        when(contentResolver.findByCanonicalUris(ImmutableList.of(expectedUri)))
+        when(contentResolver.findByCanonicalUris(ImmutableList.of(PaHelper.getFilmRtAlias("5"), expectedUri)))
                 .thenReturn(ResolvedContent.builder().build());
 
         String expectedTitle = "Prog title";
@@ -315,7 +319,7 @@ public class PaProgrammeProcessorTest {
             throws Exception {
         String brandUri = "http://pressassociation.com/brands/5";
 
-        Film film = new Film("http://pressassociation.com/films/5", "pa:f-5", Publisher.PA);
+        Film film = new Film("http://pressassociation.com/episodes/1", "pa:f-5", Publisher.PA);
         film.setTitle("title");
         film.setDescription("description");
 
@@ -325,7 +329,7 @@ public class PaProgrammeProcessorTest {
 
         when(contentResolver.findByCanonicalUris(ImmutableList.of(brandUri)))
                 .thenReturn(ResolvedContent.builder().build());
-        setupContentResolver(ImmutableList.<Identified>of(film));
+        setupContentResolverForFilm(film, PaHelper.getFilmRtAlias("5"));
 
         String expectedTitle = "Prog title";
         String expectedDescription = "Prog description";
@@ -346,7 +350,7 @@ public class PaProgrammeProcessorTest {
             throws Exception {
         String brandUri = "http://pressassociation.com/brands/5";
 
-        Film film = new Film("http://pressassociation.com/films/5", "pa:f-5", Publisher.PA);
+        Film film = new Film("http://pressassociation.com/episodes/1", "pa:f-5", Publisher.PA);
         film.setTitle("title");
         film.setDescription("description");
 
@@ -356,7 +360,7 @@ public class PaProgrammeProcessorTest {
 
         when(contentResolver.findByCanonicalUris(ImmutableList.of(brandUri)))
                 .thenReturn(ResolvedContent.builder().build());
-        setupContentResolver(ImmutableList.<Identified>of(film));
+        setupContentResolverForFilm(film, PaHelper.getFilmRtAlias("5"));
 
         ProgData progData = setupProgFilm("Prog title", "Prog description");
 
@@ -375,11 +379,11 @@ public class PaProgrammeProcessorTest {
     @Test
     public void testCreateBroadcastFromProgData() throws Exception {
         String brandUri = "http://pressassociation.com/brands/5";
-        String expectedUri = "http://pressassociation.com/films/5";
+        String expectedUri = "http://pressassociation.com/episodes/1";
 
         when(contentResolver.findByCanonicalUris(ImmutableList.of(brandUri)))
                 .thenReturn(ResolvedContent.builder().build());
-        when(contentResolver.findByCanonicalUris(ImmutableList.of(expectedUri)))
+        when(contentResolver.findByCanonicalUris(ImmutableList.of(PaHelper.getFilmRtAlias("5"), expectedUri)))
                 .thenReturn(ResolvedContent.builder().build());
 
         ProgData progData = setupProgFilm("Prog title", "Prog description");
@@ -425,6 +429,98 @@ public class PaProgrammeProcessorTest {
         assertThat(broadcast.getLastUpdated(), is(updatedAt.toDateTimeUTC()));
     }
 
+    @Test
+    public void testExtractsNewFilmWithEpisodeUri() {
+        ProgData progData = setupProgFilm("title", "description");
+        String brandUri = "http://pressassociation.com/brands/5";
+        when(contentResolver.findByCanonicalUris(ImmutableList.of(brandUri)))
+                .thenReturn(ResolvedContent.builder().build());
+        when(contentResolver.findByCanonicalUris(ImmutableList.of(
+                    "http://pressassociation.com/films/5",
+                    "http://pressassociation.com/episodes/1"
+                ))).thenReturn(ResolvedContent.builder().build());
+
+        Optional<ContentHierarchyWithoutBroadcast> processed = progProcessor.process(
+                progData,
+                UTC,
+                Timestamp.of(0)
+        );
+
+        Item item =  processed.get().getItem();
+
+        assertThat(item.getCanonicalUri(), is("http://pressassociation.com/episodes/1"));
+        assertThat(item.getCurie(), is("pa:e-1"));
+        assertThat(item.getAliases(), hasItem(new Alias("gb:pressassociation:prod:prog_id","1")));
+    }
+
+    @Test
+    public void testAddsEpisodesAliasForFilmWithRtFilmNumberUri() {
+        ProgData progData = setupProgFilm("title","desc");
+        String brandUri = "http://pressassociation.com/brands/5";
+        Film film = new Film("http://pressassociation.com/films/5", "pa:f-5", Publisher.PA);
+        Version version = new Version();
+        version.setProvider(Publisher.PA);
+        film.addVersion(version);
+
+
+        when(contentResolver.findByCanonicalUris(ImmutableList.of(brandUri)))
+                .thenReturn(ResolvedContent.builder().build());
+        when(contentResolver.findByCanonicalUris(ImmutableList.of(
+                "http://pressassociation.com/films/5",
+                "http://pressassociation.com/episodes/1"
+        ))).thenReturn(ResolvedContent.builder()
+                .put("http://pressassociation.com/films/5", film)
+                .build()
+        );
+
+        Optional<ContentHierarchyAndSummaries> processed = progProcessor.process(
+                progData,
+                channel,
+                UTC,
+                Timestamp.of(0)
+        );
+
+        Item written = processed.get().getItem();
+
+        assertThat(written.getAliases(), hasItem(new Alias("gb:pressassociation:prod:prog_id","1")));
+
+    }
+
+    @Test
+    public void testAddsRtFilmNumberAliasForFilmWithEpisodesUri() {
+        Channel channel = new Channel(METABROADCAST, "c", "c", true, VIDEO, "c");
+        ProgData progData = setupProgFilm("title", "film");
+
+        Film film = new Film("http://pressassociation.com/episodes/1", "pa:e-1", Publisher.PA);
+        Version version = new Version();
+        version.setProvider(Publisher.PA);
+        film.addVersion(version);
+
+        String brandUri = "http://pressassociation.com/brands/5";
+
+        when(contentResolver.findByCanonicalUris(ImmutableList.of(brandUri)))
+                .thenReturn(ResolvedContent.builder().build());
+        when(contentResolver.findByCanonicalUris(ImmutableList.of(
+                "http://pressassociation.com/films/5",
+                "http://pressassociation.com/episodes/1"
+        ))).thenReturn(ResolvedContent.builder()
+                .put("http://pressassociation.com/episodes/1", film)
+                .build()
+        );
+
+        Optional<ContentHierarchyAndSummaries> processed = progProcessor.process(
+                progData,
+                channel,
+                UTC,
+                Timestamp.of(0)
+        );
+
+        Item written = processed.get().getItem();
+
+        assertThat(written.getAliases(), hasItem(new Alias("gb:pressassociation:prod:prog_id","1")));
+
+    }
+
     private ProgData setupProgData() {
         ProgData inputProgData = new ProgData();
 
@@ -435,7 +531,7 @@ public class PaProgrammeProcessorTest {
         inputProgData.setTime("11:40");
         Attr threeDAttr = new Attr();
         threeDAttr.setThreeD("yes");
-        threeDAttr.setFilm("yes");
+        threeDAttr.setFilm("no");
         inputProgData.setAttr(threeDAttr);
         inputProgData.setSeriesSummary("This is the series summary!");
         Season season = new Season();
@@ -500,5 +596,13 @@ public class PaProgrammeProcessorTest {
                         );
             }
         }
+    }
+
+    private void setupContentResolverForFilm(Identified film, String alias) {
+        when(contentResolver.findByCanonicalUris(ImmutableList.of(alias, film.getCanonicalUri())))
+                .thenReturn(ResolvedContent.builder()
+                        .put(film.getCanonicalUri(), film)
+                        .build()
+                );
     }
 }


### PR DESCRIPTION
film number. Resolving existing content uses both URI styles to avoid
creating duplicate content. Aliases of the alternate style is added to
the content.