### PR TITLE
Handle availabilities and versions disappearing in Nitro.

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/ContentMerger.java
+++ b/src/main/java/org/atlasapi/remotesite/ContentMerger.java
@@ -1,42 +1,49 @@
 package org.atlasapi.remotesite;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
+import javax.annotation.Nullable;
+
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Content;
+import org.atlasapi.media.entity.Encoding;
 import org.atlasapi.media.entity.Episode;
 import org.atlasapi.media.entity.Film;
 import org.atlasapi.media.entity.Identified;
 import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Location;
+import org.atlasapi.media.entity.Policy;
 import org.atlasapi.media.entity.Series;
 import org.atlasapi.media.entity.TopicRef;
 import org.atlasapi.media.entity.Version;
-import org.joda.time.Duration;
 
 import com.google.common.base.Equivalence;
 import com.google.common.base.Function;
+import com.google.common.base.Objects;
+import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import org.joda.time.Duration;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class ContentMerger {
 
-    private static interface TopicMergeStrategy {
+    interface TopicMergeStrategy {
         Content mergeTopics(Content current, Content extracted);
     }
 
-    private static interface VersionMergeStrategy {
+    interface VersionMergeStrategy {
         Content mergeVersions(Content current, Content extracted);
     }
     
-    static interface AliasMergeStrategy {
+    interface AliasMergeStrategy {
         Item mergeAliases(Item current, Item extracted);
     }
 
@@ -46,6 +53,7 @@ public class ContentMerger {
         public static final LeaveEverythingAlone KEEP = new LeaveEverythingAlone();
         public static final ReplaceEverything REPLACE = new ReplaceEverything();
         public static final StandardMerge MERGE = new StandardMerge();
+        public static final BbcNitroRevokingMerge NITRO_VERSIONS_REVOKE = new BbcNitroRevokingMerge();
 
         public static ReplaceTopicsBasedOnEquivalence replaceTopicsBasedOn(final Equivalence<TopicRef> equivalence) {
             Preconditions.checkNotNull(equivalence);
@@ -238,9 +246,11 @@ public class ContentMerger {
         @Override
         public Content mergeVersions(Content current, Content extracted) {
             Map<String, Version> mergedVersions = Maps.newHashMap();
+
             for (Version version : current.getVersions()) {
                 mergedVersions.put(version.getCanonicalUri(), version);
             }
+
             for (Version version : extracted.getVersions()) {
                 if (mergedVersions.containsKey(version.getCanonicalUri())) {
                     Version mergedVersion = mergedVersions.get(version.getCanonicalUri());
@@ -277,6 +287,193 @@ public class ContentMerger {
                     )
             );
             return current;
+        }
+    }
+
+    private static class BbcNitroRevokingMerge implements VersionMergeStrategy {
+
+        @Override
+        public Content mergeVersions(Content current, Content extracted) {
+            ImmutableMap<String, Version> currVersions = makeUriIndex(current.getVersions());
+            ImmutableMap<String, Version> newVersions = makeUriIndex(extracted.getVersions());
+
+            Map<String, Version> mergedVersions = Maps.newHashMap();
+
+            mergedVersions.putAll(invalidateDeletedVersions(currVersions, newVersions));
+
+            for (Version newVersion : extracted.getVersions()) {
+                if (currVersions.containsKey(newVersion.getCanonicalUri())) {
+                    // updated version, merge it
+                    Version currVersion = currVersions.get(newVersion.getCanonicalUri());
+
+                    mergedVersions.put(
+                            newVersion.getCanonicalUri(),
+                            mergeUpdatedVersions(newVersion, currVersion)
+                    );
+                } else {
+                    // new Version that's not in DB, just add in
+                    mergedVersions.put(newVersion.getCanonicalUri(), newVersion);
+                }
+            }
+
+            current.setVersions(Sets.newHashSet(mergedVersions.values()));
+
+            return current;
+        }
+
+        private Version mergeUpdatedVersions(Version newVersion, Version mergedVersion) {
+            mergedVersion.setBroadcasts(Sets.union(newVersion.getBroadcasts(), mergedVersion.getBroadcasts()));
+            mergedVersion.setRestriction(newVersion.getRestriction());
+
+            if (newVersion.getDuration() != null) {
+                mergedVersion.setDuration(Duration.standardSeconds(newVersion.getDuration()));
+            } else {
+                mergedVersion.setDuration(null);
+            }
+
+            mergedVersion.setManifestedAs(mergeEncodings(
+                    mergedVersion.getManifestedAs(),
+                    newVersion.getManifestedAs()
+            ));
+
+            return mergedVersion;
+        }
+
+        private Map<String, Version> invalidateDeletedVersions(
+                ImmutableMap<String, Version> currVersions,
+                ImmutableMap<String, Version> newVersions
+        ) {
+            Map<String, Version> result = Maps.newHashMap();
+
+            for (Map.Entry<String, Version> currVersionEntry : currVersions.entrySet()) {
+                if (!newVersions.containsKey(currVersionEntry.getKey())) {
+                    // the version got deleted without properly revoking, invalidate all locations
+                    Version version = currVersionEntry.getValue();
+                    for (Encoding encoding : version.getManifestedAs()) {
+                        for (Location location : encoding.getAvailableAt()) {
+                            location.setAvailable(false);
+                        }
+                    }
+                    result.put(currVersionEntry.getKey(), version);
+                }
+            }
+
+            return result;
+        }
+
+        private ImmutableMap<String, Version> makeUriIndex(Iterable<Version> versions) {
+            return Maps.uniqueIndex(
+                    versions,
+                    new Function<Version, String>() {
+
+                        @Override
+                        public String apply(Version input) {
+                            return input.getCanonicalUri();
+                        }
+                    }
+            );
+        }
+
+        private Set<Encoding> mergeEncodings(Set<Encoding> old, Set<Encoding> ingested) {
+            Set<Encoding> result = Sets.newHashSet();
+
+            // blats out locations on all old encodings that are not present in the ingested set
+            revokeDeletedEncodings(old, ingested);
+
+            for (Encoding ingestedEncoding : ingested) {
+                Optional<Encoding> oldEncoding = findEqualEncoding(ingestedEncoding, old);
+                if (oldEncoding.isPresent()) {
+                    result.add(mergeAndRevokeLocations(oldEncoding.get(), ingestedEncoding));
+                } else {
+                    result.add(ingestedEncoding);
+                }
+            }
+
+            return result;
+        }
+
+        private void revokeDeletedEncodings(Set<Encoding> old, Set<Encoding> ingested) {
+            for (Encoding oldEncoding : old) {
+                Optional<Encoding> ingestedEncoding = findEqualEncoding(oldEncoding, ingested);
+                if (!ingestedEncoding.isPresent()) {
+                    for (Location location : oldEncoding.getAvailableAt()) {
+                        location.setAvailable(false);
+                    }
+                }
+            }
+        }
+
+        private Optional<Encoding> findEqualEncoding(Encoding needle, Set<Encoding> hay) {
+            for (Encoding candidate : hay) {
+                if (encodingFuzzyEqual(needle, candidate)) {
+                    return Optional.of(candidate);
+                }
+            }
+
+            return Optional.absent();
+        }
+
+        private boolean encodingFuzzyEqual(Encoding needle, Encoding candidate) {
+            return Objects.equal(needle.getLastUpdated(), candidate.getLastUpdated()) &&
+                    Objects.equal(needle.getVideoAspectRatio(), candidate.getVideoAspectRatio()) &&
+                    Objects.equal(needle.getVideoBitRate(), candidate.getVideoBitRate()) &&
+                    Objects.equal(
+                            needle.getVideoHorizontalSize(),
+                            candidate.getVideoHorizontalSize()
+                    ) &&
+                    Objects.equal(needle.getVideoVerticalSize(), candidate.getVideoVerticalSize()) &&
+                    Objects.equal(needle.getAudioDescribed(), candidate.getAudioDescribed()) &&
+                    Objects.equal(needle.getSigned(), candidate.getSigned()) &&
+                    Objects.equal(needle.getSubtitled(), candidate.getSubtitled());
+        }
+
+        private Encoding mergeAndRevokeLocations(Encoding oldEnc, Encoding ingestedEnc) {
+            Set<Location> result = Sets.newHashSet();
+
+            Set<Location> oldLocations = oldEnc.getAvailableAt();
+            Set<Location> ingestedLocations = ingestedEnc.getAvailableAt();
+
+            // blat out old ones
+            for (Location old : oldLocations) {
+                Optional<Location> ingested = findEqualLocation(old, ingestedLocations);
+                if (!ingested.isPresent()) {
+                    old.setAvailable(false);
+                    result.add(old);
+                }
+            }
+
+            for (Location ingested : ingestedLocations) {
+                result.add(ingested);
+            }
+
+            ingestedEnc.setAvailableAt(result);
+            return ingestedEnc;
+        }
+
+        private Optional<Location> findEqualLocation(Location needle, Set<Location> hay) {
+            for (Location candidate : hay) {
+                if (locationFuzzyEqual(needle, candidate)) {
+                    return Optional.of(candidate);
+                }
+            }
+
+            return Optional.absent();
+        }
+
+        private boolean locationFuzzyEqual(Location needle, Location candidate) {
+            return Objects.equal(needle.getLastUpdated(), candidate.getLastUpdated()) &&
+                    Objects.equal(needle.getAvailable(), candidate.getAvailable()) &&
+                    Objects.equal(needle.getTransportType(), candidate.getTransportType()) &&
+                    Objects.equal(needle.getUri(), candidate.getUri()) &&
+                    policyFuzzyEquals(needle.getPolicy(), candidate.getPolicy());
+        }
+
+        private boolean policyFuzzyEquals(@Nullable Policy needle, @Nullable Policy candidate) {
+            return needle == candidate || !(needle == null || candidate == null)
+                    && Objects.equal(needle.getAvailabilityStart(), candidate.getAvailabilityStart())
+                    && Objects.equal(needle.getAvailabilityEnd(), candidate.getAvailabilityEnd())
+                    && Objects.equal(needle.getPlatform(), candidate.getPlatform())
+                    && Objects.equal(needle.getAvailableCountries(), candidate.getAvailableCountries());
         }
     }
 

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/ContentUpdatingNitroBroadcastHandler.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/ContentUpdatingNitroBroadcastHandler.java
@@ -1,9 +1,5 @@
 package org.atlasapi.remotesite.bbc.nitro;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
-
 import java.util.Set;
 
 import org.atlasapi.media.entity.Brand;
@@ -22,8 +18,8 @@ import org.atlasapi.remotesite.bbc.BbcFeeds;
 import org.atlasapi.remotesite.bbc.nitro.extract.NitroBroadcastExtractor;
 import org.atlasapi.remotesite.bbc.nitro.extract.NitroUtil;
 import org.atlasapi.util.GroupLock;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import com.metabroadcast.atlas.glycerin.model.PidReference;
 
 import com.google.common.base.Function;
 import com.google.common.base.Objects;
@@ -35,15 +31,20 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.metabroadcast.atlas.glycerin.model.PidReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 
 /**
  * {@link NitroBroadcastHandler} which fetches, updates and writes relevant
  * content for the {@link Broadcast}.
  */
 public class ContentUpdatingNitroBroadcastHandler implements NitroBroadcastHandler<ImmutableList<Optional<ItemRefAndBroadcast>>> {
-    
-    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    private static final Logger log = LoggerFactory.getLogger(ContentUpdatingNitroBroadcastHandler.class);
     
     private final ContentWriter writer;
     private final LocalOrRemoteNitroFetcher localOrRemoteFetcher;

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/LocalOrRemoteNitroFetcher.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/LocalOrRemoteNitroFetcher.java
@@ -42,8 +42,8 @@ import org.slf4j.LoggerFactory;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class LocalOrRemoteNitroFetcher {
-    
-    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    private static final Logger log = LoggerFactory.getLogger(LocalOrRemoteNitroFetcher.class);
     
     private final ContentResolver resolver;
     private final NitroContentAdapter contentAdapter;
@@ -51,8 +51,8 @@ public class LocalOrRemoteNitroFetcher {
     private final Predicate<Item> fullFetchPermitted;
 
     public LocalOrRemoteNitroFetcher(ContentResolver resolver, NitroContentAdapter contentAdapter, final Clock clock) {
-        this(resolver, contentAdapter, 
-                new ContentMerger(MergeStrategy.MERGE, MergeStrategy.KEEP, MergeStrategy.REPLACE),
+        this(resolver, contentAdapter,
+                new ContentMerger(MergeStrategy.NITRO_VERSIONS_REVOKE, MergeStrategy.KEEP, MergeStrategy.REPLACE),
                 new Predicate<Item>() {
 
                     @Override
@@ -105,7 +105,7 @@ public class LocalOrRemoteNitroFetcher {
     
     public LocalOrRemoteNitroFetcher(ContentResolver resolver, NitroContentAdapter contentAdapter, 
             Predicate<Item> fullFetchPermitted) {
-        this(resolver, contentAdapter, new ContentMerger(MergeStrategy.MERGE, MergeStrategy.KEEP, MergeStrategy.REPLACE), fullFetchPermitted);
+        this(resolver, contentAdapter, new ContentMerger(MergeStrategy.NITRO_VERSIONS_REVOKE, MergeStrategy.KEEP, MergeStrategy.REPLACE), fullFetchPermitted);
     }
     
     public LocalOrRemoteNitroFetcher(ContentResolver resolver, NitroContentAdapter contentAdapter, 

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/BaseNitroItemExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/BaseNitroItemExtractor.java
@@ -1,8 +1,5 @@
 package org.atlasapi.remotesite.bbc.nitro.extract;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.metabroadcast.atlas.glycerin.model.Version.Types;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -19,17 +16,7 @@ import org.atlasapi.media.entity.Restriction;
 import org.atlasapi.media.entity.Specialization;
 import org.atlasapi.media.entity.Version;
 import org.atlasapi.remotesite.bbc.BbcFeeds;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.Duration;
 
-import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSetMultimap;
-import com.google.common.collect.ImmutableSetMultimap.Builder;
-import com.google.common.collect.Iterables;
 import com.metabroadcast.atlas.glycerin.model.Availability;
 import com.metabroadcast.atlas.glycerin.model.PidReference;
 import com.metabroadcast.atlas.glycerin.model.Programme;
@@ -38,6 +25,20 @@ import com.metabroadcast.atlas.glycerin.model.Warnings;
 import com.metabroadcast.common.collect.ImmutableOptionalMap;
 import com.metabroadcast.common.collect.OptionalMap;
 import com.metabroadcast.common.time.Clock;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.ImmutableSetMultimap.Builder;
+import com.google.common.collect.Iterables;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Duration;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.metabroadcast.atlas.glycerin.model.Version.Types;
 
 /**
  * Base extractor for extracting common properties of {@link Item}s from a

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroAvailabilityExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroAvailabilityExtractor.java
@@ -1,7 +1,5 @@
 package org.atlasapi.remotesite.bbc.nitro.extract;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.Map;
 import java.util.Set;
 
@@ -13,8 +11,11 @@ import org.atlasapi.media.entity.Location;
 import org.atlasapi.media.entity.Policy;
 import org.atlasapi.media.entity.Policy.Network;
 import org.atlasapi.media.entity.Policy.Platform;
-import org.joda.time.DateTime;
-import org.joda.time.chrono.ISOChronology;
+
+import com.metabroadcast.atlas.glycerin.model.Availability;
+import com.metabroadcast.atlas.glycerin.model.ScheduledTime;
+import com.metabroadcast.common.intl.Countries;
+import com.metabroadcast.common.time.DateTimeZones;
 
 import com.google.common.base.Equivalence;
 import com.google.common.base.Equivalence.Wrapper;
@@ -27,10 +28,10 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
-import com.metabroadcast.atlas.glycerin.model.Availability;
-import com.metabroadcast.atlas.glycerin.model.ScheduledTime;
-import com.metabroadcast.common.intl.Countries;
-import com.metabroadcast.common.time.DateTimeZones;
+import org.joda.time.DateTime;
+import org.joda.time.chrono.ISOChronology;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Possibly extracts an {@link Encoding} and {@link Location}s for it from some
@@ -203,6 +204,8 @@ public class NitroAvailabilityExtractor {
         location.setUri(IPLAYER_URL_BASE + checkNotNull(NitroUtil.programmePid(source)));
         location.setTransportType(TransportType.LINK);
         location.setPolicy(policy(source, platform, network, mediaType));
+        location.setAvailable(!REVOKED.equals(source.getRevocationStatus()));
+
         return location;
     }
 

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroEpisodeExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroEpisodeExtractor.java
@@ -1,7 +1,5 @@
 package org.atlasapi.remotesite.bbc.nitro.extract;
 
-import static com.metabroadcast.atlas.glycerin.model.Brand.Contributions;
-
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Set;
@@ -17,14 +15,7 @@ import org.atlasapi.media.entity.ReleaseDate;
 import org.atlasapi.persistence.content.people.QueuingPersonWriter;
 import org.atlasapi.remotesite.ContentExtractor;
 import org.atlasapi.remotesite.bbc.BbcFeeds;
-import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
 
-import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.metabroadcast.atlas.glycerin.model.AncestorTitles;
 import com.metabroadcast.atlas.glycerin.model.Brand.MasterBrand;
 import com.metabroadcast.atlas.glycerin.model.Episode;
@@ -34,6 +25,16 @@ import com.metabroadcast.atlas.glycerin.model.PidReference;
 import com.metabroadcast.atlas.glycerin.model.Synopses;
 import com.metabroadcast.common.intl.Countries;
 import com.metabroadcast.common.time.Clock;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+
+import static com.metabroadcast.atlas.glycerin.model.Brand.Contributions;
 
 /**
  * <p>


### PR DESCRIPTION
In theory, these things should never just magically vanish, they should only ever be revoked. In practice,
theory and practice aren't the same, and we need to gracefully cope with this case to then propagate these
changes to our other partners. This tries to fuzzy match versions and availabilities and revokes them
if it can't find them. This aims for recall over precision, so we *might* mistakenly revoke some
availabilities when we mismatch, but we should always catch any actual deletions.