### PR TITLE
Fetch items 12h in future for Nitro off-schedule ingest.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -609,7 +609,7 @@
        <dependency>
           <groupId>com.metabroadcast.atlas.glycerin</groupId>
           <artifactId>glycerin</artifactId>
-          <version>2.0.1</version>
+          <version>2.1.2</version>
        </dependency>
        <dependency>
            <groupId>com.google.http-client</groupId>

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/OffScheduleContentIngestTask.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/OffScheduleContentIngestTask.java
@@ -11,7 +11,6 @@ import org.atlasapi.remotesite.bbc.BbcFeeds;
 import org.atlasapi.util.GroupLock;
 
 import com.metabroadcast.atlas.glycerin.queries.AvailabilityEntityTypeOption;
-import com.metabroadcast.atlas.glycerin.queries.AvailabilityOption;
 import com.metabroadcast.atlas.glycerin.queries.EntityTypeOption;
 import com.metabroadcast.atlas.glycerin.queries.MediaTypeOption;
 import com.metabroadcast.atlas.glycerin.queries.ProgrammesMixin;
@@ -56,7 +55,8 @@ public class OffScheduleContentIngestTask extends ScheduledTask {
                 .builder()
                 .withMixins(ProgrammesMixin.ANCESTOR_TITLES, ProgrammesMixin.CONTRIBUTIONS,
                         ProgrammesMixin.IMAGES, ProgrammesMixin.GENRE_GROUPINGS)
-                .withAvailability(AvailabilityOption.AVAILABLE)
+                // TODO: MBST-15453
+                .withUnsafeArbitrary("availability", "PT12H")
                 .withPageSize(pageSize)
                 .withAvailabilityEntityType(AvailabilityEntityTypeOption.EPISODE)
                 .withEntityType(EntityTypeOption.EPISODE)


### PR DESCRIPTION
Currently we fetch only available items, which by definition means we lag behind by some sampling
duration. Nitro has the option to query for content that will become available in the future,
so we should ingest content before it actually becomes available.