### PR TITLE
Implement a /system/alive endpoint that always returns 200

### DIFF
--- a/src/main/java/org/atlasapi/system/HealthController.java
+++ b/src/main/java/org/atlasapi/system/HealthController.java
@@ -30,4 +30,10 @@ public class HealthController {
 		out.print("</body></html>");
 		out.close();
 	}
+
+	@RequestMapping("/system/alive")
+    public void isAlive(HttpServletResponse response) throws IOException {
+        response.setContentType("text/html");
+        response.setStatus(200);
+    }
 }


### PR DESCRIPTION
- This is the minimum viable test to assert the jetty is up and
  serving HTTP requests