### PR TITLE
Create filter that adds a request's processing time as a response header

### DIFF
--- a/src/main/java/org/atlasapi/query/ProcessingTimeFilter.java
+++ b/src/main/java/org/atlasapi/query/ProcessingTimeFilter.java
@@ -1,0 +1,64 @@
+package org.atlasapi.query;
+
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * This keeps track of how long it takes to process a request and adds it as a response header.
+ * It is intended to give us a metric of how long it takes to process a request that does not
+ * include any time waiting for a request thread to become available.
+ */
+public class ProcessingTimeFilter extends OncePerRequestFilter {
+
+    public static final String PROCESSING_TIME_HEADER = "Processing-Time";
+
+    private final Clock clock;
+
+    public ProcessingTimeFilter() {
+        this(Clock.systemUTC());
+    }
+
+    private ProcessingTimeFilter(Clock clock) {
+        this.clock = checkNotNull(clock);
+    }
+
+    @VisibleForTesting
+    static ProcessingTimeFilter create(Clock clock) {
+        return new ProcessingTimeFilter(clock);
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        ZonedDateTime start = ZonedDateTime.now(clock);
+
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            ZonedDateTime end = ZonedDateTime.now(clock);
+
+            response.addHeader(
+                    PROCESSING_TIME_HEADER,
+                    String.valueOf(
+                            Duration.between(start, end).toMillis()
+                    )
+            );
+        }
+    }
+}

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -41,8 +41,17 @@
        <filter-name>cors</filter-name>
        <filter-class>org.atlasapi.query.CorsFilter</filter-class>
     </filter>
+    <filter>
+        <filter-name>processingTime</filter-name>
+        <filter-class>org.atlasapi.query.ProcessingTimeFilter</filter-class>
+    </filter>
+
     <filter-mapping>
        <filter-name>cors</filter-name>
        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+    <filter-mapping>
+        <filter-name>processingTime</filter-name>
+        <url-pattern>/*</url-pattern>
     </filter-mapping>
 </web-app>

--- a/src/test/java/org/atlasapi/query/ProcessingTimeFilterTest.java
+++ b/src/test/java/org/atlasapi/query/ProcessingTimeFilterTest.java
@@ -1,0 +1,64 @@
+package org.atlasapi.query;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProcessingTimeFilterTest {
+
+    @Mock private HttpServletRequest request;
+    @Mock private HttpServletResponse response;
+    @Mock private FilterChain filterChain;
+
+    @Mock private Clock clock;
+
+    private ProcessingTimeFilter processingTimeFilter;
+
+    @Before
+    public void setUp() throws Exception {
+        processingTimeFilter = ProcessingTimeFilter.create(clock);
+
+        ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+
+        when(clock.getZone()).thenReturn(ZoneOffset.UTC);
+        when(clock.instant()).thenReturn(
+                Instant.from(now),
+                Instant.from(now.plusSeconds(1))
+        );
+    }
+
+    @Test
+    public void doFilterInternal() throws Exception {
+        processingTimeFilter.doFilterInternal(request, response, filterChain);
+
+        InOrder order = inOrder(clock, response, filterChain);
+        order.verify(clock).instant();
+        order.verify(clock).getZone();
+        order.verify(filterChain).doFilter(request, response);
+        order.verify(clock).instant();
+        order.verify(clock).getZone();
+
+        verify(response).addHeader(
+                ProcessingTimeFilter.PROCESSING_TIME_HEADER,
+                String.valueOf(Duration.ofSeconds(1).toMillis())
+        );
+    }
+}


### PR DESCRIPTION
- This is intended to give us a measure of which requests are
  intrinsically expensive by measuring the time it takes to process
  them and ignoring any time waiting for a request thread to become
  available