### PR TITLE
Add support to query channels by their type

### DIFF
--- a/src/main/java/org/atlasapi/query/v2/ChannelController.java
+++ b/src/main/java/org/atlasapi/query/v2/ChannelController.java
@@ -1,7 +1,5 @@
 package org.atlasapi.query.v2;
 
-import static com.google.common.collect.Iterables.transform;
-
 import java.io.IOException;
 import java.util.Set;
 
@@ -16,20 +14,20 @@ import org.atlasapi.application.v3.ApplicationConfiguration;
 import org.atlasapi.media.channel.Channel;
 import org.atlasapi.media.channel.ChannelQuery;
 import org.atlasapi.media.channel.ChannelResolver;
+import org.atlasapi.media.channel.ChannelType;
 import org.atlasapi.media.entity.MediaType;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.output.Annotation;
 import org.atlasapi.output.AtlasErrorSummary;
 import org.atlasapi.output.AtlasModelWriter;
 import org.atlasapi.persistence.logging.AdapterLog;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+
+import com.metabroadcast.common.base.Maybe;
+import com.metabroadcast.common.base.MoreOrderings;
+import com.metabroadcast.common.http.HttpStatusCode;
+import com.metabroadcast.common.ids.NumberToShortStringCodec;
+import com.metabroadcast.common.query.Selection;
+import com.metabroadcast.common.query.Selection.SelectionBuilder;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -42,12 +40,14 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSet.Builder;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Ordering;
-import com.metabroadcast.common.base.Maybe;
-import com.metabroadcast.common.base.MoreOrderings;
-import com.metabroadcast.common.http.HttpStatusCode;
-import com.metabroadcast.common.ids.NumberToShortStringCodec;
-import com.metabroadcast.common.query.Selection;
-import com.metabroadcast.common.query.Selection.SelectionBuilder;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import static com.google.common.collect.Iterables.transform;
 
 @Controller
 public class ChannelController extends BaseController<Iterable<Channel>> {
@@ -104,8 +104,9 @@ public class ChannelController extends BaseController<Iterable<Channel>> {
             @RequestParam(value = "genres", required = false) String genresString,
             @RequestParam(value = "advertised", required = false) String advertiseFromKey,
             @RequestParam(value = "publisher", required = false) String publisherKey,
-            @RequestParam(value = "uri", required = false) String uriKey)
-    throws IOException {
+            @RequestParam(value = "uri", required = false) String uriKey,
+            @RequestParam(value = "type", required = false) String channelType
+    ) throws IOException {
         try {
             final ApplicationConfiguration appConfig;
             try {
@@ -126,7 +127,8 @@ public class ChannelController extends BaseController<Iterable<Channel>> {
                     genresString,
                     advertiseFromKey,
                     publisherKey,
-                    uriKey
+                    uriKey,
+                    channelType
             );
 
             Iterable<Channel> channels = channelResolver.allChannels(query);
@@ -189,10 +191,18 @@ public class ChannelController extends BaseController<Iterable<Channel>> {
         return validAnnotations.containsAll(annotations);
     }
 
-    private ChannelQuery constructQuery(String platformId, String regionIds,
-            String broadcasterKey, String mediaTypeKey, String availableFromKey,
-            String genresString, String advertiseFromKey, String publisherKey,
-            String uri) {
+    private ChannelQuery constructQuery(
+            String platformId,
+            String regionIds,
+            String broadcasterKey,
+            String mediaTypeKey,
+            String availableFromKey,
+            String genresString,
+            String advertiseFromKey,
+            String publisherKey,
+            String uri,
+            String channelType
+    ) {
         ChannelQuery.Builder query = ChannelQuery.builder();
 
         Set<Long> channelGroups = getChannelGroups(platformId, regionIds);
@@ -228,6 +238,11 @@ public class ChannelController extends BaseController<Iterable<Channel>> {
         if (!Strings.isNullOrEmpty(uri)) {
             query.withUri(uri);
         }
+
+        if (!Strings.isNullOrEmpty(channelType)) {
+            query.withChannelType(ChannelType.fromKey(channelType).get());
+        }
+
         return query.build();
     }
 

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/GlycerinNitroChannelAdapter.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/GlycerinNitroChannelAdapter.java
@@ -1,11 +1,17 @@
 package org.atlasapi.remotesite.bbc.nitro;
 
-import com.google.api.client.repackaged.com.google.common.base.Strings;
-import com.google.common.base.Function;
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import org.atlasapi.media.channel.Channel;
+import org.atlasapi.media.channel.ChannelType;
+import org.atlasapi.media.entity.Alias;
+import org.atlasapi.media.entity.Image;
+import org.atlasapi.media.entity.MediaType;
+import org.atlasapi.media.entity.Publisher;
+import org.atlasapi.remotesite.bbc.nitro.extract.NitroImageExtractor;
+
 import com.metabroadcast.atlas.glycerin.Glycerin;
 import com.metabroadcast.atlas.glycerin.GlycerinException;
 import com.metabroadcast.atlas.glycerin.GlycerinResponse;
@@ -17,20 +23,16 @@ import com.metabroadcast.atlas.glycerin.queries.MasterBrandsMixin;
 import com.metabroadcast.atlas.glycerin.queries.MasterBrandsQuery;
 import com.metabroadcast.atlas.glycerin.queries.ServiceTypeOption;
 import com.metabroadcast.atlas.glycerin.queries.ServicesQuery;
-import org.atlasapi.media.channel.Channel;
-import org.atlasapi.media.channel.ChannelType;
-import org.atlasapi.media.entity.Alias;
-import org.atlasapi.media.entity.Image;
-import org.atlasapi.media.entity.MediaType;
-import org.atlasapi.media.entity.Publisher;
-import org.atlasapi.remotesite.bbc.nitro.extract.NitroImageExtractor;
+
+import com.google.api.client.repackaged.com.google.common.base.Strings;
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import org.joda.time.LocalDate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nullable;
-import java.util.List;
-import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -48,11 +50,9 @@ public class GlycerinNitroChannelAdapter implements NitroChannelAdapter {
     private static final String BBC_SERVICE_SID = "bbc:service:sid";
     private static final String BBC_MASTERBRAND_MID = "bbc:masterbrand:mid";
     private static final String PID = "pid";
-    private static final String MUSIC = "music";
-    private static final String RADIO = "radio";
     private static final String NITRO_MASTERBRAND_URI_PREFIX = "http://nitro.bbc.co.uk/masterbrands/";
-    public static final String BBC_IMAGE_TYPE = "bbc:imageType";
-    public static final String MASTERBRAND = "masterbrand";
+    private static final String BBC_IMAGE_TYPE = "bbc:imageType";
+    private static final String MASTERBRAND = "masterbrand";
 
     private final NitroImageExtractor imageExtractor = new NitroImageExtractor(1024, 576);
     private final Glycerin glycerin;
@@ -160,11 +160,8 @@ public class GlycerinNitroChannelAdapter implements NitroChannelAdapter {
         String name = result.getName();
         if (name != null) {
             builder.withTitle(name);
-            inferAndSetMediaType(builder, name);
         } else {
-            String title = result.getTitle();
-            inferAndSetMediaType(builder, title);
-            builder.withTitle(title);
+            builder.withTitle(result.getTitle());
         }
 
         if (result.getSynopses() != null) {
@@ -188,14 +185,6 @@ public class GlycerinNitroChannelAdapter implements NitroChannelAdapter {
         }
 
         return builder.build();
-    }
-
-    private void inferAndSetMediaType(Channel.Builder builder, String name) {
-        if (name.toLowerCase().contains(MUSIC) || name.toLowerCase().contains(RADIO)) {
-            builder.withMediaType(MediaType.AUDIO);
-        } else {
-            builder.withMediaType(MediaType.VIDEO);
-        }
     }
 
     private Channel getChannel(Service result, ImmutableMap<String, Channel> parentUriToId) throws GlycerinException {


### PR DESCRIPTION
This means
 * stop ingesting media type for masterbrands, since that field is meaningless in that context
 * expose the channelType field for querying via API