### PR TITLE
Equivalence writer now returns boolean whether it found any equivalen…

### DIFF
--- a/src/main/java/org/atlasapi/equiv/update/ContentEquivalenceUpdater.java
+++ b/src/main/java/org/atlasapi/equiv/update/ContentEquivalenceUpdater.java
@@ -126,7 +126,7 @@ public class ContentEquivalenceUpdater<T extends Content> implements Equivalence
     }
 
     @Override
-    public void updateEquivalences(T content) {
+    public boolean updateEquivalences(T content) {
 
         ReadableDescription desc = new DefaultDescription();
 
@@ -139,8 +139,11 @@ public class ContentEquivalenceUpdater<T extends Content> implements Equivalence
         List<ScoredCandidates<T>> mergedScores = merger.merge(generatedScores, scoredScores);
         
         EquivalenceResult<T> result = resultBuilder.resultFor(content, mergedScores, desc);
-        
         handler.handle(result);
+
+        boolean hasCandidates = !result.combinedEquivalences().candidates().isEmpty();
+
+        return hasCandidates;
     }
     
     private Iterable<T> extractCandidates(Iterable<ScoredCandidates<T>> generatedScores) {

--- a/src/main/java/org/atlasapi/equiv/update/EquivalenceUpdater.java
+++ b/src/main/java/org/atlasapi/equiv/update/EquivalenceUpdater.java
@@ -2,6 +2,6 @@ package org.atlasapi.equiv.update;
 
 public interface EquivalenceUpdater<T> {
 
-    void updateEquivalences(T subject);
+    boolean updateEquivalences(T subject);
     
 }

--- a/src/main/java/org/atlasapi/equiv/update/EquivalenceUpdaters.java
+++ b/src/main/java/org/atlasapi/equiv/update/EquivalenceUpdaters.java
@@ -21,8 +21,8 @@ public class EquivalenceUpdaters implements EquivalenceUpdater<Content> {
     }
 
     @Override
-    public void updateEquivalences(Content subject) {
-        updaters.get(subject.getPublisher()).updateEquivalences(subject);
+    public boolean updateEquivalences(Content subject) {
+        return updaters.get(subject.getPublisher()).updateEquivalences(subject);
     }
 
 }

--- a/src/main/java/org/atlasapi/equiv/update/NullEquivalenceUpdater.java
+++ b/src/main/java/org/atlasapi/equiv/update/NullEquivalenceUpdater.java
@@ -5,7 +5,8 @@ public class NullEquivalenceUpdater<T> implements EquivalenceUpdater<T> {
     private enum NullUpdater implements EquivalenceUpdater<Object> {
         INSTANCE {
             @Override
-            public void updateEquivalences(Object content) {
+            public boolean updateEquivalences(Object content) {
+                return false;
             }
         };
 
@@ -23,8 +24,8 @@ public class NullEquivalenceUpdater<T> implements EquivalenceUpdater<T> {
     }
 
     @Override
-    public void updateEquivalences(T content) {
-
+    public boolean updateEquivalences(T content) {
+        return false;
     }
 
 }

--- a/src/main/java/org/atlasapi/equiv/update/RootEquivalenceUpdater.java
+++ b/src/main/java/org/atlasapi/equiv/update/RootEquivalenceUpdater.java
@@ -32,30 +32,31 @@ public class RootEquivalenceUpdater implements EquivalenceUpdater<Content> {
     }
 
     @Override
-    public void updateEquivalences(Content content) {
+    public boolean updateEquivalences(Content content) {
         if (content instanceof Container) {
-            updateContainer((Container) content);
+            return updateContainer((Container) content);
         } else if (content instanceof Item){
-            updateContentEquivalence(content);
+            return updateContentEquivalence(content);
         }
+        return false;
     }
 
-    private void updateContentEquivalence(Content content) {
+    private boolean updateContentEquivalence(Content content) {
         log.trace("equiv update {}", content);
-        updater.updateEquivalences(content);
+        return updater.updateEquivalences(content);
     }
 
-    private void updateContainer(Container container) {
+    private boolean updateContainer(Container container) {
         updateContentEquivalence(container);
         for (Item child : childrenOf(container)) {
             updateContentEquivalence(child);
         }
         if (container instanceof Brand) {
             for (Series series : seriesOf((Brand) container)) {
-                updateContentEquivalence(series);
+               updateContentEquivalence(series);
             }
         }
-        updateContentEquivalence(container);
+        return updateContentEquivalence(container);
     }
 
     private Iterable<Series> seriesOf(Brand brand) {

--- a/src/main/java/org/atlasapi/equiv/update/SourceSpecificEquivalenceUpdater.java
+++ b/src/main/java/org/atlasapi/equiv/update/SourceSpecificEquivalenceUpdater.java
@@ -63,16 +63,16 @@ public class SourceSpecificEquivalenceUpdater implements EquivalenceUpdater<Cont
     }
 
     @Override
-    public void updateEquivalences(Content content) {
+    public boolean updateEquivalences(Content content) {
         checkArgument(content.getPublisher().equals(source),"%s can't update data for %s", source, content.getPublisher());
         if (content instanceof Item) {
-            update(itemUpdater, (Item) content);
+            return update(itemUpdater, (Item) content);
         } else if (content instanceof Brand) {
-            update(topLevelContainerUpdater, (Container) content);
+            return update(topLevelContainerUpdater, (Container) content);
         } else if (topLevelSeries(content)) {
-            update(topLevelContainerUpdater, (Container) content);
+            return update(topLevelContainerUpdater, (Container) content);
         } else if (!topLevelSeries(content)) {
-            update(nonTopLevelContainerUpdater, (Container) content);
+            return update(nonTopLevelContainerUpdater, (Container) content);
         } else {
             throw new IllegalStateException(String.format("No updater for %s for %s", source, content));
         }
@@ -83,9 +83,9 @@ public class SourceSpecificEquivalenceUpdater implements EquivalenceUpdater<Cont
             && ((Series)content).getParent() == null;
     }
 
-    private <T> void update(EquivalenceUpdater<T> updater,
+    private <T> boolean update(EquivalenceUpdater<T> updater,
             T content) {
         checkNotNull(updater, "No updater for %s %s", source, content);
-        updater.updateEquivalences(content);
+        return updater.updateEquivalences(content);
     }
 }


### PR DESCRIPTION
…t content. It is being used in schedule equivalence to determine whether content was equivalated already, to avoid overwriting good equivalence with no equivalents in case when item has broadcast not matching with anything else