### PR TITLE
MBST-15461: Unpublish endpoint: ID codec configuration fix

### DIFF
--- a/src/main/java/org/atlasapi/system/ContentPurgeWebModule.java
+++ b/src/main/java/org/atlasapi/system/ContentPurgeWebModule.java
@@ -56,7 +56,7 @@ public class ContentPurgeWebModule {
     @Bean
     public UnpublishContentController unpublishContentController() {
         return new UnpublishContentController(
-                new SubstitutionTableNumberCodec(),
+                SubstitutionTableNumberCodec.lowerCaseOnly(),
                 contentResolver,
                 lookupEntryStore,
                 contentWriter);


### PR DESCRIPTION
SubstitutionTableNumberCodec by default uses the upper case alphabet