### PR TITLE
Change Opta ingester to 2016 season

### DIFF
--- a/src/main/resources/config/environment.properties
+++ b/src/main/resources/config/environment.properties
@@ -426,15 +426,15 @@ opta.events.http.baseUrl=omo.akamai.opta.net
 opta.events.http.username=
 opta.events.http.password=
 # This format is described in the JavaDoc of OptaEvents.sportConfig
-opta.events.http.sports.soccer.football_premier_league=f1|8|2015
-opta.events.http.sports.soccer.football_scottish_premier_league=f1|14|2015
-opta.events.http.sports.soccer.football_german_bundesliga=f1|22|2015
+opta.events.http.sports.soccer.football_premier_league=f1|8|2016
+opta.events.http.sports.soccer.football_scottish_premier_league=f1|14|2016
+opta.events.http.sports.soccer.football_german_bundesliga=f1|22|2016
 opta.events.http.sports.soccer.username=
 opta.events.http.sports.soccer.password=
 opta.events.http.sports.rugby.rugby_aviva_premiership=ruf1|201|2016|t
 opta.events.http.sports.rugby.username=
 opta.events.http.sports.rugby.password=
-opta.events.http.sports.soccer.football_champions_league=f1|5|2015
+opta.events.http.sports.soccer.football_champions_league=f1|5|2016
 opta.events.http.sports.soccer.football_europa_league=f1|6|2015
 opta.events.http.sports.soccer.football_fa_cup=f1|1|2015
 


### PR DESCRIPTION
- Change Premier League, Scottish Premier League, Bundesliga to 2016
  season. Champions League, Europa League and FA Cup do not yet have
  2016 data available so they will be updated later