### PR TITLE
Externalise to config the name of MPX feed for new content

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodModule.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodModule.java
@@ -88,7 +88,7 @@ public class BtVodModule {
     private static final String PORTAL_BUY_TO_OWN_GROUP = "01_boxoffice/Must_Own_Movies_Categories/New_To_Own";
     private static final String BOX_OFFICE_PICKS_GROUP = "50_misc_car_you/Misc_metabroadcast/Misc_metabroadcast_1";
     
-    private static final String NEW_CONTENT_MPX_FEED_NAME = "btv-prd-nav-new";
+    private static final String DEFAULT_NEW_CONTENT_MPX_FEED_NAME = "btv-prd-nav-new";
     
     private static final String MUSIC_CATEGORY = "Music";
     private static final String FILM_CATEGORY = "Film";
@@ -146,13 +146,15 @@ public class BtVodModule {
     private TopicStore topicStore;
     @Autowired
     private DatabasedMongo mongo;
+
     @Value("${bt.vod.file}")
     private String filename;
     @Value("${bt.portal.baseUri}")
     private String btPortalBaseUri;
     @Value("${bt.portal.contentGroups.baseUri}")
     private String btPortalContentGroupsBaseUri;
-    
+
+    // Prod configuration
     @Value("${bt.vod.mpx.prod.feed.baseUrl}")
     private String btVodMpxProdFeedBaseUrl;
     @Value("${bt.vod.mpx.prod.feed.name}")
@@ -166,7 +168,10 @@ public class BtVodModule {
     private String btVodMpxProdFeedQParam;
     @Value("${bt.vod.mpx.prod.feed.new.suffix}")
     private String btVodMpxProdFeedNewSuffix;
+    @Value("${bt.vod.mpx.prod.feed.newContent.name}")
+    private String btVodMpxProdFeedNameForNewContent;
 
+    // Vol-D configuration
     @Value("${bt.vod.mpx.vold.feed.baseUrl}")
     private String btVodMpxVolDFeedBaseUrl;
     @Value("${bt.vod.mpx.vold.feed.name}")
@@ -175,12 +180,15 @@ public class BtVodModule {
     private String btVodMpxVolDFeedQParam;
     @Value("${bt.vod.mpx.vold.feed.new.suffix}")
     private String btVodMpxVolDFeedNewSuffix;
+    @Value("${bt.vod.mpx.vold.feed.newContent.name}")
+    private String btVodMpxVolDFeedNameForNewContent;
 
     @Value("${bt.vod.mpx.vole.feed.guidLookup.baseUrl}")
     private String btVodMpxVoleFeedBaseUrlForGuidLookup;
     @Value("${bt.vod.mpx.vole.feed.guidLookup.name}")
     private String btVodMpxVoleFeedNameForGuidLookup;
 
+    // Vol-E configuration
     @Value("${bt.vod.mpx.vole.feed.baseUrl}")
     private String btVodMpxVoleFeedBaseUrl;
     @Value("${bt.vod.mpx.vole.feed.name}")
@@ -188,8 +196,11 @@ public class BtVodModule {
     @Value("${bt.vod.mpx.vole.feed.params.q}")
     private String btVodMpxVoleFeedQParam;
     @Value("${bt.vod.mpx.vole.feed.new.suffix}")
-    private String btVodMpxVolEFeedNewSuffix;
+    private String btVodMpxVoleFeedNewSuffix;
+    @Value("${bt.vod.mpx.vole.feed.newContent.name}")
+    private String btVodMpxVoleFeedNameForNewContent;
 
+    // Systest2 configuration
     @Value("${bt.vod.mpx.systest2.feed.baseUrl}")
     private String btVodMpxSystest2FeedBaseUrl;
     @Value("${bt.vod.mpx.systest2.feed.name}")
@@ -198,6 +209,8 @@ public class BtVodModule {
     private String btVodMpxSystest2FeedQParam;
     @Value("${bt.vod.mpx.systest2.feed.new.suffix}")
     private String btVodMpxSystest2FeedNewSuffix;
+    @Value("${bt.vod.mpx.systest2.feed.newContent.name}")
+    private String btVodMpxSystest2FeedNameForNewContent;
 
     @Value("${service.bttv.id}")
     private Long btTvServiceId;
@@ -215,7 +228,6 @@ public class BtVodModule {
                 oldContentDeactivator(Publisher.BT_VOD),
                 noImageExtractor(),
                 brandUriExtractor(URI_PREFIX),
-                newFeedContentMatchingPredicate(btVodMpxProdFeedBaseUrl, newFeedSuffix, btVodMpxProdFeedQParam),
                 ImmutableSet.of(
                         topicFor(feedNamepaceFor(BT_VOD_UPDATER_ENV, BT_VOD_UPDATER_CONFIG), BT_VOD_NEW_FEED, Publisher.BT_VOD),
                         topicFor(btVodAppCategoryNamespaceFor(BT_VOD_UPDATER_ENV, BT_VOD_UPDATER_CONFIG), BT_VOD_KIDS_TOPIC, Publisher.BT_VOD),
@@ -226,7 +238,11 @@ public class BtVodModule {
                 seriesUriExtractor(URI_PREFIX),
                 versionsExtractor(URI_PREFIX, BT_VOD_UPDATER_ENV, BT_VOD_UPDATER_CONFIG),
                 describedFieldsExtractor(Publisher.BT_VOD, BT_VOD_UPDATER_ENV, BT_VOD_UPDATER_CONFIG,
-                        newFeedSuffix, btVodMpxProdFeedQParam, btVodMpxProdFeedBaseUrl),
+                        newFeedSuffix,
+                        btVodMpxProdFeedQParam,
+                        btVodMpxProdFeedBaseUrl,
+                        DEFAULT_NEW_CONTENT_MPX_FEED_NAME
+                ),
                 mpxVodClient(btVodMpxProdFeedBaseUrl, btVodMpxProdFeedName, btVodMpxProdFeedQParam),
                 topicQueryResolver,
                 BtVodEntryMatchingPredicates.schedulerChannelPredicate(KIDS_CATEGORY),
@@ -260,7 +276,8 @@ public class BtVodModule {
                 btVodMpxProdFeedNewSuffix, 
                 btVodMpxProdFeedBaseUrlForGuidLookup,
                 btVodMpxProdFeedNameForGuidLookup,
-                ImmutableMap.<String, BtVodContentMatchingPredicate>of()
+                btVodMpxProdFeedNameForNewContent,
+                ImmutableMap.of()
         );
     }
 
@@ -273,10 +290,11 @@ public class BtVodModule {
                 btVodMpxVoleFeedBaseUrl,
                 btVodMpxVoleFeedName,
                 btVodMpxVoleFeedQParam,
-                btVodMpxVolEFeedNewSuffix,
+                btVodMpxVoleFeedNewSuffix,
                 btVodMpxVoleFeedBaseUrlForGuidLookup,
                 btVodMpxVoleFeedNameForGuidLookup,
-                ImmutableMap.<String, BtVodContentMatchingPredicate>of()
+                btVodMpxVoleFeedNameForNewContent,
+                ImmutableMap.of()
         );
     }
 
@@ -292,7 +310,8 @@ public class BtVodModule {
                 btVodMpxVolDFeedNewSuffix,
                 btVodMpxVolDFeedBaseUrl,
                 btVodMpxVolDFeedName,
-                ImmutableMap.<String, BtVodContentMatchingPredicate>of()
+                btVodMpxVolDFeedNameForNewContent,
+                ImmutableMap.of()
         );
     }
 
@@ -308,7 +327,8 @@ public class BtVodModule {
                 btVodMpxSystest2FeedNewSuffix,
                 btVodMpxSystest2FeedBaseUrl,
                 btVodMpxSystest2FeedName,
-                ImmutableMap.<String, BtVodContentMatchingPredicate>of()
+                btVodMpxSystest2FeedNameForNewContent,
+                ImmutableMap.of()
         );
     }
 
@@ -322,6 +342,7 @@ public class BtVodModule {
             String newFeedSuffix,
             String baseUrlForItemLookup,
             String feedNameForItemLookup,
+            String newContentFeedName,
             Map<String, BtVodContentMatchingPredicate> contentGroupsAndCritera
     ) {
         String uriPrefix = String.format(TVE_URI_PREFIX_FORMAT, publisher.key());
@@ -334,7 +355,6 @@ public class BtVodModule {
                 oldContentDeactivator(publisher),
                 itemImageExtractor(),
                 brandUriExtractor(uriPrefix),
-                newFeedContentMatchingPredicate(baseUrlForItemLookup, feedNameForItemLookup, feedQParam),
                 ImmutableSet.of(
                         topicFor(feedNamepaceFor(envName, conf), BT_VOD_NEW_FEED, publisher),
                         topicFor(btVodAppCategoryNamespaceFor(envName, conf), BT_VOD_KIDS_TOPIC, publisher),
@@ -352,7 +372,8 @@ public class BtVodModule {
                         conf,
                         newFeedSuffix,
                         feedQParam,
-                        baseUrlForItemLookup
+                        baseUrlForItemLookup,
+                        newContentFeedName
                 ),
                 mpxVodClient(baseUrlForItemLookup, feedNameForItemLookup, btVodMpxProdFeedQParam),
                 topicQueryResolver,
@@ -407,9 +428,12 @@ public class BtVodModule {
             String conf,
             String newFeedSuffix,
             String qParam,
-            String btVodMpxProdFeedBaseUrlForGuidLookup
+            String btVodMpxProdFeedBaseUrlForGuidLookup,
+            String newContentFeedName
     ) {
-        BtVodContentMatchingPredicate newContentPredicate = newFeedContentMatchingPredicate(btVodMpxProdFeedBaseUrlForGuidLookup, newFeedSuffix, qParam);
+        BtVodContentMatchingPredicate newContentPredicate = newFeedContentMatchingPredicate(
+                btVodMpxProdFeedBaseUrlForGuidLookup, newFeedSuffix, qParam, newContentFeedName
+        );
         return new BtVodDescribedFieldsExtractor(
                 topicResolver,
                 topicStore,
@@ -469,7 +493,8 @@ public class BtVodModule {
         );
     }
     
-    private Map<String, BtVodContentMatchingPredicate> salesContentGroupsAndCriteria(String baseUrl, String feedName, String qParam) {
+    private Map<String, BtVodContentMatchingPredicate> salesContentGroupsAndCriteria(String baseUrl,
+            String feedName, String qParam) {
         return ImmutableMap.<String, BtVodContentMatchingPredicate> builder()
                 .put(MUSIC_CATEGORY.toLowerCase(), BtVodContentMatchingPredicates.schedulerChannelPredicate(MUSIC_CATEGORY))
                 .put(FILM_CATEGORY.toLowerCase(), BtVodContentMatchingPredicates.filmPredicate())
@@ -481,7 +506,12 @@ public class BtVodModule {
                 .put(BOX_OFFICE_CATEGORY.toLowerCase(), BtVodContentMatchingPredicates.portalGroupContentMatchingPredicate(portalClient(), PORTAL_BOXOFFICE_GROUP, null))
                 .put(TV_BOX_SETS_CATEGORY.toLowerCase(), BtVodContentMatchingPredicates.portalGroupContentMatchingPredicate(portalClient(), PORTAL_BOXSET_GROUP, Series.class))
                 .put(BOX_OFFICE_PICKS_CATEGORY.toLowerCase(), BtVodContentMatchingPredicates.portalGroupContentMatchingPredicate(portalClient(), BOX_OFFICE_PICKS_GROUP, null))
-                .put(NEW_CATEGORY.toLowerCase(), BtVodContentMatchingPredicates.mpxFeedContentMatchingPredicate(mpxVodClient(baseUrl, feedName, qParam), NEW_CONTENT_MPX_FEED_NAME))
+                .put(
+                        NEW_CATEGORY.toLowerCase(),
+                        newFeedContentMatchingPredicate(
+                                baseUrl, feedName, qParam, DEFAULT_NEW_CONTENT_MPX_FEED_NAME
+                        )
+                )
                 .build();
     }
     
@@ -491,8 +521,12 @@ public class BtVodModule {
         return topic;
     }
     
-    private BtVodContentMatchingPredicate newFeedContentMatchingPredicate(String baseUri, String feedName, String qParam) {
-        return BtVodContentMatchingPredicates.mpxFeedContentMatchingPredicate(mpxVodClient(baseUri, feedName, qParam), NEW_CONTENT_MPX_FEED_NAME);
+    private BtVodContentMatchingPredicate newFeedContentMatchingPredicate(String baseUri,
+            String itemLookupFeedName, String qParam, String newContentFeedName) {
+        return BtVodContentMatchingPredicates.mpxFeedContentMatchingPredicate(
+                mpxVodClient(baseUri, itemLookupFeedName, qParam),
+                newContentFeedName
+        );
     }
 
     @Bean

--- a/src/main/java/org/atlasapi/remotesite/btvod/BtVodUpdater.java
+++ b/src/main/java/org/atlasapi/remotesite/btvod/BtVodUpdater.java
@@ -36,7 +36,6 @@ public class BtVodUpdater extends ScheduledTask {
     private final BtVodOldContentDeactivator oldContentDeactivator;
     private final ImageExtractor imageExtractor;
     private final BrandUriExtractor brandUriExtractor;
-    private final BtVodContentMatchingPredicate newFeedContentMatchingPredicate;
     private final Set<Topic> topicsToPropagateToParent;
     private final Set<String> topicNamespacesToPropagateToParent;
     private final BtVodSeriesUriExtractor seriesUriExtractor;
@@ -60,7 +59,6 @@ public class BtVodUpdater extends ScheduledTask {
             BtVodOldContentDeactivator oldContentDeactivator,
             ImageExtractor imageExtractor,
             BrandUriExtractor brandUriExtractor,
-            BtVodContentMatchingPredicate newFeedContentMatchingPredicate,
             Set<Topic> topicsToPropagateToParent,
             Set<String> topicNamespacesToPropagateToParent,
             BtVodSeriesUriExtractor seriesUriExtractor,
@@ -75,7 +73,6 @@ public class BtVodUpdater extends ScheduledTask {
             String btVodImagesGuidAliasNamespace
     ) {
         this.contentWriter = checkNotNull(contentWriter);
-        this.newFeedContentMatchingPredicate = checkNotNull(newFeedContentMatchingPredicate);
         this.topicsToPropagateToParent = checkNotNull(topicsToPropagateToParent);
         this.topicNamespacesToPropagateToParent = checkNotNull(topicNamespacesToPropagateToParent);
         this.vodData = checkNotNull(vodData);
@@ -101,12 +98,11 @@ public class BtVodUpdater extends ScheduledTask {
 
     @Override
     public void runTask() {
-        newFeedContentMatchingPredicate.init();
         describedFieldsExtractor.init();
 
         MultiplexingVodContentListener listeners 
             = new MultiplexingVodContentListener(
-                ImmutableList.<BtVodContentListener>of(contentGroupUpdater)
+                ImmutableList.of(contentGroupUpdater)
         );
         Set<String> processedRows = Sets.newHashSet();
         

--- a/src/main/resources/config/environment.properties
+++ b/src/main/resources/config/environment.properties
@@ -355,11 +355,13 @@ bt.vod.mpx.prod.feed.params.q=
 bt.vod.mpx.prod.feed.new.suffix=
 bt.vod.mpx.prod.feed.guidLookup.name=
 bt.vod.mpx.prod.feed.guidLookup.baseUrl=
+bt.vod.mpx.prod.feed.newContent.name=btv-prd-nav-new
 
 bt.vod.mpx.vold.feed.baseUrl=
 bt.vod.mpx.vold.feed.name=
 bt.vod.mpx.vold.feed.params.q=
 bt.vod.mpx.vold.feed.new.suffix=
+bt.vod.mpx.vold.feed.newContent.name=btv-prd-nav-new
 
 bt.vod.mpx.vole.feed.baseUrl=http://feed.product.theplatform.eu/f/kfloDSwm/
 bt.vod.mpx.vole.feed.name=
@@ -367,11 +369,13 @@ bt.vod.mpx.vole.feed.params.q=
 bt.vod.mpx.vole.feed.new.suffix=
 bt.vod.mpx.vole.feed.guidLookup.baseUrl=
 bt.vod.mpx.vole.feed.guidLookup.name=
+bt.vod.mpx.vole.feed.newContent.name=
 
 bt.vod.mpx.systest2.feed.baseUrl=
 bt.vod.mpx.systest2.feed.name=
 bt.vod.mpx.systest2.feed.params.q=
 bt.vod.mpx.systest2.new.suffix=
+bt.vod.mpx.systest2.feed.newContent.name=btv-prd-nav-new
 
 metabroadcast.picks.priorityChannelGroup=
 


### PR DESCRIPTION
- This is done because the new content feed for the Vol-E environment
  has a different name than one in the production environment that we
  had hardcoded before
- Also remove unused `newFeedContentMatchingPredicate` from BtVodUpdater