### PR TITLE
Instead of getting content from schedule store to be equivalated, we …

### DIFF
--- a/src/main/java/org/atlasapi/equiv/EquivTaskModule.java
+++ b/src/main/java/org/atlasapi/equiv/EquivTaskModule.java
@@ -282,16 +282,14 @@ public class EquivTaskModule {
                         .withPublishers(YOUVIEW)
                         .withChannelsSupplier(youviewChannelsSupplier())
                         .build().withName("YouView Schedule Equivalence (8 day) Updater"),
-                YOUVIEW_SCHEDULE_EQUIVALENCE_REPETITION,
-                jobsAtStartup
+                YOUVIEW_SCHEDULE_EQUIVALENCE_REPETITION
         );
         scheduleEquivalenceJob(
                 taskBuilder(0, 7)
                         .withPublishers(YOUVIEW_STAGE)
                         .withChannelsSupplier(youviewChannelsSupplier())
                         .build().withName("YouView Stage Schedule Equivalence (8 day) Updater"),
-                YOUVIEW_STAGE_SCHEDULE_EQUIVALENCE_REPETITION,
-                jobsAtStartup
+                YOUVIEW_STAGE_SCHEDULE_EQUIVALENCE_REPETITION
         );
 
         // This job is scheduled for late in the day so run it for +8 days to ensure we get +7 day
@@ -301,8 +299,7 @@ public class EquivTaskModule {
                         .withPublishers(YOUVIEW_BT)
                         .withChannelsSupplier(youviewChannelsSupplier())
                         .build().withName("YouView BT Schedule Equivalence (8 day) Updater"),
-                YOUVIEW_SCHEDULE_EQUIVALENCE_REPETITION,
-                jobsAtStartup
+                YOUVIEW_SCHEDULE_EQUIVALENCE_REPETITION
         );
         scheduleEquivalenceJob(
                 taskBuilder(0, 7)
@@ -310,8 +307,7 @@ public class EquivTaskModule {
                         .withChannelsSupplier(youviewChannelsSupplier())
                         .build()
                         .withName("YouView Stage BT Schedule Equivalence (8 day) Updater"),
-                YOUVIEW_STAGE_SCHEDULE_EQUIVALENCE_REPETITION,
-                jobsAtStartup
+                YOUVIEW_STAGE_SCHEDULE_EQUIVALENCE_REPETITION
         );
 
         // This job is scheduled for late in the day so run it for +8 days to ensure we get +7 day
@@ -322,8 +318,7 @@ public class EquivTaskModule {
                         .withChannelsSupplier(youviewChannelsSupplier())
                         .build()
                         .withName("YouView Scotland Radio Schedule Equivalence (8 day) Updater"),
-                YOUVIEW_SCHEDULE_EQUIVALENCE_REPETITION,
-                jobsAtStartup
+                YOUVIEW_SCHEDULE_EQUIVALENCE_REPETITION
         );
         scheduleEquivalenceJob(
                 taskBuilder(0, 7)
@@ -332,8 +327,7 @@ public class EquivTaskModule {
                         .build()
                         .withName(
                                 "YouView Stage Scotland Radio Schedule Equivalence (8 day) Updater"),
-                YOUVIEW_STAGE_SCHEDULE_EQUIVALENCE_REPETITION,
-                jobsAtStartup
+                YOUVIEW_STAGE_SCHEDULE_EQUIVALENCE_REPETITION
         );
     }
 
@@ -347,8 +341,14 @@ public class EquivTaskModule {
         return jobsAtStartup;
     }
 
+    private void scheduleEquivalenceJob(ScheduledTask task,
+            RepetitionRule repetitionRule) {
+        taskScheduler.schedule(task, repetitionRule);
+    }
+
     private Builder taskBuilder(int back, int forward) {
         return ScheduleEquivalenceUpdateTask.builder()
+            .withContentResolver(contentResolver)
             .withUpdater(equivUpdater)
             .withScheduleResolver(scheduleResolver)
             .withBack(back)

--- a/src/test/java/org/atlasapi/equiv/update/tasks/ScheduleEquivalenceUpdateTaskTest.java
+++ b/src/test/java/org/atlasapi/equiv/update/tasks/ScheduleEquivalenceUpdateTaskTest.java
@@ -16,10 +16,12 @@ import org.atlasapi.media.entity.Schedule;
 import org.atlasapi.media.entity.Schedule.ScheduleChannel;
 import org.atlasapi.media.entity.Version;
 import org.atlasapi.persistence.content.ContentResolver;
+import org.atlasapi.persistence.content.ResolvedContent;
 import org.atlasapi.persistence.content.ScheduleResolver;
 
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -29,11 +31,14 @@ import org.joda.time.LocalDateTime;
 import org.junit.Test;
 import static org.junit.Assert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
 
-
+@RunWith(MockitoJUnitRunner.class)
 public class ScheduleEquivalenceUpdateTaskTest {
 
     @SuppressWarnings("unchecked") 
@@ -80,49 +85,23 @@ public class ScheduleEquivalenceUpdateTaskTest {
         Broadcast broadcast1 = new Broadcast("bbcone", DateTime.now(), DateTime.now());
         version1.addBroadcast(broadcast1);
         yvItemTwo.addVersion(version1);
-
-        Item yvItemSecondOne = new Item("yv1", "yv1c", Publisher.YOUVIEW);
-        Version version2 = new Version();
-        Broadcast broadcast2 = new Broadcast("bbcone", DateTime.now().plusMinutes(1), DateTime.now());
-        version2.addBroadcast(broadcast2);
-        yvItemSecondOne.addVersion(version2);
-
-        Item yvItem3 = new Item("yv1", "yv1c", Publisher.YOUVIEW);
-        Version version3 = new Version();
-        Broadcast broadcast3 = new Broadcast("bbcone", DateTime.now().plusMinutes(3), DateTime.now());
-        version3.addBroadcast(broadcast3);
-        yvItem3.addVersion(version3);
-
-        Item yvItem4 = new Item("yv1", "yv1c", Publisher.YOUVIEW);
-        Version version4 = new Version();
-        Broadcast broadcast4 = new Broadcast("bbcone", DateTime.now().plusMinutes(4), DateTime.now());
-        version4.addBroadcast(broadcast4);
-        yvItem4.addVersion(version4);
-
-        Item yvItem5 = new Item("yv1", "yv1c", Publisher.YOUVIEW);
-        Version version5 = new Version();
-        Broadcast broadcast5 = new Broadcast("bbcone", DateTime.now().plusMinutes(5), DateTime.now());
-        version5.addBroadcast(broadcast5);
-        yvItem5.addVersion(version5);
-
-        Item yvItem6 = new Item("yv1", "yv1c", Publisher.YOUVIEW);
-        Version version6 = new Version();
-        Broadcast broadcast6 = new Broadcast("bbcone", DateTime.now().plusMinutes(6), DateTime.now());
-        version6.addBroadcast(broadcast6);
-        yvItem6.addVersion(version6);
         
         DateTime now = new DateTime().withZone(DateTimeZone.UTC);
         
-        ScheduleChannel schChannel1 = new ScheduleChannel(bbcOne, ImmutableList.of(yvItemOne, yvItemTwo, yvItemSecondOne,yvItem3, yvItem4, yvItem5, yvItem6));
+        ScheduleChannel schChannel1 = new ScheduleChannel(bbcOne, ImmutableList.of(yvItemOne, yvItemTwo));
         LocalDate today = new LocalDate();
         LocalDate tomorrow = today.plusDays(1);
         Schedule schedule1 = new Schedule(ImmutableList.of(schChannel1), new Interval(today.toDateTimeAtStartOfDay(), tomorrow.toDateTimeAtStartOfDay()));
         
         ScheduleResolver resolver = scheduleResolver(schedule1);
-        
+        ResolvedContent yv1 = ResolvedContent.builder().put("yv1", yvItemOne).build();
+        ResolvedContent yv2 = ResolvedContent.builder().put("yv2", yvItemTwo).build();
+        when(contentResolver.findByCanonicalUris(ImmutableSet.of("yv1"))).thenReturn(yv1);
+        when(contentResolver.findByCanonicalUris(ImmutableSet.of("yv2"))).thenReturn(yv2);
         ScheduleEquivalenceUpdateTask.builder()
             .withBack(0)
             .withForward(0)
+            .withContentResolver(contentResolver)
             .withPublishers(ImmutableList.of(Publisher.YOUVIEW))
             .withChannelsSupplier(Suppliers.ofInstance((Iterable<Channel>)ImmutableList.of(bbcOne)))
             .withScheduleResolver(resolver)
@@ -130,10 +109,8 @@ public class ScheduleEquivalenceUpdateTaskTest {
             .build().run();
         
 
-        verify(updater, times(6)).updateEquivalences(yvItemOne);
+        verify(updater).updateEquivalences(yvItemOne);
         verify(updater).updateEquivalences(yvItemTwo);
-        verify(updater, times(6)).updateEquivalences(yvItemSecondOne);
-        assertThat(Iterables.getOnlyElement(yvItem6.getVersions()).getBroadcasts().size(), is(6));
     }
 
 }


### PR DESCRIPTION
…are retrieving whole content with all its broadcasts, so it will be not overwritten with the same item but with different broadcast