### PR TITLE
When desserialing channel we set key from uri

### DIFF
--- a/src/main/java/org/atlasapi/input/ChannelModelTransformer.java
+++ b/src/main/java/org/atlasapi/input/ChannelModelTransformer.java
@@ -24,6 +24,7 @@ import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.joda.time.LocalDate;
 
+import static com.google.gdata.util.common.base.Preconditions.checkArgument;
 import static com.google.gdata.util.common.base.Preconditions.checkNotNull;
 
 public class ChannelModelTransformer implements ModelTransformer<Channel, org.atlasapi.media.channel.Channel> {
@@ -48,9 +49,12 @@ public class ChannelModelTransformer implements ModelTransformer<Channel, org.at
 
     @Override
     public org.atlasapi.media.channel.Channel transform(Channel simple) {
+        checkArgument(simple.getUri() != null, "Channel uri should be provided");
+
         org.atlasapi.media.channel.Channel.Builder complex = org.atlasapi.media.channel.Channel.builder();
 
         complex.withUri(simple.getUri());
+        complex.withKey(simple.getUri());
         complex.withHighDefinition(simple.getHighDefinition());
         complex.withRegional(simple.getRegional());
         complex.withRegion(simple.getRegion());

--- a/src/test/java/org/atlasapi/input/ChannelModelTransformerTest.java
+++ b/src/test/java/org/atlasapi/input/ChannelModelTransformerTest.java
@@ -82,6 +82,7 @@ public class ChannelModelTransformerTest {
         assertTrue(complex.getAdvertiseFrom() != null);
         assertTrue(complex.getStartDate() != null);
         assertThat(complex.getGenres().size(), is(1));
+        assertThat(complex.getKey(), is("http://test.channel"));
         assertThat(complex.getGenres().stream().findFirst().get(), is("action"));
     }
 


### PR DESCRIPTION
because key is compulsory field in some part of the system