### PR TITLE
Add a scorer for matching title and description

### DIFF
--- a/src/main/java/org/atlasapi/equiv/EquivModule.java
+++ b/src/main/java/org/atlasapi/equiv/EquivModule.java
@@ -68,6 +68,7 @@ import org.atlasapi.equiv.scorers.SubscriptionCatchupBrandDetector;
 import org.atlasapi.equiv.scorers.TitleMatchingContainerScorer;
 import org.atlasapi.equiv.scorers.TitleMatchingItemScorer;
 import org.atlasapi.equiv.scorers.TitleSubsetBroadcastItemScorer;
+import org.atlasapi.equiv.scorers.DescriptionTitleMatchingScorer;
 import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
 import org.atlasapi.equiv.update.EquivalenceUpdater;
 import org.atlasapi.equiv.update.EquivalenceUpdaters;
@@ -313,7 +314,7 @@ public class EquivModule {
         ));
         
         EquivalenceUpdater<Item> standardItemUpdater = standardItemUpdater(MoreSets.add(acceptablePublishers, LOVEFILM), 
-                ImmutableSet.of(new TitleMatchingItemScorer(), new SequenceItemScorer(Score.ONE))).build();
+                ImmutableSet.of(new TitleMatchingItemScorer(), new SequenceItemScorer(Score.ONE), new DescriptionTitleMatchingScorer())).build();
         EquivalenceUpdater<Container> topLevelContainerUpdater = topLevelContainerUpdater(MoreSets.add(acceptablePublishers, LOVEFILM));
 
         Set<Publisher> nonStandardPublishers = ImmutableSet.copyOf(Sets.union(
@@ -712,7 +713,8 @@ public class EquivModule {
             new TitleMatchingItemScorer(), 
             new SequenceItemScorer(Score.ONE),
             new TitleSubsetBroadcastItemScorer(contentResolver, titleMismatch, 80/*percent*/),
-            new BroadcastAliasScorer(Score.nullScore())
+            new BroadcastAliasScorer(Score.nullScore()),
+            new DescriptionTitleMatchingScorer()
         ), filter).build();
     }
 

--- a/src/main/java/org/atlasapi/equiv/scorers/DescriptionTitleMatchingScorer.java
+++ b/src/main/java/org/atlasapi/equiv/scorers/DescriptionTitleMatchingScorer.java
@@ -1,0 +1,107 @@
+package org.atlasapi.equiv.scorers;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableSet;
+
+import org.atlasapi.equiv.results.description.ResultDescription;
+import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
+import org.atlasapi.equiv.results.scores.DefaultScoredCandidates.Builder;
+import org.atlasapi.equiv.results.scores.Score;
+import org.atlasapi.equiv.results.scores.ScoredCandidates;
+import org.atlasapi.media.entity.Item;
+
+import com.google.common.base.Strings;
+
+public class DescriptionTitleMatchingScorer implements EquivalenceScorer<Item> {
+
+    public static final String NAME = "Description Title Matching Item Scorer";
+
+    private final Set<String> commonWords = ImmutableSet.of(
+            "the", "in", "a", "and", "&", "of", "to", "show"
+    );
+
+    private final Score scoreOnMismatch;
+
+    // This can be calibrated to change how often matching occurs
+    private final double DIVISION_FACTOR;
+
+    public DescriptionTitleMatchingScorer() {
+        this(Score.nullScore(), 2.0);
+    }
+
+    public DescriptionTitleMatchingScorer(Score scoreOnMismatch, double divisionFactor) {
+        this.scoreOnMismatch = scoreOnMismatch;
+        this.DIVISION_FACTOR = divisionFactor;
+    }
+
+    @Override
+    public ScoredCandidates<Item> score(Item subject, Set<? extends Item> suggestions, ResultDescription desc) {
+        Builder<Item> equivalents = DefaultScoredCandidates.fromSource(NAME);
+
+        for (Item suggestion : suggestions) {
+            equivalents.addEquivalent(suggestion, score(subject, suggestion, desc));
+        }
+
+        return equivalents.build();
+    }
+
+    private Score score(Item subject, Item suggestion, ResultDescription desc) {
+
+        Score score = score(subject, suggestion);
+        desc.appendText("%s (%s) scored: %s", suggestion.getTitle(), suggestion.getCanonicalUri(), score);
+
+        return score;
+    }
+
+    private Score score(Item subject, Item suggestion) {
+        return descriptionTitleMatch(subject, suggestion)? Score.ONE: Score.nullScore();
+    }
+
+    private boolean descriptionTitleMatch(Item subject, Item candidate) {
+        Set<String> candidateList = descriptionToProcessedList(candidate.getDescription());
+        Set<String> subjectList = descriptionToProcessedList(subject.getDescription());
+
+        Set<String> candidateTitleList = titleToProcessedList(candidate.getTitle());
+        Set<String> subjectTitleList = titleToProcessedList(subject.getTitle());
+
+        subjectList.retainAll(candidateTitleList);
+        candidateList.retainAll(subjectTitleList);
+
+        // Calibrate the division factor to alter matching frequency
+        return subjectList.size() > (candidateTitleList.size()/ DIVISION_FACTOR) || candidateList.size() > (subjectTitleList.size()/ DIVISION_FACTOR);
+
+    }
+
+    private Set<String> titleToProcessedList(String title) {
+        Set<String> titleList = new HashSet<>();
+        if (!Strings.isNullOrEmpty(title)) {
+            titleList = Arrays.stream(title.toLowerCase().split(" "))
+                    .filter(o -> !commonWords.contains(o))
+                    .collect(Collectors.toSet());
+        }
+        return titleList;
+    }
+
+    private Set<String> descriptionToProcessedList(String description) {
+        Set<String> descriptionList = new HashSet<>();
+        if (!Strings.isNullOrEmpty(description)) {
+            descriptionList = Arrays.stream(description.split(" "))
+                    .filter( o -> Character.isUpperCase(o.charAt(0)))
+                    .filter( o -> !commonWords.contains(o))
+                    .map(String::toLowerCase)
+                    .collect(Collectors.toSet());
+        }
+        return descriptionList;
+    }
+
+    @Override
+    public String toString() {
+        return "Description Title Matching Item Scorer";
+    }
+}

--- a/src/test/java/org/atlasapi/equiv/scorers/DescriptionTitleMatchingScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/scorers/DescriptionTitleMatchingScorerTest.java
@@ -1,0 +1,110 @@
+package org.atlasapi.equiv.scorers;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+import org.atlasapi.equiv.results.description.DefaultDescription;
+import org.atlasapi.equiv.results.scores.Score;
+import org.atlasapi.equiv.results.scores.ScoredCandidates;
+import org.atlasapi.equiv.scorers.DescriptionTitleMatchingScorer;
+import org.atlasapi.media.entity.Item;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+import scala.actors.threadpool.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class DescriptionTitleMatchingScorerTest {
+
+    private DescriptionTitleMatchingScorer scorer;
+
+    public DescriptionTitleMatchingScorerTest() {
+        this.scorer = new DescriptionTitleMatchingScorer();
+    }
+
+    @Test
+    public void testMatch() {
+        Item subject = new Item();
+        subject.setTitle("This is the News");
+        Item candidate = new Item();
+        candidate.setDescription("This is the News which discusses news related stuff");
+        assertEquals(Score.ONE, score(subject, candidate));
+        assertEquals(Score.ONE, score(candidate, subject));
+    }
+
+    @Test
+    public void testMoreDifficultMismatch() {
+        Item subject = new Item();
+        subject.setTitle("Something not football Related");
+        Item candidate = new Item();
+        candidate.setDescription("something not football related Either");
+        assertEquals(Score.nullScore(), score(subject, candidate));
+        assertEquals(Score.nullScore(), score(candidate, subject));
+    }
+
+    @Test
+    public void testCapitals() {
+        Item subject = new Item();
+        subject.setTitle("something lower case");
+        Item candidate = new Item();
+        candidate.setDescription("something also lower case");
+        assertEquals(Score.nullScore(), score(subject, candidate));
+        assertEquals(Score.nullScore(), score(candidate, subject));
+
+        Item subjectTwo = new Item();
+        subjectTwo.setTitle("something lower case");
+        Item candidateTwo = new Item();
+        candidateTwo.setDescription("Something Not Lower Case");
+        assertEquals(Score.ONE, score(subjectTwo, candidateTwo));
+        assertEquals(Score.ONE, score(candidateTwo, subjectTwo));
+
+        assertEquals(Score.ONE, score(subject, candidateTwo));
+        assertEquals(Score.nullScore(), score(subjectTwo, candidate));
+    }
+
+    @Test
+    public void testMismatch() {
+        Item subject = new Item();
+        subject.setTitle("Football Madness");
+        Item candidate = new Item();
+        candidate.setDescription("Some unrelated Stuff that doesn't Mention what's in the title");
+        assertEquals(Score.nullScore(), score(subject, candidate));
+        assertEquals(Score.nullScore(), score(candidate, subject));
+    }
+
+    @Test
+    public void testNulls() {
+        Item subject = new Item();
+        Item candidate = new Item();
+        assertEquals(Score.nullScore(), score(subject, candidate));
+        assertEquals(Score.nullScore(), score(candidate, subject));
+    }
+
+    @Test
+    public void testDivisionFactor() {
+        Item subject = new Item();
+        Item candidate = new Item();
+        subject.setTitle("Word");
+        candidate.setDescription("Word and Some Other Words That Are Different");
+        assertEquals(Score.ONE, score(subject, candidate));
+    }
+
+    @Test
+    public void testFailDivisonFactor() {
+        Item subject = new Item();
+        Item candidate = new Item();
+        subject.setTitle("Three small words");
+        candidate.setDescription("Three is the only Word Repeated");
+        assertEquals(Score.nullScore(), score(subject, candidate));
+    }
+
+    private Score score(Item subject, Item candidate) {
+        DefaultDescription desc = new DefaultDescription();
+        ScoredCandidates<Item> scores = scorer.score(subject, ImmutableSet.of(candidate), desc);
+        return scores.candidates().get(candidate);
+    }
+}


### PR DESCRIPTION
- Created equivalence scorer for matching title and description
  keywords. This helps with some content that has a description but
  no title or vv.