### PR TITLE
When writing new content set actively published

### DIFF
--- a/src/main/java/org/atlasapi/query/content/ContentWriteExecutor.java
+++ b/src/main/java/org/atlasapi/query/content/ContentWriteExecutor.java
@@ -158,6 +158,8 @@ public class ContentWriteExecutor {
     }
 
     private Content merge(Content existing, Content update, boolean merge) {
+        existing.setActivelyPublished(update.isActivelyPublished());
+
         existing.setEquivalentTo(merge ?
                                  merge(existing.getEquivalentTo(), update.getEquivalentTo()) :
                                  update.getEquivalentTo());


### PR DESCRIPTION
- The write executor was not updating the actively published flag in
  the existing content which means if the existing content was
  unpublished it was impossible to re-publish it via the API