### PR TITLE
changes to only allow multiple items of the same publisher equivalate…

### DIFF
--- a/src/main/java/org/atlasapi/equiv/results/DefaultEquivalenceResultBuilder.java
+++ b/src/main/java/org/atlasapi/equiv/results/DefaultEquivalenceResultBuilder.java
@@ -1,61 +1,55 @@
 package org.atlasapi.equiv.results;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import org.atlasapi.equiv.results.combining.ScoreCombiner;
 import org.atlasapi.equiv.results.description.ReadableDescription;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.extractors.EquivalenceExtractor;
+import org.atlasapi.equiv.results.extractors.MultipleCandidateExtractor;
 import org.atlasapi.equiv.results.filters.EquivalenceFilter;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
-import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.media.entity.Brand;
-import org.atlasapi.media.entity.Broadcast;
 import org.atlasapi.media.entity.Content;
-import org.atlasapi.media.entity.Identified;
 import org.atlasapi.media.entity.Publisher;
-import org.atlasapi.media.entity.Series;
-import org.atlasapi.media.entity.Version;
-
-import com.metabroadcast.common.stream.MoreCollectors;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMap.Builder;
 import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.SortedSetMultimap;
 import com.google.common.collect.TreeMultimap;
-import org.joda.time.DateTime;
-import org.joda.time.Duration;
-import org.joda.time.Interval;
 
 public class DefaultEquivalenceResultBuilder<T extends Content> implements EquivalenceResultBuilder<T> {
-
-    public static <T extends Content> EquivalenceResultBuilder<T> create(ScoreCombiner<T> combiner, EquivalenceFilter<T> filter, EquivalenceExtractor<T> marker) {
-        return new DefaultEquivalenceResultBuilder<T>(combiner, filter, marker);
-    }
 
     private final ScoreCombiner<T> combiner;
     private final EquivalenceExtractor<T> extractor;
     private final EquivalenceFilter<T> filter;
-    private static final Duration BROADCAST_TIME_FLEXIBILITY = Duration.standardMinutes(5);
-    private static double PUBLISHER_MATCHING_EQUIV_THRESHOLD = 0.3;
 
-    public DefaultEquivalenceResultBuilder(ScoreCombiner<T> combiner, EquivalenceFilter<T> filter, EquivalenceExtractor<T> extractor) {
+    private final MultipleCandidateExtractor<T> multipleCandidateExtractor;
+
+    public DefaultEquivalenceResultBuilder(
+            ScoreCombiner<T> combiner,
+            EquivalenceFilter<T> filter,
+            EquivalenceExtractor<T> extractor
+    ) {
         this.combiner = combiner;
         this.filter = filter;
         this.extractor = extractor;
+
+        this.multipleCandidateExtractor = MultipleCandidateExtractor.create();
+    }
+
+    public static <T extends Content> EquivalenceResultBuilder<T> create(
+            ScoreCombiner<T> combiner,
+            EquivalenceFilter<T> filter,
+            EquivalenceExtractor<T> marker
+    ) {
+        return new DefaultEquivalenceResultBuilder<T>(combiner, filter, marker);
     }
 
     @Override
@@ -87,30 +81,39 @@ public class DefaultEquivalenceResultBuilder<T extends Content> implements Equiv
         return filteredCandidates;
     }
 
-    private Multimap<Publisher, ScoredCandidate<T>> extract(T target, List<ScoredCandidate<T>> filteredCandidates, ResultDescription desc) {
+    private Multimap<Publisher, ScoredCandidate<T>> extract(
+            T target,
+            List<ScoredCandidate<T>> filteredCandidates,
+            ResultDescription desc
+    ) {
         desc.startStage("Extracting strong equivalents");
-        SortedSetMultimap<Publisher, ScoredCandidate<T>> publisherBins = publisherBin(filteredCandidates);
+        SortedSetMultimap<Publisher, ScoredCandidate<T>> publisherBins =
+                publisherBin(filteredCandidates);
         
-        ImmutableMultimap.Builder<Publisher, ScoredCandidate<T>> builder = ImmutableMultimap.builder();
+        ImmutableMultimap.Builder<Publisher, ScoredCandidate<T>> builder =
+                ImmutableMultimap.builder();
         
         for (Publisher publisher : publisherBins.keySet()) {
             desc.startStage(String.format("Publisher: %s", publisher));
             
-            ImmutableSortedSet<ScoredCandidate<T>> copyOfSorted = ImmutableSortedSet.copyOfSorted(publisherBins.get(publisher));
-            Optional<ScoredCandidate<T>> extracted = extractor.extract(copyOfSorted.asList().reverse(), target, desc);
-            Set<ScoredCandidate<T>> allowedCandidates = candidatesThatCanBeEquivalatedToSamePublisher(copyOfSorted, extracted, target);
+            ImmutableSortedSet<ScoredCandidate<T>> copyOfSorted =
+                    ImmutableSortedSet.copyOfSorted(publisherBins.get(publisher));
 
-            if(!extracted.isPresent()) {
-                // no candidates - do nothing
-            }
-            else if (isSeriesOrBrand(extracted.get().candidate())) {
-                builder.put(publisher, extracted.get());
-            } else if(allowedCandidates.size() > 0 && !isSeriesOrBrand(target)) {
-                for (ScoredCandidate<T> scoredCandidate : allowedCandidates) {
-                    builder.put(publisher, scoredCandidate);
-                }
+            Optional<Set<ScoredCandidate<T>>> multipleExtractedCandidates =
+                    multipleCandidateExtractor.extract(
+                            copyOfSorted.asList().reverse(), target
+                    );
+
+            if (multipleExtractedCandidates.isPresent()) {
+                builder.putAll(
+                        publisher,
+                        multipleExtractedCandidates.get()
+                );
             } else {
-                if(extracted.isPresent()) {
+                Optional<ScoredCandidate<T>> extracted = extractor.extract(
+                        copyOfSorted.asList().reverse(), target, desc
+                );
+                if (extracted.isPresent()) {
                     builder.put(publisher, extracted.get());
                 }
             }
@@ -120,70 +123,6 @@ public class DefaultEquivalenceResultBuilder<T extends Content> implements Equiv
         
         desc.finishStage();
         return builder.build();
-    }
-
-    private boolean isSeriesOrBrand(T target) {
-        return (target instanceof Brand || target instanceof Series);
-    }
-
-    private Set<ScoredCandidate<T>> candidatesThatCanBeEquivalatedToSamePublisher(
-            Set<ScoredCandidate<T>> candidates,
-            Optional<ScoredCandidate<T>> optionalHighestScoringCandidate,
-            T target
-    ) {
-        final ScoredCandidate<T> highestScoringCandidate;
-        Set<ScoredCandidate<T>> allowedCandidates = new HashSet<>();
-        if (!optionalHighestScoringCandidate.isPresent()) {
-            return allowedCandidates;
-        } else {
-            highestScoringCandidate = optionalHighestScoringCandidate.get();
-        }
-
-        ImmutableSet<ScoredCandidate<T>> filteredCandidates = candidates.stream()
-                .filter(candidate -> !isSeriesOrBrand(candidate.candidate()))
-                .collect(MoreCollectors.toImmutableSet());
-
-        ImmutableSet<ScoredCandidate<T>> matchedCandidates = filteredCandidates
-                .stream()
-                .filter(candidate -> Math.abs(
-                        candidate.score().asDouble() - highestScoringCandidate.score().asDouble()
-                ) < PUBLISHER_MATCHING_EQUIV_THRESHOLD)
-                .filter(candidate -> broadcastsMatchCheck(target, candidate))
-                .collect(MoreCollectors.toImmutableSet());
-
-        if (matchedCandidates.size() > 0) {
-            allowedCandidates.addAll(matchedCandidates);
-        }
-
-        return allowedCandidates;
-    }
-
-    private boolean broadcastsMatchCheck(
-            T target,
-            ScoredCandidate<T> candidate
-    ) {
-        return target.getVersions().stream()
-                .flatMap(v -> v.getBroadcasts().stream())
-                .anyMatch(b -> broadcastsMatchCheck(candidate, b));
-    }
-
-    private boolean broadcastsMatchCheck(ScoredCandidate<T> candidate, Broadcast broadcast) {
-        return candidate.candidate().getVersions().stream()
-                .flatMap(v -> v.getBroadcasts().stream())
-                .anyMatch(b -> broadcastsMatchCheckInclusive(b, broadcast));
-    }
-
-    private boolean broadcastsMatchCheckInclusive(Broadcast broadcastOne, Broadcast broadcastTwo) {
-        DateTime broadcastTransmissionStart = broadcastOne.getTransmissionTime();
-        DateTime broadcastTransmissionEnd = broadcastOne.getTransmissionEndTime();
-        DateTime broadcastTwoTransmissionStart = broadcastTwo.getTransmissionTime();
-        DateTime broadcastTwoTransmissionEnd = broadcastTwo.getTransmissionEndTime();
-
-        // Check if first broadcast is contained within the second with some flexibility
-        return broadcastTransmissionStart.isAfter(
-                broadcastTwoTransmissionStart.minus(BROADCAST_TIME_FLEXIBILITY)) &&
-                broadcastTransmissionEnd.isBefore(
-                        broadcastTwoTransmissionEnd.plus(BROADCAST_TIME_FLEXIBILITY));
     }
 
     private SortedSetMultimap<Publisher, ScoredCandidate<T>> publisherBin(List<ScoredCandidate<T>> filteredCandidates) {

--- a/src/main/java/org/atlasapi/equiv/results/DefaultEquivalenceResultBuilder.java
+++ b/src/main/java/org/atlasapi/equiv/results/DefaultEquivalenceResultBuilder.java
@@ -35,6 +35,7 @@ import com.google.common.collect.Ordering;
 import com.google.common.collect.SortedSetMultimap;
 import com.google.common.collect.TreeMultimap;
 import org.joda.time.DateTime;
+import org.joda.time.Duration;
 
 public class DefaultEquivalenceResultBuilder<T extends Content> implements EquivalenceResultBuilder<T> {
 
@@ -45,6 +46,7 @@ public class DefaultEquivalenceResultBuilder<T extends Content> implements Equiv
     private final ScoreCombiner<T> combiner;
     private final EquivalenceExtractor<T> extractor;
     private final EquivalenceFilter<T> filter;
+    private static final Duration BROADCAST_TIME_FLEXIBILITY = Duration.standardMinutes(5);
 
     public DefaultEquivalenceResultBuilder(ScoreCombiner<T> combiner, EquivalenceFilter<T> filter, EquivalenceExtractor<T> extractor) {
         this.combiner = combiner;
@@ -160,10 +162,14 @@ public class DefaultEquivalenceResultBuilder<T extends Content> implements Equiv
         DateTime broadcastTwoTransmissionStart = broadcastTwo.getTransmissionTime();
         DateTime broadcastTwoTransmissionEnd = broadcastTwo.getTransmissionEndTime();
 
-        return (broadcastTransmissionStart.isAfter(broadcastTwoTransmissionStart) &&
-                broadcastTransmissionStart.isBefore(broadcastTwoTransmissionEnd) &&
-                broadcastTransmissionEnd.isAfter(broadcastTwoTransmissionStart) &&
-                broadcastTransmissionEnd.isBefore(broadcastTwoTransmissionEnd));
+        return (broadcastTransmissionStart.isAfter(
+                broadcastTwoTransmissionStart.minus(BROADCAST_TIME_FLEXIBILITY)) &&
+                broadcastTransmissionStart.isBefore(
+                        broadcastTwoTransmissionEnd.plus(BROADCAST_TIME_FLEXIBILITY)) &&
+                broadcastTransmissionEnd.isAfter(
+                        broadcastTwoTransmissionStart.minus(BROADCAST_TIME_FLEXIBILITY)) &&
+                broadcastTransmissionEnd.isBefore(
+                        broadcastTwoTransmissionEnd.plus(BROADCAST_TIME_FLEXIBILITY)));
     }
 
     private SortedSetMultimap<Publisher, ScoredCandidate<T>> publisherBin(List<ScoredCandidate<T>> filteredCandidates) {

--- a/src/main/java/org/atlasapi/equiv/results/extractors/MultipleCandidateExtractor.java
+++ b/src/main/java/org/atlasapi/equiv/results/extractors/MultipleCandidateExtractor.java
@@ -1,0 +1,122 @@
+package org.atlasapi.equiv.results.extractors;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.atlasapi.equiv.results.DefaultEquivalenceResultBuilder;
+import org.atlasapi.equiv.results.scores.ScoredCandidate;
+import org.atlasapi.media.entity.Brand;
+import org.atlasapi.media.entity.Broadcast;
+import org.atlasapi.media.entity.Content;
+import org.atlasapi.media.entity.Series;
+
+import com.metabroadcast.common.stream.MoreCollectors;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableSet;
+import org.joda.time.DateTime;
+import org.joda.time.Duration;
+
+/**
+ * This extractor attempts to get multiple candidates for the same publisher. It will only do this
+ * if
+ * <ul>
+ *     <li>the target is not a brand or a series</li>
+ *     <li>the top scoring candidate is not a brand or a series</li>
+ *     <li>it can find a group of candidates whose score is close (within
+ *     {@link MultipleCandidateExtractor#BROADCAST_TIME_FLEXIBILITY}) to the top scoring candidate
+ *     and that have at least one broadcast that either contains or are contained by any
+ *     target broadcast (+- {@link MultipleCandidateExtractor#BROADCAST_TIME_FLEXIBILITY})</li>
+ * </ul>
+ */
+public class MultipleCandidateExtractor<T extends Content> {
+
+    private static final Duration BROADCAST_TIME_FLEXIBILITY = Duration.standardMinutes(5);
+    private static final double PUBLISHER_MATCHING_EQUIV_THRESHOLD = 0.3;
+
+    private MultipleCandidateExtractor() {
+    }
+
+    public static <T extends Content> MultipleCandidateExtractor<T> create() {
+        return new MultipleCandidateExtractor<>();
+    }
+
+    public Optional<Set<ScoredCandidate<T>>> extract(
+            List<ScoredCandidate<T>> candidates,
+            T target
+    ) {
+        if (isSeriesOrBrand(target) || candidates.isEmpty()) {
+            return Optional.absent();
+        }
+
+        ScoredCandidate<T> highestScoringCandidate = candidates.get(0);
+
+        if (isSeriesOrBrand(highestScoringCandidate.candidate())) {
+            return Optional.absent();
+        }
+
+        Set<ScoredCandidate<T>> allowedCandidates = new HashSet<ScoredCandidate<T>>();
+
+        allowedCandidates.add(highestScoringCandidate);
+
+        ImmutableSet<ScoredCandidate<T>> filteredCandidates = candidates.stream()
+                .filter(candidate -> !isSeriesOrBrand(candidate.candidate()))
+                .collect(MoreCollectors.toImmutableSet());
+
+        ImmutableSet<ScoredCandidate<T>> matchedCandidates = filteredCandidates
+                .stream()
+                .filter(candidate -> Math.abs(
+                        candidate.score().asDouble() - highestScoringCandidate.score().asDouble()
+                ) < PUBLISHER_MATCHING_EQUIV_THRESHOLD)
+                .filter(candidate -> broadcastsMatchCheck(target, candidate))
+                .collect(MoreCollectors.toImmutableSet());
+
+        allowedCandidates.addAll(matchedCandidates);
+
+        // If we have found a group of candidates return it otherwise return absent and let
+        // the configured extractor decide instead
+        if (allowedCandidates.size() > 1) {
+            return Optional.of(allowedCandidates);
+        } else {
+            return Optional.absent();
+        }
+    }
+
+    private boolean isSeriesOrBrand(T target) {
+        return (target instanceof Brand || target instanceof Series);
+    }
+
+    private boolean broadcastsMatchCheck(
+            T target,
+            ScoredCandidate<T> candidate
+    ) {
+        return target.getVersions().stream()
+                .flatMap(version -> version.getBroadcasts().stream())
+                .anyMatch(broadcast -> broadcastsMatchCheck(candidate.candidate(), broadcast))
+                ||
+                candidate.candidate().getVersions().stream()
+                        .flatMap(version -> version.getBroadcasts().stream())
+                        .anyMatch(broadcast -> broadcastsMatchCheck(target, broadcast));
+    }
+
+    private boolean broadcastsMatchCheck(T candidate, Broadcast broadcast) {
+        return candidate.getVersions().stream()
+                .flatMap(version -> version.getBroadcasts().stream())
+                .anyMatch(broadcast1 -> broadcastsMatchCheckInclusive(broadcast1, broadcast));
+    }
+
+    private boolean broadcastsMatchCheckInclusive(Broadcast broadcastOne, Broadcast broadcastTwo) {
+        DateTime broadcastTransmissionStart = broadcastOne.getTransmissionTime();
+        DateTime broadcastTransmissionEnd = broadcastOne.getTransmissionEndTime();
+        DateTime broadcastTwoTransmissionStart = broadcastTwo.getTransmissionTime();
+        DateTime broadcastTwoTransmissionEnd = broadcastTwo.getTransmissionEndTime();
+
+        // Check if first broadcast is contained within the second with some flexibility
+        return broadcastTransmissionStart.isAfter(
+                broadcastTwoTransmissionStart.minus(BROADCAST_TIME_FLEXIBILITY))
+                &&
+                broadcastTransmissionEnd.isBefore(
+                        broadcastTwoTransmissionEnd.plus(BROADCAST_TIME_FLEXIBILITY));
+    }
+}

--- a/src/test/java/org/atlasapi/equiv/results/DefaultEquivalenceResultBuilderTest.java
+++ b/src/test/java/org/atlasapi/equiv/results/DefaultEquivalenceResultBuilderTest.java
@@ -1,5 +1,6 @@
 package org.atlasapi.equiv.results;
 
+import java.util.Date;
 import java.util.List;
 
 import org.atlasapi.equiv.results.combining.AddingEquivalenceCombiner;
@@ -55,10 +56,10 @@ public class DefaultEquivalenceResultBuilderTest {
     public void checkDoesEquivalateToSeveralPaWithInclusiveBroadcasts() {
 
         EquivalenceResult equivalenceResult = itemsWithBroadcastAndScores(
-                "4500",
-                "2500",
-                "5500",
-                "6500",
+                new DateTime().withHourOfDay(4),
+                new DateTime().withHourOfDay(2),
+                new DateTime().withHourOfDay(5),
+                new DateTime().withHourOfDay(6),
                 5.0,
                 4.8
         );
@@ -69,10 +70,10 @@ public class DefaultEquivalenceResultBuilderTest {
     public void checkDoesEquivalateToSeveralPaWithBoundaryBroadcasts() {
 
         EquivalenceResult equivalenceResult = itemsWithBroadcastAndScores(
-                "4500",
-                "4500",
-                "5500",
-                "5500",
+                new DateTime().withHourOfDay(4),
+                new DateTime().withHourOfDay(4),
+                new DateTime().withHourOfDay(5),
+                new DateTime().withHourOfDay(5),
                 5.0,
                 4.8
         );
@@ -82,10 +83,10 @@ public class DefaultEquivalenceResultBuilderTest {
     @Test
     public void checkWontEquivalateToBothWithOverlappingScores() {
         EquivalenceResult equivalenceResult = itemsWithBroadcastAndScores(
-                "2500",
-                "5500",
-                "4500",
-                "6500",
+                new DateTime().withHourOfDay(2),
+                new DateTime().withHourOfDay(5),
+                new DateTime().withHourOfDay(4),
+                new DateTime().withHourOfDay(6),
                 5.0,
                 4.8
         );
@@ -98,11 +99,17 @@ public class DefaultEquivalenceResultBuilderTest {
         item.setPublisher(Publisher.ARQIVA);
         item.setCanonicalUri("target");
 
-        Brand candidate1 = brandWithBroadcast("2500", "6500");
+        Brand candidate1 = brandWithBroadcast(
+                new DateTime().withHourOfDay(2),
+                new DateTime().withHourOfDay(6)
+        );
         candidate1.setPublisher(Publisher.PA);
         candidate1.setCanonicalUri("candidate1");
 
-        Item candidate2 = itemWithBroadcast("4500", "5500");
+        Item candidate2 = itemWithBroadcast(
+                new DateTime().withHourOfDay(4),
+                new DateTime().withHourOfDay(5)
+        );
         candidate2.setPublisher(Publisher.PA);
         candidate2.setCanonicalUri("candidate2");
 
@@ -127,12 +134,18 @@ public class DefaultEquivalenceResultBuilderTest {
         item.setPublisher(Publisher.ARQIVA);
         item.setCanonicalUri("target");
 
-        Series candidate1 = seriesWithBroadcast("2500", "6500");
+        Series candidate1 = seriesWithBroadcast(
+                new DateTime().withHourOfDay(2),
+                new DateTime().withHourOfDay(6)
+        );
         candidate1.setPublisher(Publisher.PA);
         candidate1.setCanonicalUri("candidate1");
 
 
-        Item candidate2 = itemWithBroadcast("4500", "5500");
+        Item candidate2 = itemWithBroadcast(
+                new DateTime().withHourOfDay(4),
+                new DateTime().withHourOfDay(5)
+        );
         candidate2.setPublisher(Publisher.PA);
         candidate2.setCanonicalUri("candidate2");
 
@@ -154,12 +167,12 @@ public class DefaultEquivalenceResultBuilderTest {
     @Test
     public void checkWillOnlyTakeBroadcastMatchingCandidatesNotAll() {
         EquivalenceResult equivalenceResult = itemsWithBroadcastAndScores(
-                "4500",
-                "2500",
-                "9500",
-                "4400",
-                "6500",
-                "9600",
+                new DateTime().withHourOfDay(5),
+                new DateTime().withHourOfDay(2),
+                new DateTime().withHourOfDay(9),
+                new DateTime().withHourOfDay(4),
+                new DateTime().withHourOfDay(6),
+                new DateTime().withHourOfDay(9).withMinuteOfHour(15),
                 5.0,
                 4.8,
                 4.9
@@ -168,12 +181,12 @@ public class DefaultEquivalenceResultBuilderTest {
     }
 
     private EquivalenceResult itemsWithBroadcastAndScores(
-            String startTime1,
-            String startTime2,
-            String startTime3,
-            String endTime1,
-            String endTime2,
-            String endTime3,
+            DateTime startTime1,
+            DateTime startTime2,
+            DateTime startTime3,
+            DateTime endTime1,
+            DateTime endTime2,
+            DateTime endTime3,
             Double score1,
             Double score2,
             Double score3
@@ -212,10 +225,10 @@ public class DefaultEquivalenceResultBuilderTest {
     }
 
     private EquivalenceResult itemsWithBroadcastAndScores(
-            String startTime1,
-            String startTime2,
-            String endTime1,
-            String endTime2,
+            DateTime startTime1,
+            DateTime startTime2,
+            DateTime endTime1,
+            DateTime endTime2,
             Double score1,
             Double score2
     ) {
@@ -247,73 +260,28 @@ public class DefaultEquivalenceResultBuilderTest {
         return equivalenceResult;
     }
 
-    private Item itemWithBroadcast(String startTime, String endTime) {
+    private Item itemWithBroadcast(DateTime startTime, DateTime endTime) {
         Item item = new Item();
         Version version = new Version();
-
-        DateTime dateTime1 = new DateTime().withDayOfYear(1).withYear(1).withTime(
-                Integer.parseInt(startTime.substring(0, 1)),
-                Integer.parseInt(startTime.substring(1, 2)),
-                Integer.parseInt(startTime.substring(2, 3)),
-                Integer.parseInt(startTime.substring(3, 4))
-        );
-
-        DateTime dateTime2 = new DateTime().withDayOfYear(1).withDayOfYear(1).withTime(
-                Integer.parseInt(endTime.substring(0, 1)),
-                Integer.parseInt(endTime.substring(1, 2)),
-                Integer.parseInt(endTime.substring(2, 3)),
-                Integer.parseInt(endTime.substring(3, 4))
-        );
-
-        Broadcast broadcast1 = new Broadcast("", dateTime1, dateTime2);
+        Broadcast broadcast1 = new Broadcast("", startTime, endTime);
         version.setBroadcasts(ImmutableSet.of(broadcast1));
         item.setVersions(ImmutableSet.of(version));
         return item;
     }
 
-    private Brand brandWithBroadcast(String startTime, String endTime) {
+    private Brand brandWithBroadcast(DateTime startTime, DateTime endTime) {
         Brand brand = new Brand();
         Version version = new Version();
-
-        DateTime dateTime1 = new DateTime().withDayOfYear(1).withYear(1).withTime(
-                Integer.parseInt(startTime.substring(0, 1)),
-                Integer.parseInt(startTime.substring(1, 2)),
-                Integer.parseInt(startTime.substring(2, 3)),
-                Integer.parseInt(startTime.substring(3, 4))
-        );
-
-        DateTime dateTime2 = new DateTime().withDayOfYear(1).withDayOfYear(1).withTime(
-                Integer.parseInt(endTime.substring(0, 1)),
-                Integer.parseInt(endTime.substring(1, 2)),
-                Integer.parseInt(endTime.substring(2, 3)),
-                Integer.parseInt(endTime.substring(3, 4))
-        );
-
-        Broadcast broadcast1 = new Broadcast("", dateTime1, dateTime2);
+        Broadcast broadcast1 = new Broadcast("", startTime, endTime);
         version.setBroadcasts(ImmutableSet.of(broadcast1));
         brand.setVersions(ImmutableSet.of(version));
         return brand;
     }
 
-    private Series seriesWithBroadcast(String startTime, String endTime) {
+    private Series seriesWithBroadcast(DateTime startTime, DateTime endTime) {
         Series series = new Series();
         Version version = new Version();
-
-        DateTime dateTime1 = new DateTime().withDayOfYear(1).withYear(1).withTime(
-                Integer.parseInt(startTime.substring(0, 1)),
-                Integer.parseInt(startTime.substring(1, 2)),
-                Integer.parseInt(startTime.substring(2, 3)),
-                Integer.parseInt(startTime.substring(3, 4))
-        );
-
-        DateTime dateTime2 = new DateTime().withDayOfYear(1).withDayOfYear(1).withTime(
-                Integer.parseInt(endTime.substring(0, 1)),
-                Integer.parseInt(endTime.substring(1, 2)),
-                Integer.parseInt(endTime.substring(2, 3)),
-                Integer.parseInt(endTime.substring(3, 4))
-        );
-
-        Broadcast broadcast1 = new Broadcast("", dateTime1, dateTime2);
+        Broadcast broadcast1 = new Broadcast("", startTime, endTime);
         version.setBroadcasts(ImmutableSet.of(broadcast1));
         series.setVersions(ImmutableSet.of(version));
         return series;

--- a/src/test/java/org/atlasapi/equiv/results/DefaultEquivalenceResultBuilderTest.java
+++ b/src/test/java/org/atlasapi/equiv/results/DefaultEquivalenceResultBuilderTest.java
@@ -1,6 +1,5 @@
 package org.atlasapi.equiv.results;
 
-import java.util.Date;
 import java.util.List;
 
 import org.atlasapi.equiv.results.combining.AddingEquivalenceCombiner;
@@ -12,7 +11,6 @@ import org.atlasapi.equiv.results.filters.AlwaysTrueFilter;
 import org.atlasapi.equiv.results.filters.EquivalenceFilter;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.results.scores.Score;
-import org.atlasapi.equiv.results.scores.ScoredCandidate;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
 import org.atlasapi.media.entity.Brand;
 import org.atlasapi.media.entity.Broadcast;
@@ -22,14 +20,12 @@ import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.media.entity.Series;
 import org.atlasapi.media.entity.Version;
 
-import com.google.common.base.Equivalence;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.joda.time.DateTime;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class DefaultEquivalenceResultBuilderTest {
 
@@ -105,6 +101,25 @@ public class DefaultEquivalenceResultBuilderTest {
                 4.8
         );
         assertTrue(equivalenceResult.strongEquivalences().values().size() == 2);
+    }
+
+    @Test
+    public void checkDoesEquivalateToSeveralPaWithCandidatesLargerBroadcastThanTarget() {
+
+        EquivalenceResult equivalenceResult = itemsWithBroadcastAndScores(
+                new DateTime().withHourOfDay(4),
+                new DateTime().withHourOfDay(5),
+                new DateTime().withHourOfDay(4),
+                new DateTime().withHourOfDay(3),
+                new DateTime().withHourOfDay(4),
+                new DateTime().withHourOfDay(5),
+                new DateTime().withHourOfDay(6),
+                new DateTime().withHourOfDay(5),
+                5.0,
+                4.8,
+                4.9
+        );
+        assertTrue(equivalenceResult.strongEquivalences().values().size() == 3);
     }
 
     @Test

--- a/src/test/java/org/atlasapi/equiv/results/DefaultEquivalenceResultBuilderTest.java
+++ b/src/test/java/org/atlasapi/equiv/results/DefaultEquivalenceResultBuilderTest.java
@@ -66,6 +66,20 @@ public class DefaultEquivalenceResultBuilderTest {
     }
 
     @Test
+    public void checkDoesEquivalateToSeveralPaWithBoundaryBroadcasts() {
+
+        EquivalenceResult equivalenceResult = itemsWithBroadcastAndScores(
+                "4500",
+                "4500",
+                "5500",
+                "5500",
+                5.0,
+                4.8
+        );
+        assertTrue(equivalenceResult.strongEquivalences().values().size() == 2);
+    }
+
+    @Test
     public void checkWontEquivalateToBothWithOverlappingScores() {
         EquivalenceResult equivalenceResult = itemsWithBroadcastAndScores(
                 "2500",

--- a/src/test/java/org/atlasapi/equiv/results/DefaultEquivalenceResultBuilderTest.java
+++ b/src/test/java/org/atlasapi/equiv/results/DefaultEquivalenceResultBuilderTest.java
@@ -39,7 +39,7 @@ public class DefaultEquivalenceResultBuilderTest {
     private final DefaultEquivalenceResultBuilder resultBuilder = new DefaultEquivalenceResultBuilder(combiner, filter, extractor);
 
     @Test
-    public void checkDoesNotEquivalateToSeveralPa() {
+    public void checkDoesNotEquivalateToSeveralPaWithoutBroadcasts() {
         Item item = new Item();
         item.setPublisher(Publisher.ARQIVA);
         item.setCanonicalUri("target");


### PR DESCRIPTION
… to content if their broadcasts overlap

this checks through all the candidates and their versions and their broadcasts within versions and sees if any of the broadcasts are inclusive of another's broadcast. If so the target content is allowed to equivalate to multiple pieces of content with the same publisher.