### PR TITLE
Add support for broadcastAssertions request parameter when writing

### DIFF
--- a/src/main/java/org/atlasapi/query/QueryExecutorModule.java
+++ b/src/main/java/org/atlasapi/query/QueryExecutorModule.java
@@ -91,7 +91,7 @@ public class QueryExecutorModule {
 
     @Bean
     public ContentWriteExecutor contentWriteExecutor() {
-        return new ContentWriteExecutor(
+        return ContentWriteExecutor.create(
                 new DefaultJacksonModelReader(),
                 delegatingModelTransformer(),
                 contentResolver,

--- a/src/main/java/org/atlasapi/query/content/merge/BroadcastMerger.java
+++ b/src/main/java/org/atlasapi/query/content/merge/BroadcastMerger.java
@@ -1,0 +1,230 @@
+package org.atlasapi.query.content.merge;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import org.atlasapi.media.entity.Broadcast;
+
+import com.metabroadcast.common.stream.MoreCollectors;
+
+import com.google.api.client.repackaged.com.google.common.base.Strings;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import org.joda.time.DateTime;
+import org.joda.time.Interval;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class BroadcastMerger {
+
+    private static final Splitter ASSERTION_LIST_SPLITTER = Splitter.on("\",\"");
+    private static final Splitter ASSERTION_SPLITTER = Splitter.on("\"|\"");
+
+    private final Optional<ImmutableMultimap<String, BroadcastAssertion>> channelAssertions;
+
+    private BroadcastMerger(
+            Optional<ImmutableMultimap<String, BroadcastAssertion>> channelAssertions) {
+        this.channelAssertions = checkNotNull(channelAssertions);
+
+        if (this.channelAssertions.isPresent()) {
+            checkArgument(!this.channelAssertions.get().isEmpty());
+        }
+    }
+
+    public static BroadcastMerger defaultMerger() {
+        return new BroadcastMerger(Optional.empty());
+    }
+
+    public static BroadcastMerger parse(@Nullable String broadcastAssertionsParameter) {
+        if (Strings.isNullOrEmpty(broadcastAssertionsParameter)) {
+            return new BroadcastMerger(Optional.empty());
+        }
+
+        String trimmedParameter = broadcastAssertionsParameter.trim();
+
+        checkArgument(trimmedParameter.startsWith("\""));
+        checkArgument(trimmedParameter.endsWith("\""));
+
+        String parameter = trimmedParameter.substring(
+                1, trimmedParameter.length() - 1
+        );
+
+        ImmutableListMultimap<String, BroadcastAssertion> assertions = ASSERTION_LIST_SPLITTER
+                .splitToList(parameter)
+                .stream()
+                .map(BroadcastMerger::parseAssertion)
+                .collect(MoreCollectors.toImmutableListMultiMap(
+                        BroadcastAssertion::getChannelUri,
+                        Function.identity()
+                ));
+
+        return new BroadcastMerger(Optional.of(assertions));
+    }
+
+    private static BroadcastAssertion parseAssertion(String assertion) {
+        List<String> parsedAssertion = ASSERTION_SPLITTER.splitToList(assertion);
+
+        checkArgument(parsedAssertion.size() == 3);
+
+        return BroadcastAssertion.create(
+                parsedAssertion.get(0),
+                DateTime.parse(parsedAssertion.get(1)),
+                DateTime.parse(parsedAssertion.get(2))
+        );
+    }
+
+    public ImmutableSet<Broadcast> merge(
+            Set<Broadcast> update,
+            Set<Broadcast> existing,
+            boolean merge
+    ) {
+        if (!merge) {
+            return ImmutableSet.copyOf(update);
+        }
+
+        boolean updateBroadcastsValid = update
+                .stream()
+                .allMatch(this::isValidUpdateBroadcast);
+
+        if (!updateBroadcastsValid) {
+            throw new IllegalArgumentException("Found broadcasts in the request body that are"
+                    + " outside the asserted interval");
+        }
+
+        ImmutableSet<Broadcast> broadcastsToPreserve = existing
+                .stream()
+                .filter(this::shouldPreserveExistingBroadcast)
+                .collect(MoreCollectors.toImmutableSet());
+
+        return ImmutableSet.<Broadcast>builder()
+                .addAll(broadcastsToPreserve)
+                .addAll(update)
+                .build();
+    }
+
+    private Boolean shouldPreserveExistingBroadcast(Broadcast broadcast) {
+        if (!channelAssertions.isPresent()) {
+            // If we have no assertions all existing broadcasts should be removed
+            return false;
+        }
+
+        ImmutableCollection<BroadcastAssertion> assertions =
+                channelAssertions.get().get(broadcast.getBroadcastOn());
+
+        if (assertions.isEmpty()) {
+            return true;
+        }
+
+        Interval broadcastInterval = new Interval(
+                broadcast.getTransmissionTime(),
+                broadcast.getTransmissionEndTime()
+        );
+
+        return assertions.stream()
+                .noneMatch(assertion -> assertion.overlaps(broadcastInterval));
+    }
+
+    private Boolean isValidUpdateBroadcast(Broadcast broadcast) {
+        if (!channelAssertions.isPresent()) {
+            // If we have no assertions all update broadcasts are valid
+            return true;
+        }
+
+        ImmutableCollection<BroadcastAssertion> assertions =
+                channelAssertions.get().get(broadcast.getBroadcastOn());
+
+        if (assertions.isEmpty()) {
+            return false;
+        }
+
+        Interval broadcastInterval = new Interval(
+                broadcast.getTransmissionTime(),
+                broadcast.getTransmissionEndTime()
+        );
+
+        return assertions.stream()
+                .anyMatch(assertion -> assertion.contains(broadcastInterval));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BroadcastMerger that = (BroadcastMerger) o;
+        return Objects.equals(channelAssertions, that.channelAssertions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(channelAssertions);
+    }
+
+    private static class BroadcastAssertion {
+
+        private final String channelUri;
+        private final Interval interval;
+
+        private BroadcastAssertion(String channelUri, DateTime from, DateTime to) {
+            this.channelUri = checkNotNull(channelUri);
+
+            checkNotNull(from);
+            checkNotNull(to);
+            checkArgument(from.isBefore(to));
+
+            this.interval = new Interval(from, to);
+        }
+
+        public static BroadcastAssertion create(String channelId, DateTime from, DateTime to) {
+            return new BroadcastAssertion(channelId, from, to);
+        }
+
+        public String getChannelUri() {
+            return channelUri;
+        }
+
+        public boolean overlaps(Interval interval) {
+            return this.interval.overlaps(interval);
+        }
+
+        public boolean contains(Interval interval) {
+            return this.interval.contains(interval)
+                    || isZeroDurationAtEndOfThisInterval(interval);
+        }
+
+        private boolean isZeroDurationAtEndOfThisInterval(Interval interval) {
+            return interval.toDurationMillis() == 0L
+                    && interval.getStart().equals(this.interval.getEnd());
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            BroadcastAssertion that = (BroadcastAssertion) o;
+            return Objects.equals(channelUri, that.channelUri) &&
+                    Objects.equals(interval, that.interval);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(channelUri, interval);
+        }
+    }
+}

--- a/src/main/java/org/atlasapi/query/content/merge/package-info.java
+++ b/src/main/java/org/atlasapi/query/content/merge/package-info.java
@@ -1,0 +1,4 @@
+@NonNullByDefault
+package org.atlasapi.query.content.merge;
+
+import com.metabroadcast.common.annotation.NonNullByDefault;

--- a/src/test/java/org/atlasapi/query/content/merge/BroadcastMergerTest.java
+++ b/src/test/java/org/atlasapi/query/content/merge/BroadcastMergerTest.java
@@ -1,0 +1,487 @@
+package org.atlasapi.query.content.merge;
+
+import org.atlasapi.media.entity.Broadcast;
+
+import com.google.common.collect.ImmutableSet;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class BroadcastMergerTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void missingAssertionValueFailsParsing() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        BroadcastMerger.parse("\"cbkM\"|\"2016-01-01T00:00:00Z\"");
+    }
+
+    @Test
+    public void fromDateAfterToFailsParsing() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        BroadcastMerger.parse("\"cbkM\"|\"2016-01-02T00:00:00Z\"|\"2016-01-01T00:00:00Z\"");
+    }
+
+    @Test
+    public void fromDateSameAsToFailsParsing() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        BroadcastMerger.parse("\"cbkM\"|\"2016-01-01T00:00:00Z\"|\"2016-01-01T00:00:00Z\"");
+    }
+
+    @Test
+    public void invalidDateFailsParsing() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        BroadcastMerger.parse("\"cbkM\"|\"2016-01-01T00:00:00Z\"|\"2016-01-01T99:00:00Z\"");
+    }
+
+    @Test
+    public void mergerWithMissingQuotesFailsParsing() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        BroadcastMerger.parse("\"cbkM\"|\"2016-01-01T00:00:00Z|\"2016-01-01T12:00:00Z\"");
+    }
+
+    @Test
+    public void mergerWithLeadingAndTrailingWhitespaceDoesNotFailParsing() throws Exception {
+        BroadcastMerger.parse(" \"cbkM\"|\"2016-01-01T00:00:00Z\"|\"2016-01-01T12:00:00Z\" ");
+    }
+
+    @Test
+    public void nullAssertionParameterRemovesAllExistingBroadcasts() throws Exception {
+        BroadcastMerger merger = BroadcastMerger.parse(null);
+
+        Broadcast broadcast = new Broadcast("channelUri", DateTime.now(), DateTime.now());
+
+        ImmutableSet<Broadcast> merge = merger.merge(
+                ImmutableSet.of(),
+                ImmutableSet.of(broadcast),
+                true
+        );
+
+        assertThat(merge.isEmpty(), is(true));
+    }
+
+    @Test
+    public void emptyAssertionParameterRemovesAllExistingBroadcasts() throws Exception {
+        BroadcastMerger merger = BroadcastMerger.parse("");
+
+        Broadcast broadcast = new Broadcast("channelUri", DateTime.now(), DateTime.now());
+
+        ImmutableSet<Broadcast> merge = merger.merge(
+                ImmutableSet.of(),
+                ImmutableSet.of(broadcast),
+                true
+        );
+
+        assertThat(merge.isEmpty(), is(true));
+    }
+
+    @Test
+    public void nullAssertionParameterConsidersAllUpdateBroadcastsValid() throws Exception {
+        BroadcastMerger merger = BroadcastMerger.parse(null);
+
+        Broadcast broadcast = new Broadcast("channelUri", DateTime.now(), DateTime.now());
+
+        ImmutableSet<Broadcast> merge = merger.merge(
+                ImmutableSet.of(broadcast),
+                ImmutableSet.of(),
+                true
+        );
+
+        assertThat(merge.contains(broadcast), is(true));
+    }
+
+    @Test
+    public void emptyAssertionParameterConsidersAllUpdateBroadcastsValid() throws Exception {
+        BroadcastMerger merger = BroadcastMerger.parse("");
+
+        Broadcast broadcast = new Broadcast("channelUri", DateTime.now(), DateTime.now());
+
+        ImmutableSet<Broadcast> merge = merger.merge(
+                ImmutableSet.of(broadcast),
+                ImmutableSet.of(),
+                true
+        );
+
+        assertThat(merge.contains(broadcast), is(true));
+    }
+
+    @Test
+    public void mergerPreservesNonOverlappingBroadcast() throws Exception {
+        BroadcastMerger merger = BroadcastMerger.parse(
+                "\"channelUri\"|\"2016-01-01T00:00:00Z\"|\"2016-01-02T00:00:00Z\""
+        );
+
+        Broadcast broadcast = new Broadcast(
+                "channelUri",
+                new DateTime(2016, 2, 1, 0, 0, 0, DateTimeZone.UTC),
+                new DateTime(2016, 2, 2, 0, 0, 0, DateTimeZone.UTC)
+        );
+
+        ImmutableSet<Broadcast> merge = merger.merge(
+                ImmutableSet.of(),
+                ImmutableSet.of(broadcast),
+                true
+        );
+
+        assertThat(merge.contains(broadcast), is(true));
+    }
+
+    @Test
+    public void mergerPreservesBroadcastThatEndsWhenTheAssertionBegins() throws Exception {
+        BroadcastMerger merger = BroadcastMerger.parse(
+                "\"channelUri\"|\"2016-01-05T00:00:00Z\"|\"2016-01-06T00:00:00Z\""
+        );
+
+        Broadcast broadcast = new Broadcast(
+                "channelUri",
+                new DateTime(2016, 1, 4, 0, 0, 0, DateTimeZone.UTC),
+                new DateTime(2016, 1, 5, 0, 0, 0, DateTimeZone.UTC)
+        );
+
+        ImmutableSet<Broadcast> merge = merger.merge(
+                ImmutableSet.of(),
+                ImmutableSet.of(broadcast),
+                true
+        );
+
+        assertThat(merge.contains(broadcast), is(true));
+    }
+
+    @Test
+    public void mergerPreservesBroadcastThatBeginsWhenTheAssertionEnds() throws Exception {
+        BroadcastMerger merger = BroadcastMerger.parse(
+                "\"channelUri\"|\"2016-01-05T00:00:00Z\"|\"2016-01-06T00:00:00Z\""
+        );
+
+        Broadcast broadcast = new Broadcast(
+                "channelUri",
+                new DateTime(2016, 1, 6, 0, 0, 0, DateTimeZone.UTC),
+                new DateTime(2016, 1, 7, 0, 0, 0, DateTimeZone.UTC)
+        );
+
+        ImmutableSet<Broadcast> merge = merger.merge(
+                ImmutableSet.of(),
+                ImmutableSet.of(broadcast),
+                true
+        );
+
+        assertThat(merge.contains(broadcast), is(true));
+    }
+
+    @Test
+    public void mergerPreservesBroadcastOnDifferentChannel() throws Exception {
+        BroadcastMerger merger = BroadcastMerger.parse(
+                "\"channelUri\"|\"2016-01-05T00:00:00Z\"|\"2016-01-06T00:00:00Z\""
+        );
+
+        Broadcast broadcast = new Broadcast(
+                "otherChannelUri",
+                new DateTime(2016, 1, 5, 0, 0, 0, DateTimeZone.UTC),
+                new DateTime(2016, 1, 6, 0, 0, 0, DateTimeZone.UTC)
+        );
+
+        ImmutableSet<Broadcast> merge = merger.merge(
+                ImmutableSet.of(),
+                ImmutableSet.of(broadcast),
+                true
+        );
+
+        assertThat(merge.contains(broadcast), is(true));
+    }
+
+    @Test
+    public void mergerDoesNotPreserveFullyOverlappingBroadcast() throws Exception {
+        BroadcastMerger merger = BroadcastMerger.parse(
+                "\"channelUri\"|\"2016-01-05T00:00:00Z\"|\"2016-01-06T00:00:00Z\""
+        );
+
+        Broadcast broadcast = new Broadcast(
+                "channelUri",
+                new DateTime(2016, 1, 5, 12, 0, 0, DateTimeZone.UTC),
+                new DateTime(2016, 1, 6, 13, 0, 0, DateTimeZone.UTC)
+        );
+
+        ImmutableSet<Broadcast> merge = merger.merge(
+                ImmutableSet.of(),
+                ImmutableSet.of(broadcast),
+                true
+        );
+
+        assertThat(merge.isEmpty(), is(true));
+    }
+
+    @Test
+    public void mergerDoesNotPreserveOverlappingAtStartBroadcast() throws Exception {
+        BroadcastMerger merger = BroadcastMerger.parse(
+                "\"channelUri\"|\"2016-01-05T00:00:00Z\"|\"2016-01-06T00:00:00Z\""
+        );
+
+        Broadcast broadcast = new Broadcast(
+                "channelUri",
+                new DateTime(2016, 1, 4, 22, 0, 0, DateTimeZone.UTC),
+                new DateTime(2016, 1, 5, 2, 0, 0, DateTimeZone.UTC)
+        );
+
+        ImmutableSet<Broadcast> merge = merger.merge(
+                ImmutableSet.of(),
+                ImmutableSet.of(broadcast),
+                true
+        );
+
+        assertThat(merge.isEmpty(), is(true));
+    }
+
+    @Test
+    public void mergerDoesNotPreserveOverlappingAtEndBroadcast() throws Exception {
+        BroadcastMerger merger = BroadcastMerger.parse(
+                "\"channelUri\"|\"2016-01-05T00:00:00Z\"|\"2016-01-06T00:00:00Z\""
+        );
+
+        Broadcast broadcast = new Broadcast(
+                "channelUri",
+                new DateTime(2016, 1, 5, 22, 0, 0, DateTimeZone.UTC),
+                new DateTime(2016, 1, 6, 2, 0, 0, DateTimeZone.UTC)
+        );
+
+        ImmutableSet<Broadcast> merge = merger.merge(
+                ImmutableSet.of(),
+                ImmutableSet.of(broadcast),
+                true
+        );
+
+        assertThat(merge.isEmpty(), is(true));
+    }
+
+    @Test
+    public void MergerWithMultipleAssertionsDoesNotPreserveOverlappingBroadcasts()
+            throws Exception {
+        BroadcastMerger merger = BroadcastMerger.parse(""
+                + "\"channelUri\"|\"2016-01-05T00:00:00Z\"|\"2016-01-06T00:00:00Z\","
+                + "\"channelUri\"|\"2016-02-06T12:00:00Z\"|\"2016-02-06T14:00:00Z\","
+                + "\"otherChannelUri\"|\"2016-02-06T12:00:00Z\"|\"2016-02-06T14:00:00Z\""
+        );
+
+        Broadcast firstBroadcast = new Broadcast(
+                "channelUri",
+                new DateTime(2016, 1, 5, 10, 0, 0, DateTimeZone.UTC),
+                new DateTime(2016, 1, 5, 12, 0, 0, DateTimeZone.UTC)
+        );
+        Broadcast secondBroadcast = new Broadcast(
+                "channelUri",
+                new DateTime(2016, 2, 6, 12, 0, 0, DateTimeZone.UTC),
+                new DateTime(2016, 2, 6, 14, 0, 0, DateTimeZone.UTC)
+        );
+        Broadcast thirdBroadcast = new Broadcast(
+                "otherChannelUri",
+                new DateTime(2016, 2, 6, 12, 0, 0, DateTimeZone.UTC),
+                new DateTime(2016, 2, 6, 14, 0, 0, DateTimeZone.UTC)
+        );
+
+        ImmutableSet<Broadcast> merge = merger.merge(
+                ImmutableSet.of(),
+                ImmutableSet.of(firstBroadcast, secondBroadcast, thirdBroadcast),
+                true
+        );
+
+        assertThat(merge.isEmpty(), is(true));
+    }
+
+    @Test
+    public void mergerKeepsOverlappingUpdateBroadcast() throws Exception {
+        BroadcastMerger merger = BroadcastMerger.parse(
+                "\"channelUri\"|\"2016-01-05T00:00:00Z\"|\"2016-01-06T00:00:00Z\""
+        );
+
+        Broadcast broadcast = new Broadcast(
+                "channelUri",
+                new DateTime(2016, 1, 5, 22, 0, 0, DateTimeZone.UTC),
+                new DateTime(2016, 1, 5, 23, 0, 0, DateTimeZone.UTC)
+        );
+
+        ImmutableSet<Broadcast> merge = merger.merge(
+                ImmutableSet.of(broadcast),
+                ImmutableSet.of(),
+                true
+        );
+
+        assertThat(merge.contains(broadcast), is(true));
+    }
+
+    @Test
+    public void mergerKeepsOverlappingUpdateBroadcastAtStartOfInterval() throws Exception {
+        BroadcastMerger merger = BroadcastMerger.parse(
+                "\"channelUri\"|\"2016-01-05T00:00:00Z\"|\"2016-01-06T00:00:00Z\""
+        );
+
+        Broadcast broadcast = new Broadcast(
+                "channelUri",
+                new DateTime(2016, 1, 5, 0, 0, 0, DateTimeZone.UTC),
+                new DateTime(2016, 1, 5, 2, 0, 0, DateTimeZone.UTC)
+        );
+
+        ImmutableSet<Broadcast> merge = merger.merge(
+                ImmutableSet.of(broadcast),
+                ImmutableSet.of(),
+                true
+        );
+
+        assertThat(merge.contains(broadcast), is(true));
+    }
+
+    @Test
+    public void mergerKeepsOverlappingUpdateBroadcastAtEndOfInterval() throws Exception {
+        BroadcastMerger merger = BroadcastMerger.parse(
+                "\"channelUri\"|\"2016-01-05T00:00:00Z\"|\"2016-01-06T00:00:00Z\""
+        );
+
+        Broadcast broadcast = new Broadcast(
+                "channelUri",
+                new DateTime(2016, 1, 5, 22, 0, 0, DateTimeZone.UTC),
+                new DateTime(2016, 1, 6, 0, 0, 0, DateTimeZone.UTC)
+        );
+
+        ImmutableSet<Broadcast> merge = merger.merge(
+                ImmutableSet.of(broadcast),
+                ImmutableSet.of(),
+                true
+        );
+
+        assertThat(merge.contains(broadcast), is(true));
+    }
+
+    @Test
+    public void mergerKeepsZeroDurationUpdateBroadcastAtStartOfInterval() throws Exception {
+        BroadcastMerger merger = BroadcastMerger.parse(
+                "\"channelUri\"|\"2016-01-05T00:00:00Z\"|\"2016-01-06T00:00:00Z\""
+        );
+
+        Broadcast broadcast = new Broadcast(
+                "channelUri",
+                new DateTime(2016, 1, 5, 0, 0, 0, DateTimeZone.UTC),
+                new DateTime(2016, 1, 5, 0, 0, 0, DateTimeZone.UTC)
+        );
+
+        ImmutableSet<Broadcast> merge = merger.merge(
+                ImmutableSet.of(broadcast),
+                ImmutableSet.of(),
+                true
+        );
+
+        assertThat(merge.contains(broadcast), is(true));
+    }
+
+    @Test
+    public void mergerKeepsZeroDurationUpdateBroadcastAtEndOfInterval() throws Exception {
+        BroadcastMerger merger = BroadcastMerger.parse(
+                "\"channelUri\"|\"2016-01-05T00:00:00Z\"|\"2016-01-06T00:00:00Z\""
+        );
+
+        Broadcast broadcast = new Broadcast(
+                "channelUri",
+                new DateTime(2016, 1, 6, 0, 0, 0, DateTimeZone.UTC),
+                new DateTime(2016, 1, 6, 0, 0, 0, DateTimeZone.UTC)
+        );
+
+        ImmutableSet<Broadcast> merge = merger.merge(
+                ImmutableSet.of(broadcast),
+                ImmutableSet.of(),
+                true
+        );
+
+        assertThat(merge.contains(broadcast), is(true));
+    }
+
+    @Test
+    public void mergerConsidersNonOverlappingUpdateBroadcastInvalid() throws Exception {
+        BroadcastMerger merger = BroadcastMerger.parse(
+                "\"channelUri\"|\"2016-01-05T00:00:00Z\"|\"2016-01-06T00:00:00Z\""
+        );
+
+        Broadcast broadcast = new Broadcast(
+                "channelUri",
+                new DateTime(2016, 1, 6, 22, 0, 0, DateTimeZone.UTC),
+                new DateTime(2016, 1, 7, 2, 0, 0, DateTimeZone.UTC)
+        );
+
+        exception.expect(IllegalArgumentException.class);
+        merger.merge(
+                ImmutableSet.of(broadcast),
+                ImmutableSet.of(),
+                true
+        );
+    }
+
+    @Test
+    public void mergerConsidersPartiallyOverlappingUpdateBroadcastInvalid() throws Exception {
+        BroadcastMerger merger = BroadcastMerger.parse(
+                "\"channelUri\"|\"2016-01-05T00:00:00Z\"|\"2016-01-06T00:00:00Z\""
+        );
+
+        Broadcast broadcast = new Broadcast(
+                "channelUri",
+                new DateTime(2016, 1, 5, 22, 0, 0, DateTimeZone.UTC),
+                new DateTime(2016, 1, 6, 2, 0, 0, DateTimeZone.UTC)
+        );
+
+        exception.expect(IllegalArgumentException.class);
+        merger.merge(
+                ImmutableSet.of(broadcast),
+                ImmutableSet.of(),
+                true
+        );
+    }
+
+    @Test
+    public void mergerConsidersUpdateBroadcastOnDifferentChannelInvalid() throws Exception {
+        BroadcastMerger merger = BroadcastMerger.parse(
+                "\"channelUri\"|\"2016-01-05T00:00:00Z\"|\"2016-01-06T00:00:00Z\""
+        );
+
+        Broadcast broadcast = new Broadcast(
+                "otherChannelUri",
+                new DateTime(2016, 1, 5, 22, 0, 0, DateTimeZone.UTC),
+                new DateTime(2016, 1, 5, 23, 0, 0, DateTimeZone.UTC)
+        );
+
+        exception.expect(IllegalArgumentException.class);
+        merger.merge(
+                ImmutableSet.of(broadcast),
+                ImmutableSet.of(),
+                true
+        );
+    }
+
+    @Test
+    public void ifMergeIsFalseKeepsAllUpdateBroadcastsAndNoExistingOnes() throws Exception {
+        BroadcastMerger merger = BroadcastMerger.parse(
+                "\"channelUri\"|\"2016-01-05T00:00:00Z\"|\"2016-01-06T00:00:00Z\""
+        );
+
+        Broadcast existingBroadcast = new Broadcast(
+                "channelUri",
+                new DateTime(2016, 1, 5, 22, 0, 0, DateTimeZone.UTC),
+                new DateTime(2016, 1, 5, 23, 0, 0, DateTimeZone.UTC)
+        );
+        Broadcast updateBroadcast = new Broadcast(
+                "channelUri",
+                new DateTime(2016, 1, 6, 20, 0, 0, DateTimeZone.UTC),
+                new DateTime(2016, 1, 6, 22, 0, 0, DateTimeZone.UTC)
+        );
+
+        ImmutableSet<Broadcast> merge = merger.merge(
+                ImmutableSet.of(updateBroadcast),
+                ImmutableSet.of(existingBroadcast),
+                false
+        );
+
+        assertThat(merge.contains(updateBroadcast), is(true));
+        assertThat(merge.contains(existingBroadcast), is(false));
+    }
+}

--- a/src/test/java/org/atlasapi/query/worker/ContentWriteWorkerTest.java
+++ b/src/test/java/org/atlasapi/query/worker/ContentWriteWorkerTest.java
@@ -47,7 +47,7 @@ public class ContentWriteWorkerTest {
     @Before
     public void setUp() throws Exception {
         messageBytes = "{ content: {} }".getBytes();
-        inputContent = new ContentWriteExecutor.InputContent(
+        inputContent = ContentWriteExecutor.InputContent.create(
                 new Item("uri", "curie", Publisher.METABROADCAST), "item"
         );
         when(writeExecutor.parseInputStream(any(ByteArrayInputStream.class), anyBoolean()))


### PR DESCRIPTION
- The broadcast assertions are effectively a promise made by the
  writer that if any broadcasts existed in the asserted
  channel/dateTime ranges for the written item then these broadcasts
  would have been provided in this write. Therefore Atlas can use
  these assertions to remove any existing broadcast in the given
  range and replace it with the ones provided
- The existing behaviour of removing all existing broadcasts and
  replacing them with the new ones is preserved if no broadcast
  assertions are provided