### PR TITLE
Add support for changing episodes to items in the PA ingester

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/pa/PaProgrammeProcessor.java
+++ b/src/main/java/org/atlasapi/remotesite/pa/PaProgrammeProcessor.java
@@ -721,11 +721,12 @@ public class PaProgrammeProcessor implements PaProgDataProcessor, PaProgDataUpda
 
         Item item;
         if (possiblePrevious.hasValue()) {
-            item = (Item) possiblePrevious.requireValue();
-            if (!(item instanceof Episode) && isEpisode) {
+            Item previous = (Item) possiblePrevious.requireValue();
+
+            if (!(previous instanceof Episode) && isEpisode) {
                 String message = String.format(
                         "%s resolved as %s being ingested as Episode",
-                        episodeUri, item.getClass().getSimpleName()
+                        episodeUri, previous.getClass().getSimpleName()
                 );
 
                 adapterLog.record(warnEntry()
@@ -734,18 +735,23 @@ public class PaProgrammeProcessor implements PaProgDataProcessor, PaProgDataUpda
                 );
                 log.info(message);
 
-                item = convertItemToEpisode(item);
-            } else if(item instanceof Episode && !isEpisode) {
+                item = convertItemToEpisode(previous);
+            } else if(previous instanceof Episode && !isEpisode) {
                 String message = String.format(
-                        "%s resolved as %s being ingested as Item. Keeping it as Episode",
-                        episodeUri, item.getClass().getSimpleName()
+                        "%s resolved as %s being ingested as Item",
+                        episodeUri, previous.getClass().getSimpleName()
                 );
 
                 adapterLog.record(errorEntry()
                         .withSource(getClass())
                         .withDescription(message)
                 );
-                log.warn(message);
+                log.info(message);
+
+                item = new Item();
+                Item.copyTo(previous, item);
+            } else {
+                item = previous;
             }
         } else {
             item = getBasicEpisode(progData, isEpisode);


### PR DESCRIPTION
- This was not previously supported, but the ingester is already
  converting episodes to films where needed so functionally this
  should not be any different
- Also `Item.copyTo` was set to `protected`, which meant that anyone
  calling `Item.copyTo` from outside the Item class hierarchy was
  effectively calling `Content.copyTo` which `Item` inherits and is
  thus missing some fields. Changing `Item.copyTo` to public will
  affect the `ContentMerger` class as well as the merging logic in
  the RT ingester that use this, but this should be the correct
  behaviour and it's likely that those parts of the codebase never
  intended to rely on this behaviour and instead didn't realise that
  some fields were being missed