### PR TITLE
Fix bug where PA bootstrap would not re-ingest any files

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/pa/PaCompleteUpdater.java
+++ b/src/main/java/org/atlasapi/remotesite/pa/PaCompleteUpdater.java
@@ -21,7 +21,7 @@ public class PaCompleteUpdater extends PaBaseProgrammeUpdater implements Runnabl
     
     @Override
     public void runTask() {
-        this.processFiles(fileManager.localTvDataFiles(Predicates.<File>alwaysTrue()));
+        this.processFiles(fileManager.localTvDataFiles(Predicates.<File>alwaysTrue()), true);
     }
     
 }

--- a/src/main/java/org/atlasapi/remotesite/pa/PaCompleteUpdater.java
+++ b/src/main/java/org/atlasapi/remotesite/pa/PaCompleteUpdater.java
@@ -15,13 +15,20 @@ public class PaCompleteUpdater extends PaBaseProgrammeUpdater implements Runnabl
     private final PaProgrammeDataStore fileManager;
 
     public PaCompleteUpdater(ExecutorService executor, PaChannelProcessor processor, PaProgrammeDataStore fileManager, ChannelResolver channelResolver) {
-        super(executor, processor, fileManager, channelResolver, Optional.<PaScheduleVersionStore>absent());
+        super(
+                executor,
+                processor,
+                fileManager,
+                channelResolver,
+                Optional.absent(),
+                Mode.BOOTSTRAP
+        );
         this.fileManager = fileManager;
     }
     
     @Override
     public void runTask() {
-        this.processFiles(fileManager.localTvDataFiles(Predicates.<File>alwaysTrue()), true);
+        this.processFiles(fileManager.localTvDataFiles(Predicates.alwaysTrue()));
     }
     
 }

--- a/src/main/java/org/atlasapi/remotesite/pa/PaModule.java
+++ b/src/main/java/org/atlasapi/remotesite/pa/PaModule.java
@@ -71,6 +71,7 @@ import com.metabroadcast.common.time.DayOfWeek;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.mongodb.DBCollection;
+import com.sun.org.apache.xpath.internal.operations.Mod;
 import org.joda.time.Duration;
 import org.joda.time.LocalTime;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -235,7 +236,7 @@ public class PaModule {
                 channelResolver,
                 fileUploadResultStore(),
                 paScheduleVersionStore(),
-                true
+                PaBaseProgrammeUpdater.Mode.NORMAL
         );
     }
 
@@ -255,7 +256,7 @@ public class PaModule {
                 channelResolver,
                 fileUploadResultStore(),
                 paScheduleVersionStore(),
-                false
+                PaBaseProgrammeUpdater.Mode.BOOTSTRAP
         );
     }
 

--- a/src/main/java/org/atlasapi/remotesite/pa/PaRecentUpdater.java
+++ b/src/main/java/org/atlasapi/remotesite/pa/PaRecentUpdater.java
@@ -34,7 +34,7 @@ public class PaRecentUpdater extends PaBaseProgrammeUpdater implements Runnable 
     @Override
     public void runTask() {
         Predicate<File> filter = getFileSelectionPredicate();
-        this.processFiles(fileManager.localTvDataFiles(filter));
+        this.processFiles(fileManager.localTvDataFiles(filter), !ignoreProcessedFiles);
     }
 
     @Override
@@ -50,13 +50,8 @@ public class PaRecentUpdater extends PaBaseProgrammeUpdater implements Runnable 
                     new DateTime(DateTimeZones.UTC).minusDays(10).getMillis()
             );
         } else {
-            return new Predicate<File>() {
-                @Override
-                public boolean apply(File input) {
-                    return input.lastModified() >
-                            new DateTime(DateTimeZones.UTC).minusDays(3).getMillis();
-                }
-            };
+            return input -> input.lastModified() >
+                    new DateTime(DateTimeZones.UTC).minusDays(5).getMillis();
         }
     }
 }

--- a/src/main/java/org/atlasapi/remotesite/pa/PaRecentUpdater.java
+++ b/src/main/java/org/atlasapi/remotesite/pa/PaRecentUpdater.java
@@ -15,26 +15,33 @@ import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import org.joda.time.DateTime;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 public class PaRecentUpdater extends PaBaseProgrammeUpdater implements Runnable {
-       
+
     private final PaProgrammeDataStore fileManager;
     private final FileUploadResultStore fileUploadResultStore;
-    private final boolean ignoreProcessedFiles;
     
     public PaRecentUpdater(ExecutorService executor, PaChannelProcessor channelProcessor,
             PaProgrammeDataStore fileManager, ChannelResolver channelResolver,
             FileUploadResultStore fileUploadResultStore,
-            PaScheduleVersionStore paScheduleVersionStore, boolean ignoreProcessedFiles) {
-        super(executor, channelProcessor, fileManager, channelResolver, Optional.of(paScheduleVersionStore));
+            PaScheduleVersionStore paScheduleVersionStore, Mode mode) {
+        super(
+                executor,
+                channelProcessor,
+                fileManager,
+                channelResolver,
+                Optional.of(paScheduleVersionStore),
+                mode
+        );
         this.fileManager = fileManager;
         this.fileUploadResultStore = fileUploadResultStore;
-        this.ignoreProcessedFiles = ignoreProcessedFiles;
     }
     
     @Override
     public void runTask() {
         Predicate<File> filter = getFileSelectionPredicate();
-        this.processFiles(fileManager.localTvDataFiles(filter), !ignoreProcessedFiles);
+        this.processFiles(fileManager.localTvDataFiles(filter));
     }
 
     @Override
@@ -43,7 +50,7 @@ public class PaRecentUpdater extends PaBaseProgrammeUpdater implements Runnable 
     }
 
     private Predicate<File> getFileSelectionPredicate() {
-        if (ignoreProcessedFiles) {
+        if (mode == Mode.NORMAL) {
             return new UnprocessedFileFilter(
                     fileUploadResultStore,
                     SERVICE,

--- a/src/main/java/org/atlasapi/remotesite/pa/PaSingleDateUpdater.java
+++ b/src/main/java/org/atlasapi/remotesite/pa/PaSingleDateUpdater.java
@@ -22,7 +22,14 @@ public class PaSingleDateUpdater extends PaBaseProgrammeUpdater {
     private final PaProgrammeDataStore fileManager;
 
     public PaSingleDateUpdater(ExecutorService executor, PaChannelProcessor channelProcessor, PaProgrammeDataStore fileManager, ChannelResolver channelResolver, String dateString) {
-        super(executor, channelProcessor, fileManager, channelResolver, Optional.<PaScheduleVersionStore>absent());
+        super(
+                executor,
+                channelProcessor,
+                fileManager,
+                channelResolver,
+                Optional.absent(),
+                Mode.BOOTSTRAP
+        );
         this.fileManager = fileManager;
         this.dateString = dateString;
     }
@@ -33,13 +40,7 @@ public class PaSingleDateUpdater extends PaBaseProgrammeUpdater {
 
     	final String filenameContains = dateString + "_tvdata";
         processFiles(
-                fileManager.localTvDataFiles(new Predicate<File>() {
-                    @Override
-                    public boolean apply(File input) {
-                        return input.getName().contains(filenameContains);
-                    }
-                }),
-                true
+                fileManager.localTvDataFiles(input -> input.getName().contains(filenameContains))
         );
 
         LOG.info("Finished ingest of PA files for {}", dateString);

--- a/src/main/java/org/atlasapi/remotesite/pa/PaSingleDateUpdater.java
+++ b/src/main/java/org/atlasapi/remotesite/pa/PaSingleDateUpdater.java
@@ -32,12 +32,15 @@ public class PaSingleDateUpdater extends PaBaseProgrammeUpdater {
         LOG.info("Beginning ingest of PA files for {}", dateString);
 
     	final String filenameContains = dateString + "_tvdata";
-        processFiles(fileManager.localTvDataFiles(new Predicate<File>() {
-            @Override
-            public boolean apply(File input) {
-                return input.getName().contains(filenameContains);
-            }
-        }));
+        processFiles(
+                fileManager.localTvDataFiles(new Predicate<File>() {
+                    @Override
+                    public boolean apply(File input) {
+                        return input.getName().contains(filenameContains);
+                    }
+                }),
+                true
+        );
 
         LOG.info("Finished ingest of PA files for {}", dateString);
     }

--- a/src/test/java/org/atlasapi/remotesite/pa/PaBaseProgrammeUpdaterTest.java
+++ b/src/test/java/org/atlasapi/remotesite/pa/PaBaseProgrammeUpdaterTest.java
@@ -268,14 +268,27 @@ public class PaBaseProgrammeUpdaterTest extends TestCase {
                 MongoScheduleStore scheduleWriter, List<File> files, BroadcastTrimmer trimmer,
                 PaScheduleVersionStore scheduleVersionStore, ContentBuffer contentBuffer, ContentWriter contentWriter) {
 
-            super(MoreExecutors.sameThreadExecutor(), new PaChannelProcessor(processor, trimmer, scheduleWriter, scheduleVersionStore, contentBuffer, contentWriter),
-                    new DefaultPaProgrammeDataStore(TMP_TEST_DIRECTORY, null), channelResolver, Optional.fromNullable(scheduleVersionStore));
+            super(
+                    MoreExecutors.sameThreadExecutor(),
+                    new PaChannelProcessor(
+                            processor,
+                            trimmer,
+                            scheduleWriter,
+                            scheduleVersionStore,
+                            contentBuffer,
+                            contentWriter
+                    ),
+                    new DefaultPaProgrammeDataStore(TMP_TEST_DIRECTORY, null),
+                    channelResolver,
+                    Optional.fromNullable(scheduleVersionStore),
+                    Mode.NORMAL
+            );
             this.files = files;
         }
 
         @Override
         public void runTask() {
-            this.processFiles(files, false);
+            this.processFiles(files);
         }
     }
 

--- a/src/test/java/org/atlasapi/remotesite/pa/PaBaseProgrammeUpdaterTest.java
+++ b/src/test/java/org/atlasapi/remotesite/pa/PaBaseProgrammeUpdaterTest.java
@@ -275,7 +275,7 @@ public class PaBaseProgrammeUpdaterTest extends TestCase {
 
         @Override
         public void runTask() {
-            this.processFiles(files);
+            this.processFiles(files, false);
         }
     }
 


### PR DESCRIPTION
Prior to this change a bootstrap would only process unprocessed files
rather than the desired behavior of of re processing the most recent.