### PR TITLE
add flag to reset the score on content with only null results for ebs

### DIFF
--- a/src/main/java/org/atlasapi/equiv/EquivModule.java
+++ b/src/main/java/org/atlasapi/equiv/EquivModule.java
@@ -284,24 +284,36 @@ public class EquivModule {
             )));
     }
 
-    private ContentEquivalenceUpdater.Builder<Item> ebsItemUpdater(Set<Publisher> acceptablePublishers, Set<? extends EquivalenceScorer<Item>> scorers) {
+    private ContentEquivalenceUpdater.Builder<Item> ebsItemUpdater(
+            Set<Publisher> acceptablePublishers,
+            Set<? extends EquivalenceScorer<Item>> scorers
+    ) {
 
-        NullScoreAwareAveragingCombiner<Item> combiner = new NullScoreAwareAveragingCombiner<>();
-        combiner.setIgnoreNullScoringContent(true);
+        NullScoreAwareAveragingCombiner<Item> combiner =
+                new NullScoreAwareAveragingCombiner<>(true);
 
         return ContentEquivalenceUpdater.<Item> builder()
                 .withGenerators(ImmutableSet.<EquivalenceGenerator<Item>> of(
-                        new BroadcastMatchingItemEquivalenceGenerator(scheduleResolver,
-                                channelResolver, acceptablePublishers, Duration.standardMinutes(5), Predicates.alwaysTrue())
+                        new BroadcastMatchingItemEquivalenceGenerator(
+                                scheduleResolver,
+                                channelResolver,
+                                acceptablePublishers,
+                                Duration.standardMinutes(5),
+                                Predicates.alwaysTrue())
                 ))
                 .withExcludedUris(excludedUrisFromProperties())
                 .withScorers(scorers)
                 .withCombiner(combiner)
                 .withFilter(this.standardFilter())
-                .withExtractor(PercentThresholdAboveNextBestMatchEquivalenceExtractor.atLeastNTimesGreater(1.5))
+                .withExtractor(
+                        PercentThresholdAboveNextBestMatchEquivalenceExtractor
+                                .atLeastNTimesGreater(1.5)
+                )
                 .withHandler(new BroadcastingEquivalenceResultHandler<Item>(ImmutableList.of(
                         EpisodeFilteringEquivalenceResultHandler.relaxed(
-                                new LookupWritingEquivalenceHandler<Item>(lookupWriter, acceptablePublishers),
+                                new LookupWritingEquivalenceHandler<Item>(
+                                        lookupWriter,
+                                        acceptablePublishers),
                                 equivSummaryStore
                         ),
                         new ResultWritingEquivalenceHandler<Item>(equivalenceResultStore()),

--- a/src/main/java/org/atlasapi/equiv/results/combining/NullScoreAwareAveragingCombiner.java
+++ b/src/main/java/org/atlasapi/equiv/results/combining/NullScoreAwareAveragingCombiner.java
@@ -22,11 +22,19 @@ import com.google.common.collect.Maps.EntryTransformer;
 
 public class NullScoreAwareAveragingCombiner<T extends Described> implements ScoreCombiner<T> {
     
+    private boolean ignoreNullScoringContent;
+
     public static final <T extends Described> NullScoreAwareAveragingCombiner<T> get() {
         return new NullScoreAwareAveragingCombiner<T>();
     }
     
-    public NullScoreAwareAveragingCombiner() {}
+    public NullScoreAwareAveragingCombiner() {
+        ignoreNullScoringContent = false;
+    }
+
+    public void setIgnoreNullScoringContent(boolean choice) {
+        ignoreNullScoringContent = choice;
+    }
     
     @Override
     public ScoredCandidates<T> combine(List<ScoredCandidates<T>> scoredEquivalents, ResultDescription desc) {
@@ -78,6 +86,11 @@ public class NullScoreAwareAveragingCombiner<T extends Described> implements Sco
             public Score transformEntry(T key, Score value) {
                 if (value.isRealScore()) {
                     Integer count = publisherCounts.get(key.getPublisher());
+
+                    if (ignoreNullScoringContent && count == 1) {
+                        return Score.ZERO;
+                    }
+
                     return Score.valueOf(value.asDouble() / (count != null ? count : 1));
                 } else {
                     return value;

--- a/src/main/java/org/atlasapi/equiv/update/ContentEquivalenceUpdater.java
+++ b/src/main/java/org/atlasapi/equiv/update/ContentEquivalenceUpdater.java
@@ -25,76 +25,8 @@ import com.google.common.collect.Iterables;
 
 public class ContentEquivalenceUpdater<T extends Content> implements EquivalenceUpdater<T> {
 
-    public static final <T extends Content> Builder<T> builder() {
+    public static <T extends Content> Builder<T> builder() {
         return new Builder<T>();
-    }
-    
-    public static final class Builder<T extends Content> {
-        
-        private ImmutableSet.Builder<EquivalenceGenerator<T>> generators = ImmutableSet.builder();
-        private ImmutableSet.Builder<EquivalenceScorer<T>> scorers = ImmutableSet.builder();
-        private ScoreCombiner<T> combiner;
-        private EquivalenceFilter<T> filter;
-        private EquivalenceExtractor<T> extractor;
-        private EquivalenceResultHandler<T> handler;
-        private Set<String> excludedUris;
-        
-        public Builder<T> withGenerator(EquivalenceGenerator<T> generator) {
-            generators.add(generator);
-            return this;
-        }
-        
-        public Builder<T> withGenerators(Iterable<? extends EquivalenceGenerator<T>> generators) {
-            this.generators.addAll(generators);
-            return this;
-        }
-        
-        public Builder<T> withScorer(EquivalenceScorer<T> scorer) {
-            this.scorers.add(scorer);
-            return this;
-        }
-
-        public Builder<T> withScorers(Iterable<? extends EquivalenceScorer<T>> scorers) {
-            this.scorers.addAll(scorers);
-            return this;
-        }
-        
-        public Builder<T> withCombiner(ScoreCombiner<T> combiner) {
-            this.combiner = combiner;
-            return this;
-        }
-        
-        public Builder<T> withFilter(EquivalenceFilter<T> filter) {
-            this.filter = filter;
-            return this;
-        }
-        
-        public Builder<T> withExtractor(EquivalenceExtractor<T> extractor) {
-            this.extractor = extractor;
-            return this;
-        }
-
-        public Builder<T> withHandler(EquivalenceResultHandler<T> handler) {
-            this.handler = handler;
-            return this;
-        }
-
-        public Builder<T> withExcludedUris(Set<String> excludedUris) {
-            this.excludedUris = excludedUris;
-            return this;
-        }
-        
-        public ContentEquivalenceUpdater<T> build() {
-            return new ContentEquivalenceUpdater<T>(
-                generators.build(),
-                scorers.build(),
-                combiner,
-                filter,
-                extractor,
-                handler,
-                excludedUris
-            );
-        }
     }
     
     private final ScoredEquivalentsMerger merger = new ScoredEquivalentsMerger();
@@ -109,15 +41,15 @@ public class ContentEquivalenceUpdater<T extends Content> implements Equivalence
     private final EquivalenceScorers<T> scorers;
     private final DefaultEquivalenceResultBuilder<T> resultBuilder;
     private final EquivalenceResultHandler<T> handler;
-    
+
     private ContentEquivalenceUpdater(
-        Iterable<EquivalenceGenerator<T>> generators,
-        Iterable<EquivalenceScorer<T>> scorers,
-        ScoreCombiner<T> combiner,
-        EquivalenceFilter<T> filter,
-        EquivalenceExtractor<T> extractor,
-        EquivalenceResultHandler<T> handler,
-        Set<String> excludedUris
+            Iterable<EquivalenceGenerator<T>> generators,
+            Iterable<EquivalenceScorer<T>> scorers,
+            ScoreCombiner<T> combiner,
+            EquivalenceFilter<T> filter,
+            EquivalenceExtractor<T> extractor,
+            EquivalenceResultHandler<T> handler,
+            Set<String> excludedUris
     ) {
         this.generators = EquivalenceGenerators.from(generators, excludedUris);
         this.scorers = EquivalenceScorers.from(scorers);
@@ -148,5 +80,73 @@ public class ContentEquivalenceUpdater<T extends Content> implements Equivalence
     
     private Iterable<T> extractCandidates(Iterable<ScoredCandidates<T>> generatedScores) {
         return Iterables.concat(Iterables.transform(generatedScores, extractCandidates));
+    }
+
+    public static final class Builder<T extends Content> {
+
+        private ImmutableSet.Builder<EquivalenceGenerator<T>> generators = ImmutableSet.builder();
+        private ImmutableSet.Builder<EquivalenceScorer<T>> scorers = ImmutableSet.builder();
+        private ScoreCombiner<T> combiner;
+        private EquivalenceFilter<T> filter;
+        private EquivalenceExtractor<T> extractor;
+        private EquivalenceResultHandler<T> handler;
+        private Set<String> excludedUris;
+
+        public Builder<T> withGenerator(EquivalenceGenerator<T> generator) {
+            generators.add(generator);
+            return this;
+        }
+
+        public Builder<T> withGenerators(Iterable<? extends EquivalenceGenerator<T>> generators) {
+            this.generators.addAll(generators);
+            return this;
+        }
+
+        public Builder<T> withScorer(EquivalenceScorer<T> scorer) {
+            this.scorers.add(scorer);
+            return this;
+        }
+
+        public Builder<T> withScorers(Iterable<? extends EquivalenceScorer<T>> scorers) {
+            this.scorers.addAll(scorers);
+            return this;
+        }
+
+        public Builder<T> withCombiner(ScoreCombiner<T> combiner) {
+            this.combiner = combiner;
+            return this;
+        }
+
+        public Builder<T> withFilter(EquivalenceFilter<T> filter) {
+            this.filter = filter;
+            return this;
+        }
+
+        public Builder<T> withExtractor(EquivalenceExtractor<T> extractor) {
+            this.extractor = extractor;
+            return this;
+        }
+
+        public Builder<T> withHandler(EquivalenceResultHandler<T> handler) {
+            this.handler = handler;
+            return this;
+        }
+
+        public Builder<T> withExcludedUris(Set<String> excludedUris) {
+            this.excludedUris = excludedUris;
+            return this;
+        }
+
+        public ContentEquivalenceUpdater<T> build() {
+            return new ContentEquivalenceUpdater<T>(
+                    generators.build(),
+                    scorers.build(),
+                    combiner,
+                    filter,
+                    extractor,
+                    handler,
+                    excludedUris
+            );
+        }
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/ContentEquivalenceUpdater.java
+++ b/src/main/java/org/atlasapi/equiv/update/ContentEquivalenceUpdater.java
@@ -30,7 +30,8 @@ public class ContentEquivalenceUpdater<T extends Content> implements Equivalence
     }
     
     private final ScoredEquivalentsMerger merger = new ScoredEquivalentsMerger();
-    private final Function<ScoredCandidates<T>, Iterable<T>> extractCandidates = new Function<ScoredCandidates<T>, Iterable<T>>() {
+    private final Function<ScoredCandidates<T>, Iterable<T>> extractCandidates =
+            new Function<ScoredCandidates<T>, Iterable<T>>() {
         @Override
         public Iterable<T> apply(ScoredCandidates<T> input) {
             return input.candidates().keySet();

--- a/src/test/java/org/atlasapi/equiv/results/combining/NullScoreAwareAveragingCombinerTest.java
+++ b/src/test/java/org/atlasapi/equiv/results/combining/NullScoreAwareAveragingCombinerTest.java
@@ -115,4 +115,36 @@ public class NullScoreAwareAveragingCombinerTest extends TestCase {
         assertEquals(Score.valueOf(2.0), combined.candidates().get(equivalent5));
         
     }
+
+    @Test
+    public void testCombineWithIgnoreNullFlagOn() {
+
+        combiner.setIgnoreNullScoringContent(true);
+
+        List<ScoredCandidates<Item>> scores = ImmutableList.of(
+                DefaultScoredCandidates.<Item>fromSource("source2")
+                        .addEquivalent(equivalent1, Score.valueOf(5.0))
+                        .addEquivalent(equivalent2, Score.NULL_SCORE)
+                        .addEquivalent(equivalent3, Score.valueOf(5.0))
+                        .build(),
+                DefaultScoredCandidates.<Item>fromSource("source1")
+                        .addEquivalent(equivalent1, Score.valueOf(5.0))
+                        .addEquivalent(equivalent2, Score.valueOf(5.0))
+                        .addEquivalent(equivalent3, Score.valueOf(5.0))
+                        .addEquivalent(equivalent1, Score.valueOf(5.0))
+                        .build(),
+                DefaultScoredCandidates.<Item>fromSource("source3")
+                        .addEquivalent(equivalent3, Score.valueOf(5.0))
+                        .addEquivalent(equivalent1, Score.NULL_SCORE)
+                        .build()
+        );
+
+        ScoredCandidates<Item> combined = combiner.combine(scores, new DefaultDescription());
+
+        assertEquals(Score.valueOf(5.0), combined.candidates().get(equivalent3));
+        assertEquals(Score.valueOf(7.5), combined.candidates().get(equivalent1));
+        assertEquals(Score.valueOf(0.0), combined.candidates().get(equivalent2));
+
+        combiner.setIgnoreNullScoringContent(false);
+    }
 }

--- a/src/test/java/org/atlasapi/equiv/results/combining/NullScoreAwareAveragingCombinerTest.java
+++ b/src/test/java/org/atlasapi/equiv/results/combining/NullScoreAwareAveragingCombinerTest.java
@@ -16,7 +16,8 @@ import com.google.common.collect.ImmutableList;
 
 public class NullScoreAwareAveragingCombinerTest extends TestCase {
     
-    private final NullScoreAwareAveragingCombiner<Item> combiner = NullScoreAwareAveragingCombiner.get();
+    private final NullScoreAwareAveragingCombiner<Item> combiner =
+            NullScoreAwareAveragingCombiner.get();
 
     private final Item equivalent1 = target("equivalent1", "Equivalent1", Publisher.BBC);
     private final Item equivalent2 = target("equivalent2", "Equivalent2", Publisher.C4);
@@ -29,7 +30,7 @@ public class NullScoreAwareAveragingCombinerTest extends TestCase {
     }
 
     @Test
-    public void testCombine() {
+    public void testCombineSingleNonNullScoreWithIgnoreNullScoringCandidatesFlagOffReturnsScore() {
         
         List<ScoredCandidates<Item>> scores = ImmutableList.of(
                 DefaultScoredCandidates.<Item>fromSource("source2")
@@ -117,34 +118,34 @@ public class NullScoreAwareAveragingCombinerTest extends TestCase {
     }
 
     @Test
-    public void testCombineWithIgnoreNullFlagOn() {
+    public void testCombineSingleNonNullScoreWithIgnoreNullScoringCandidatesFlagOffReturnsZero() {
 
-        combiner.setIgnoreNullScoringContent(true);
+        NullScoreAwareAveragingCombiner ignoreSetCombiner =
+                new NullScoreAwareAveragingCombiner(true);
 
         List<ScoredCandidates<Item>> scores = ImmutableList.of(
                 DefaultScoredCandidates.<Item>fromSource("source2")
                         .addEquivalent(equivalent1, Score.valueOf(5.0))
-                        .addEquivalent(equivalent2, Score.NULL_SCORE)
+                        .addEquivalent(equivalent2, Score.nullScore())
                         .addEquivalent(equivalent3, Score.valueOf(5.0))
                         .build(),
                 DefaultScoredCandidates.<Item>fromSource("source1")
-                        .addEquivalent(equivalent1, Score.valueOf(5.0))
+                        .addEquivalent(equivalent1, Score.nullScore())
                         .addEquivalent(equivalent2, Score.valueOf(5.0))
-                        .addEquivalent(equivalent3, Score.valueOf(5.0))
-                        .addEquivalent(equivalent1, Score.valueOf(5.0))
+                        .addEquivalent(equivalent3, Score.nullScore())
+                        .addEquivalent(equivalent1, Score.nullScore())
                         .build(),
                 DefaultScoredCandidates.<Item>fromSource("source3")
-                        .addEquivalent(equivalent3, Score.valueOf(5.0))
-                        .addEquivalent(equivalent1, Score.NULL_SCORE)
+                        .addEquivalent(equivalent3, Score.nullScore())
+                        .addEquivalent(equivalent1, Score.nullScore())
                         .build()
         );
 
-        ScoredCandidates<Item> combined = combiner.combine(scores, new DefaultDescription());
+        ScoredCandidates<Item> combined =
+                ignoreSetCombiner.combine(scores, new DefaultDescription());
 
-        assertEquals(Score.valueOf(5.0), combined.candidates().get(equivalent3));
-        assertEquals(Score.valueOf(7.5), combined.candidates().get(equivalent1));
+        assertEquals(Score.valueOf(0.0), combined.candidates().get(equivalent3));
+        assertEquals(Score.valueOf(0.0), combined.candidates().get(equivalent1));
         assertEquals(Score.valueOf(0.0), combined.candidates().get(equivalent2));
-
-        combiner.setIgnoreNullScoringContent(false);
     }
 }


### PR DESCRIPTION
flag can be set to change logic in combiner to set score to 0 if all scorers returned null
ebs sport content registered to use this flag