### PR TITLE
Ensure equivalence updaters are only explicitly enabled

### DIFF
--- a/src/main/resources/config/environments/prod.properties
+++ b/src/main/resources/config/environments/prod.properties
@@ -30,8 +30,6 @@ updaters.metabroadcast.enabled=true
 updaters.youview.enabled=true
 updaters.rovi.enabled=false
 
-equiv.updater.enabled=true
-
 interlinking.delta.enabled=true
 interlinking.delta.bucket=bbc-interlinking
 interlinking.delta.folder=feeds/bbc-interlinking


### PR DESCRIPTION
- This caused app servers to start running equivalence jobs because
  equiv updaters used to be enabled by default