### PR TITLE
Remove rt upcoming from normal equivalence

### DIFF
--- a/src/main/java/org/atlasapi/equiv/EquivModule.java
+++ b/src/main/java/org/atlasapi/equiv/EquivModule.java
@@ -17,6 +17,7 @@ package org.atlasapi.equiv;
 import java.io.File;
 import java.util.Set;
 
+import com.google.common.base.*;
 import org.atlasapi.equiv.generators.BroadcastMatchingItemEquivalenceGenerator;
 import org.atlasapi.equiv.generators.ContainerCandidatesContainerEquivalenceGenerator;
 import org.atlasapi.equiv.generators.ContainerCandidatesItemEquivalenceGenerator;
@@ -95,10 +96,6 @@ import com.metabroadcast.common.collect.MoreSets;
 import com.metabroadcast.common.queue.MessageSender;
 import com.metabroadcast.common.time.DateTimeZones;
 
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
-import com.google.common.base.Splitter;
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -381,6 +378,17 @@ public class EquivModule {
                         )
                 ).build();
 
+        EquivalenceUpdater<Item> rtUpcomingItemUpdater =
+                standardItemUpdater(
+                        ImmutableSet.of(AMAZON_UNBOX),
+                        ImmutableSet.of(
+                                new TitleMatchingItemScorer(),
+                                new SequenceItemScorer(Score.ONE),
+                                new DescriptionTitleMatchingScorer(),
+                                DescriptionMatchingScorer.makeScorer()
+                        )
+                ).build();
+
         EquivalenceUpdater<Item> ebsItemUpdater =
                 ebsItemUpdater(
                         MoreSets.add(acceptablePublishers, LOVEFILM),
@@ -411,13 +419,9 @@ public class EquivModule {
         }
 
         updaters.register(RADIO_TIMES_UPCOMING, SourceSpecificEquivalenceUpdater.builder(RADIO_TIMES_UPCOMING)
-                .withItemUpdater(broadcastItemEquivalenceUpdater(
-                        ImmutableSet.of(AMAZON_UNBOX),
-                        Score.nullScore(),
-                        Predicates.alwaysTrue()
-                ))
-                .withTopLevelContainerUpdater(NullEquivalenceUpdater.get())
-                .withNonTopLevelContainerUpdater(NullEquivalenceUpdater.get())
+                .withItemUpdater(rtUpcomingItemUpdater)
+                .withTopLevelContainerUpdater(topLevelContainerUpdater(ImmutableSet.of(AMAZON_UNBOX)))
+                .withNonTopLevelContainerUpdater(standardSeriesUpdater(ImmutableSet.of(AMAZON_UNBOX)))
                 .build());
 
         updaters.register(BT_SPORT_EBS, SourceSpecificEquivalenceUpdater.builder(BT_SPORT_EBS)

--- a/src/main/java/org/atlasapi/equiv/EquivModule.java
+++ b/src/main/java/org/atlasapi/equiv/EquivModule.java
@@ -132,6 +132,7 @@ import static org.atlasapi.media.entity.Publisher.NETFLIX;
 import static org.atlasapi.media.entity.Publisher.PA;
 import static org.atlasapi.media.entity.Publisher.PREVIEW_NETWORKS;
 import static org.atlasapi.media.entity.Publisher.RADIO_TIMES;
+import static org.atlasapi.media.entity.Publisher.RADIO_TIMES_UPCOMING;
 import static org.atlasapi.media.entity.Publisher.RDIO;
 import static org.atlasapi.media.entity.Publisher.RTE;
 import static org.atlasapi.media.entity.Publisher.SOUNDCLOUD;
@@ -364,7 +365,7 @@ public class EquivModule {
             Publisher.all(), 
             Sets.union(
                 ImmutableSet.of(PREVIEW_NETWORKS, BBC_REDUX, RADIO_TIMES, LOVEFILM, NETFLIX, YOUVIEW,
-                        YOUVIEW_STAGE, YOUVIEW_BT, YOUVIEW_BT_STAGE, BT_SPORT_EBS, C4_PRESS),
+                        YOUVIEW_STAGE, YOUVIEW_BT, YOUVIEW_BT_STAGE, BT_SPORT_EBS, C4_PRESS, RADIO_TIMES_UPCOMING),
                 Sets.union(musicPublishers, roviPublishers)
             )
         ));
@@ -397,7 +398,7 @@ public class EquivModule {
         Set<Publisher> nonStandardPublishers = ImmutableSet.copyOf(Sets.union(
             ImmutableSet.of(ITUNES, BBC_REDUX, RADIO_TIMES, FACEBOOK, LOVEFILM, NETFLIX,
                     RTE, YOUVIEW, YOUVIEW_STAGE, YOUVIEW_BT, YOUVIEW_BT_STAGE, TALK_TALK,
-                    PA, BT_VOD, BT_TVE_VOD, BETTY, AMC_EBS, BT_SPORT_EBS, C4_PRESS),
+                    PA, BT_VOD, BT_TVE_VOD, BETTY, AMC_EBS, BT_SPORT_EBS, C4_PRESS, RADIO_TIMES_UPCOMING),
             Sets.union(musicPublishers, roviPublishers)
         ));
         final EquivalenceUpdaters updaters = new EquivalenceUpdaters();
@@ -408,6 +409,16 @@ public class EquivModule {
                 .withNonTopLevelContainerUpdater(standardSeriesUpdater(acceptablePublishers))
                 .build());
         }
+
+        updaters.register(RADIO_TIMES_UPCOMING, SourceSpecificEquivalenceUpdater.builder(RADIO_TIMES_UPCOMING)
+                .withItemUpdater(broadcastItemEquivalenceUpdater(
+                        ImmutableSet.of(AMAZON_UNBOX),
+                        Score.nullScore(),
+                        Predicates.alwaysTrue()
+                ))
+                .withTopLevelContainerUpdater(NullEquivalenceUpdater.get())
+                .withNonTopLevelContainerUpdater(NullEquivalenceUpdater.get())
+                .build());
 
         updaters.register(BT_SPORT_EBS, SourceSpecificEquivalenceUpdater.builder(BT_SPORT_EBS)
                 .withItemUpdater(ebsItemUpdater)

--- a/src/main/java/org/atlasapi/remotesite/itunes/epf/ItunesEpfUpdateTask.java
+++ b/src/main/java/org/atlasapi/remotesite/itunes/epf/ItunesEpfUpdateTask.java
@@ -99,7 +99,6 @@ public class ItunesEpfUpdateTask extends ScheduledTask {
             //episode id -> trackNumber/series
             Multimap<Series, Episode> extractedEpisodes = linkEpisodesAndSeries(
                     dataSet.getCollectionVideoTable(),
-                    dataSet.getVideoTable(),
                     extractedSeries,
                     extractVideos(dataSet.getVideoTable(), extractedSeries, extractedLocations)
             );
@@ -262,9 +261,7 @@ public class ItunesEpfUpdateTask extends ScheduledTask {
         });
     }
 
-    private Multimap<Series, Episode> linkEpisodesAndSeries(
-            EpfTable<EpfCollectionVideo> cvTable,
-            EpfTable<EpfVideo> vTable,
+    private Multimap<Series, Episode> linkEpisodesAndSeries(EpfTable<EpfCollectionVideo> cvTable,
             final Map<Integer, Series> extractedSeries,
             final Map<Integer, Episode> extractedEpisodes) throws IOException {
         reportStatus("Linking videos to series...");
@@ -276,8 +273,7 @@ public class ItunesEpfUpdateTask extends ScheduledTask {
             public boolean process(EpfCollectionVideo row) {
                 Series series = extractedSeries.get(row.get(EpfCollectionVideo.COLLECTION_ID));
                 if (series != null) {
-//                    series.withSeriesNumber(row.get(EpfCollectionVideo.VOLUME_NUMBER));
-                    series.withSeriesNumber(parseSeriesNumber(row.get(EpfVideo.COLLECTION_DISPLAY_NAME)))
+                    series.withSeriesNumber(row.get(EpfCollectionVideo.VOLUME_NUMBER));
                     Episode ep = extractedEpisodes.get(row.get(EpfCollectionVideo.VIDEO_ID));
                     if (ep != null) {
                         ep.setEpisodeNumber(row.get(EpfCollectionVideo.TRACK_NUMBER));
@@ -292,10 +288,6 @@ public class ItunesEpfUpdateTask extends ScheduledTask {
                 ep.setSeriesNumber(series.getSeriesNumber());
                 ep.setParentRef(series.getParent());
                 return ep;
-            }
-
-            private int parseSeriesNumber(String collectionDisplayName) {
-                return 0;
             }
 
             @Override

--- a/src/main/java/org/atlasapi/remotesite/itunes/epf/ItunesEpfUpdateTask.java
+++ b/src/main/java/org/atlasapi/remotesite/itunes/epf/ItunesEpfUpdateTask.java
@@ -99,6 +99,7 @@ public class ItunesEpfUpdateTask extends ScheduledTask {
             //episode id -> trackNumber/series
             Multimap<Series, Episode> extractedEpisodes = linkEpisodesAndSeries(
                     dataSet.getCollectionVideoTable(),
+                    dataSet.getVideoTable(),
                     extractedSeries,
                     extractVideos(dataSet.getVideoTable(), extractedSeries, extractedLocations)
             );
@@ -261,7 +262,9 @@ public class ItunesEpfUpdateTask extends ScheduledTask {
         });
     }
 
-    private Multimap<Series, Episode> linkEpisodesAndSeries(EpfTable<EpfCollectionVideo> cvTable,
+    private Multimap<Series, Episode> linkEpisodesAndSeries(
+            EpfTable<EpfCollectionVideo> cvTable,
+            EpfTable<EpfVideo> vTable,
             final Map<Integer, Series> extractedSeries,
             final Map<Integer, Episode> extractedEpisodes) throws IOException {
         reportStatus("Linking videos to series...");
@@ -273,7 +276,8 @@ public class ItunesEpfUpdateTask extends ScheduledTask {
             public boolean process(EpfCollectionVideo row) {
                 Series series = extractedSeries.get(row.get(EpfCollectionVideo.COLLECTION_ID));
                 if (series != null) {
-                    series.withSeriesNumber(row.get(EpfCollectionVideo.VOLUME_NUMBER));
+//                    series.withSeriesNumber(row.get(EpfCollectionVideo.VOLUME_NUMBER));
+                    series.withSeriesNumber(parseSeriesNumber(row.get(EpfVideo.COLLECTION_DISPLAY_NAME)))
                     Episode ep = extractedEpisodes.get(row.get(EpfCollectionVideo.VIDEO_ID));
                     if (ep != null) {
                         ep.setEpisodeNumber(row.get(EpfCollectionVideo.TRACK_NUMBER));
@@ -288,6 +292,10 @@ public class ItunesEpfUpdateTask extends ScheduledTask {
                 ep.setSeriesNumber(series.getSeriesNumber());
                 ep.setParentRef(series.getParent());
                 return ep;
+            }
+
+            private int parseSeriesNumber(String collectionDisplayName) {
+                return 0;
             }
 
             @Override


### PR DESCRIPTION
Intended behaviour is now:

RT Upcoming to only equivalate to Amazon Unbox content
Nothing can equivalate to RT Upcoming.
j