### PR TITLE
Add equivalence generator metadata

### DIFF
--- a/src/main/java/org/atlasapi/equiv/generators/BroadcastMatchingItemEquivalenceGenerator.java
+++ b/src/main/java/org/atlasapi/equiv/generators/BroadcastMatchingItemEquivalenceGenerator.java
@@ -2,6 +2,8 @@ package org.atlasapi.equiv.generators;
 
 import java.util.Set;
 
+import org.atlasapi.equiv.generators.metadata.EquivalenceGeneratorMetadata;
+import org.atlasapi.equiv.generators.metadata.SourceLimitedEquivalenceGeneratorMetadata;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates.Builder;
@@ -16,8 +18,9 @@ import org.atlasapi.media.entity.Schedule;
 import org.atlasapi.media.entity.Schedule.ScheduleChannel;
 import org.atlasapi.media.entity.Version;
 import org.atlasapi.persistence.content.ScheduleResolver;
-import org.joda.time.DateTime;
-import org.joda.time.Duration;
+
+import com.metabroadcast.common.base.Maybe;
+import com.metabroadcast.common.time.DateTimeZones;
 
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
@@ -25,8 +28,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Maps.EntryTransformer;
 import com.google.common.collect.Sets;
-import com.metabroadcast.common.base.Maybe;
-import com.metabroadcast.common.time.DateTimeZones;
+import org.joda.time.DateTime;
+import org.joda.time.Duration;
 
 public class BroadcastMatchingItemEquivalenceGenerator implements EquivalenceGenerator<Item>{
 
@@ -87,7 +90,19 @@ public class BroadcastMatchingItemEquivalenceGenerator implements EquivalenceGen
         return scale(scores.build(), processedBroadcasts, desc);
     }
 
-    public void findMatchesForBroadcast(Builder<Item> scores, Broadcast broadcast, Set<Publisher> validPublishers) {
+    @Override
+    public EquivalenceGeneratorMetadata getMetadata() {
+        return SourceLimitedEquivalenceGeneratorMetadata.create(
+                this.getClass().getCanonicalName(),
+                supportedPublishers
+        );
+    }
+
+    private void findMatchesForBroadcast(
+            Builder<Item> scores,
+            Broadcast broadcast,
+            Set<Publisher> validPublishers
+    ) {
 
         Schedule schedule = scheduleAround(broadcast, validPublishers);
 

--- a/src/main/java/org/atlasapi/equiv/generators/EquivalenceGenerator.java
+++ b/src/main/java/org/atlasapi/equiv/generators/EquivalenceGenerator.java
@@ -1,10 +1,15 @@
 package org.atlasapi.equiv.generators;
 
+import org.atlasapi.equiv.generators.metadata.EquivalenceGeneratorMetadata;
+import org.atlasapi.equiv.generators.metadata.GenericEquivalenceGeneratorMetadata;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
 
 public interface EquivalenceGenerator<T> {
 
     ScoredCandidates<T> generate(T subject, ResultDescription desc);
-    
+
+    default EquivalenceGeneratorMetadata getMetadata() {
+        return GenericEquivalenceGeneratorMetadata.create(this.getClass().getCanonicalName());
+    }
 }

--- a/src/main/java/org/atlasapi/equiv/generators/FilmEquivalenceGenerator.java
+++ b/src/main/java/org/atlasapi/equiv/generators/FilmEquivalenceGenerator.java
@@ -1,13 +1,13 @@
 package org.atlasapi.equiv.generators;
 
-import static com.google.common.collect.Iterables.filter;
-
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.atlasapi.application.v3.ApplicationConfiguration;
 import org.atlasapi.application.v3.SourceStatus;
+import org.atlasapi.equiv.generators.metadata.EquivalenceGeneratorMetadata;
+import org.atlasapi.equiv.generators.metadata.SourceLimitedEquivalenceGeneratorMetadata;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates.Builder;
@@ -20,6 +20,9 @@ import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.persistence.content.SearchResolver;
 import org.atlasapi.search.model.SearchQuery;
 
+import com.metabroadcast.common.base.Maybe;
+import com.metabroadcast.common.query.Selection;
+
 import com.google.common.base.Functions;
 import com.google.common.base.Objects;
 import com.google.common.base.Strings;
@@ -27,8 +30,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
-import com.metabroadcast.common.base.Maybe;
-import com.metabroadcast.common.query.Selection;
+
+import static com.google.common.collect.Iterables.filter;
 
 public class FilmEquivalenceGenerator implements EquivalenceGenerator<Item> {
     
@@ -130,6 +133,14 @@ public class FilmEquivalenceGenerator implements EquivalenceGenerator<Item> {
         }
         
         return scores.build();
+    }
+
+    @Override
+    public EquivalenceGeneratorMetadata getMetadata() {
+        return SourceLimitedEquivalenceGeneratorMetadata.create(
+                this.getClass().getCanonicalName(),
+                publishers
+        );
     }
 
     private Maybe<String> getImdbRef(Film film) {

--- a/src/main/java/org/atlasapi/equiv/generators/TitleSearchGenerator.java
+++ b/src/main/java/org/atlasapi/equiv/generators/TitleSearchGenerator.java
@@ -1,11 +1,12 @@
 package org.atlasapi.equiv.generators;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.atlasapi.application.v3.ApplicationConfiguration;
 import org.atlasapi.application.v3.SourceStatus;
+import org.atlasapi.equiv.generators.metadata.EquivalenceGeneratorMetadata;
+import org.atlasapi.equiv.generators.metadata.SourceLimitedEquivalenceGeneratorMetadata;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
@@ -68,6 +69,14 @@ public class TitleSearchGenerator<T extends Content> implements EquivalenceGener
         }
         Iterable<? extends T> candidates = searchForCandidates(content, desc);
         return titleScorer.scoreCandidates(content, candidates, desc);
+    }
+
+    @Override
+    public EquivalenceGeneratorMetadata getMetadata() {
+        return SourceLimitedEquivalenceGeneratorMetadata.create(
+                this.getClass().getCanonicalName(),
+                searchPublishers
+        );
     }
 
     private Iterable<? extends T> searchForCandidates(T content, ResultDescription desc) {

--- a/src/main/java/org/atlasapi/equiv/generators/metadata/EquivalenceGeneratorMetadata.java
+++ b/src/main/java/org/atlasapi/equiv/generators/metadata/EquivalenceGeneratorMetadata.java
@@ -1,0 +1,5 @@
+package org.atlasapi.equiv.generators.metadata;
+
+public interface EquivalenceGeneratorMetadata {
+
+}

--- a/src/main/java/org/atlasapi/equiv/generators/metadata/GenericEquivalenceGeneratorMetadata.java
+++ b/src/main/java/org/atlasapi/equiv/generators/metadata/GenericEquivalenceGeneratorMetadata.java
@@ -1,0 +1,20 @@
+package org.atlasapi.equiv.generators.metadata;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class GenericEquivalenceGeneratorMetadata implements EquivalenceGeneratorMetadata {
+
+    private final String name;
+
+    private GenericEquivalenceGeneratorMetadata(String name) {
+        this.name = checkNotNull(name);
+    }
+
+    public static GenericEquivalenceGeneratorMetadata create(String name) {
+        return new GenericEquivalenceGeneratorMetadata(name);
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/generators/metadata/SourceLimitedEquivalenceGeneratorMetadata.java
+++ b/src/main/java/org/atlasapi/equiv/generators/metadata/SourceLimitedEquivalenceGeneratorMetadata.java
@@ -1,0 +1,45 @@
+package org.atlasapi.equiv.generators.metadata;
+
+import java.util.stream.StreamSupport;
+
+import org.atlasapi.media.entity.Publisher;
+
+import com.metabroadcast.common.stream.MoreCollectors;
+
+import com.google.common.collect.ImmutableSet;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class SourceLimitedEquivalenceGeneratorMetadata implements EquivalenceGeneratorMetadata {
+
+    private final String name;
+    private final ImmutableSet<String> sources;
+
+    private SourceLimitedEquivalenceGeneratorMetadata(
+            String name,
+            ImmutableSet<String> sources
+    ) {
+        this.name = checkNotNull(name);
+        this.sources = sources;
+    }
+
+    public static SourceLimitedEquivalenceGeneratorMetadata create(
+            String name,
+            Iterable<Publisher> sources
+    ) {
+        ImmutableSet<String> sourceKeys = StreamSupport
+                .stream(sources.spliterator(), false)
+                .map(Publisher::key)
+                .collect(MoreCollectors.toImmutableSet());
+
+        return new SourceLimitedEquivalenceGeneratorMetadata(name, sourceKeys);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public ImmutableSet<String> getSources() {
+        return sources;
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/ContentEquivalenceUpdater.java
+++ b/src/main/java/org/atlasapi/equiv/update/ContentEquivalenceUpdater.java
@@ -20,6 +20,7 @@ import org.atlasapi.equiv.scorers.EquivalenceScorers;
 import org.atlasapi.equiv.update.metadata.ContentEquivalenceUpdaterMetadata;
 import org.atlasapi.equiv.update.metadata.EquivalenceUpdaterMetadata;
 import org.atlasapi.media.entity.Content;
+import org.atlasapi.media.entity.Publisher;
 
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableSet;
@@ -87,7 +88,7 @@ public class ContentEquivalenceUpdater<T extends Content> implements Equivalence
     }
 
     @Override
-    public EquivalenceUpdaterMetadata getMetadata() {
+    public EquivalenceUpdaterMetadata getMetadata(Set<Publisher> sources) {
         return metadata;
     }
 

--- a/src/main/java/org/atlasapi/equiv/update/EquivalenceUpdater.java
+++ b/src/main/java/org/atlasapi/equiv/update/EquivalenceUpdater.java
@@ -1,10 +1,13 @@
 package org.atlasapi.equiv.update;
 
+import java.util.Set;
+
 import org.atlasapi.equiv.update.metadata.EquivalenceUpdaterMetadata;
+import org.atlasapi.media.entity.Publisher;
 
 public interface EquivalenceUpdater<T> {
 
     boolean updateEquivalences(T subject);
 
-    EquivalenceUpdaterMetadata getMetadata();
+    EquivalenceUpdaterMetadata getMetadata(Set<Publisher> sources);
 }

--- a/src/main/java/org/atlasapi/equiv/update/MultipleSourceEquivalenceUpdater.java
+++ b/src/main/java/org/atlasapi/equiv/update/MultipleSourceEquivalenceUpdater.java
@@ -1,6 +1,7 @@
 package org.atlasapi.equiv.update;
 
 import java.util.Map;
+import java.util.Set;
 
 import org.atlasapi.equiv.update.metadata.EquivalenceUpdaterMetadata;
 import org.atlasapi.equiv.update.metadata.MultipleSourceEquivalenceUpdaterMetadata;
@@ -37,13 +38,15 @@ public class MultipleSourceEquivalenceUpdater implements EquivalenceUpdater<Cont
     }
 
     @Override
-    public EquivalenceUpdaterMetadata getMetadata() {
+    public EquivalenceUpdaterMetadata getMetadata(Set<Publisher> sources) {
         return MultipleSourceEquivalenceUpdaterMetadata.create(
                 updaters.entrySet()
                         .stream()
+                        .filter(entry -> sources.contains(entry.getKey()))
+                        .sorted((o1, o2) -> o1.getKey().compareTo(o2.getKey()))
                         .collect(MoreCollectors.toImmutableMap(
                                 entry -> entry.getKey().key(),
-                                entry -> entry.getValue().getMetadata()
+                                entry -> entry.getValue().getMetadata(sources)
                         ))
         );
     }

--- a/src/main/java/org/atlasapi/equiv/update/NullEquivalenceUpdater.java
+++ b/src/main/java/org/atlasapi/equiv/update/NullEquivalenceUpdater.java
@@ -1,7 +1,10 @@
 package org.atlasapi.equiv.update;
 
+import java.util.Set;
+
 import org.atlasapi.equiv.update.metadata.EquivalenceUpdaterMetadata;
 import org.atlasapi.equiv.update.metadata.NopEquivalenceUpdaterMetadata;
+import org.atlasapi.media.entity.Publisher;
 
 public class NullEquivalenceUpdater<T> implements EquivalenceUpdater<T> {
 
@@ -13,7 +16,7 @@ public class NullEquivalenceUpdater<T> implements EquivalenceUpdater<T> {
             }
 
             @Override
-            public EquivalenceUpdaterMetadata getMetadata() {
+            public EquivalenceUpdaterMetadata getMetadata(Set<Publisher> sources) {
                 return NopEquivalenceUpdaterMetadata.create();
             }
         };
@@ -37,7 +40,7 @@ public class NullEquivalenceUpdater<T> implements EquivalenceUpdater<T> {
     }
 
     @Override
-    public EquivalenceUpdaterMetadata getMetadata() {
+    public EquivalenceUpdaterMetadata getMetadata(Set<Publisher> sources) {
         return NopEquivalenceUpdaterMetadata.create();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/RootEquivalenceUpdater.java
+++ b/src/main/java/org/atlasapi/equiv/update/RootEquivalenceUpdater.java
@@ -1,6 +1,7 @@
 package org.atlasapi.equiv.update;
 
 import java.util.List;
+import java.util.Set;
 
 import org.atlasapi.equiv.update.metadata.EquivalenceUpdaterMetadata;
 import org.atlasapi.equiv.update.metadata.RootEquivalenceUpdaterMetadata;
@@ -8,6 +9,7 @@ import org.atlasapi.media.entity.Brand;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.media.entity.Series;
 import org.atlasapi.media.entity.SeriesRef;
 import org.atlasapi.persistence.content.ContentResolver;
@@ -54,9 +56,9 @@ public class RootEquivalenceUpdater implements EquivalenceUpdater<Content> {
     }
 
     @Override
-    public EquivalenceUpdaterMetadata getMetadata() {
+    public EquivalenceUpdaterMetadata getMetadata(Set<Publisher> sources) {
         return RootEquivalenceUpdaterMetadata.create(
-                updater.getMetadata()
+                updater.getMetadata(sources)
         );
     }
 

--- a/src/main/java/org/atlasapi/equiv/update/SourceSpecificEquivalenceUpdater.java
+++ b/src/main/java/org/atlasapi/equiv/update/SourceSpecificEquivalenceUpdater.java
@@ -1,5 +1,7 @@
 package org.atlasapi.equiv.update;
 
+import java.util.Set;
+
 import org.atlasapi.equiv.update.metadata.EquivalenceUpdaterMetadata;
 import org.atlasapi.equiv.update.metadata.SourceSpecificEquivalenceUpdaterMetadata;
 import org.atlasapi.media.entity.Brand;
@@ -62,17 +64,17 @@ public class SourceSpecificEquivalenceUpdater implements EquivalenceUpdater<Cont
     }
 
     @Override
-    public EquivalenceUpdaterMetadata getMetadata() {
+    public EquivalenceUpdaterMetadata getMetadata(Set<Publisher> sources) {
         return SourceSpecificEquivalenceUpdaterMetadata.builder()
                 .withSource(source)
                 .withTopLevelContainerUpdaterMetadata(
-                        topLevelContainerUpdater.getMetadata()
+                        topLevelContainerUpdater.getMetadata(sources)
                 )
                 .withNonTopLevelContainerUpdaterMetadata(
-                        nonTopLevelContainerUpdater.getMetadata()
+                        nonTopLevelContainerUpdater.getMetadata(sources)
                 )
                 .withItemUpdaterMetadata(
-                        itemUpdater.getMetadata()
+                        itemUpdater.getMetadata(sources)
                 )
                 .build();
     }

--- a/src/main/java/org/atlasapi/equiv/update/metadata/ContentEquivalenceUpdaterMetadata.java
+++ b/src/main/java/org/atlasapi/equiv/update/metadata/ContentEquivalenceUpdaterMetadata.java
@@ -2,10 +2,14 @@ package org.atlasapi.equiv.update.metadata;
 
 import java.util.List;
 import java.util.Set;
+import java.util.stream.StreamSupport;
 
 import org.atlasapi.equiv.generators.EquivalenceGenerator;
+import org.atlasapi.equiv.generators.metadata.EquivalenceGeneratorMetadata;
 import org.atlasapi.equiv.handlers.EquivalenceResultHandler;
 import org.atlasapi.equiv.scorers.EquivalenceScorer;
+
+import com.metabroadcast.common.stream.MoreCollectors;
 
 import com.google.common.collect.ImmutableList;
 
@@ -13,7 +17,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public class ContentEquivalenceUpdaterMetadata extends EquivalenceUpdaterMetadata {
 
-    private final ImmutableList<String> generators;
+    private final ImmutableList<EquivalenceGeneratorMetadata> generators;
     private final ImmutableList<String> scorers;
     private final String combiner;
     private final String filter;
@@ -22,7 +26,7 @@ public class ContentEquivalenceUpdaterMetadata extends EquivalenceUpdaterMetadat
     private final ImmutableList<String> excludedUris;
 
     private ContentEquivalenceUpdaterMetadata(
-            Iterable<String> generators,
+            Iterable<EquivalenceGeneratorMetadata> generators,
             Iterable<String> scorers,
             String combiner,
             String filter,
@@ -43,7 +47,7 @@ public class ContentEquivalenceUpdaterMetadata extends EquivalenceUpdaterMetadat
         return new Builder();
     }
 
-    public ImmutableList<String> getGenerators() {
+    public ImmutableList<EquivalenceGeneratorMetadata> getGenerators() {
         return generators;
     }
 
@@ -114,7 +118,7 @@ public class ContentEquivalenceUpdaterMetadata extends EquivalenceUpdaterMetadat
     public static class Builder implements GeneratorsStep, ScorersStep, CombinerStep, FilterStep,
             ExtractorStep, HandlerStep, ExcludedUrisStep, BuildStep {
 
-        private List<String> generators;
+        private List<EquivalenceGeneratorMetadata> generators;
         private List<String> scorers;
         private String combiner;
         private String filter;
@@ -127,7 +131,9 @@ public class ContentEquivalenceUpdaterMetadata extends EquivalenceUpdaterMetadat
 
         @Override
         public <T> ScorersStep withGenerators(Iterable<EquivalenceGenerator<T>> generators) {
-            this.generators = getClassName(generators);
+            this.generators = StreamSupport.stream(generators.spliterator(), false)
+                    .map(EquivalenceGenerator::getMetadata)
+                    .collect(MoreCollectors.toImmutableList());
             return this;
         }
 


### PR DESCRIPTION
- This will show which sources we equivalate to
- Also add support in equivalence configuration endpoint to only show
  equivalence for a single publisher
- Add sorting by publisher to make the output more readable