### PR TITLE
Refactor equivalence configuration for readability

### DIFF
--- a/src/main/java/org/atlasapi/equiv/EquivModule.java
+++ b/src/main/java/org/atlasapi/equiv/EquivModule.java
@@ -15,74 +15,19 @@ permissions and limitations under the License. */
 package org.atlasapi.equiv;
 
 import java.io.File;
-import java.util.Set;
 
-import com.google.common.base.*;
-import org.atlasapi.equiv.generators.BroadcastMatchingItemEquivalenceGenerator;
-import org.atlasapi.equiv.generators.ContainerCandidatesContainerEquivalenceGenerator;
-import org.atlasapi.equiv.generators.ContainerCandidatesItemEquivalenceGenerator;
-import org.atlasapi.equiv.generators.ContainerChildEquivalenceGenerator;
-import org.atlasapi.equiv.generators.EquivalenceGenerator;
-import org.atlasapi.equiv.generators.FilmEquivalenceGenerator;
-import org.atlasapi.equiv.generators.RadioTimesFilmEquivalenceGenerator;
-import org.atlasapi.equiv.generators.ScalingEquivalenceGenerator;
-import org.atlasapi.equiv.generators.SongTitleTransform;
-import org.atlasapi.equiv.generators.TitleSearchGenerator;
-import org.atlasapi.equiv.handlers.BroadcastingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeMatchingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.EquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.MessageQueueingResultHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
-import org.atlasapi.equiv.results.combining.RequiredScoreFilteringCombiner;
-import org.atlasapi.equiv.results.extractors.MusicEquivalenceExtractor;
-import org.atlasapi.equiv.results.extractors.PercentThresholdAboveNextBestMatchEquivalenceExtractor;
-import org.atlasapi.equiv.results.extractors.PercentThresholdEquivalenceExtractor;
-import org.atlasapi.equiv.results.filters.AlwaysTrueFilter;
-import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
-import org.atlasapi.equiv.results.filters.ContainerHierarchyFilter;
-import org.atlasapi.equiv.results.filters.DummyContainerFilter;
-import org.atlasapi.equiv.results.filters.EquivalenceFilter;
-import org.atlasapi.equiv.results.filters.ExclusionListFilter;
-import org.atlasapi.equiv.results.filters.FilmFilter;
-import org.atlasapi.equiv.results.filters.MediaTypeFilter;
-import org.atlasapi.equiv.results.filters.MinimumScoreFilter;
-import org.atlasapi.equiv.results.filters.PublisherFilter;
-import org.atlasapi.equiv.results.filters.SpecializationFilter;
-import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
 import org.atlasapi.equiv.results.persistence.FileEquivalenceResultStore;
 import org.atlasapi.equiv.results.persistence.RecentEquivalenceResultStore;
-import org.atlasapi.equiv.results.scores.Score;
-import org.atlasapi.equiv.results.scores.ScoreThreshold;
-import org.atlasapi.equiv.scorers.BroadcastAliasScorer;
-import org.atlasapi.equiv.scorers.ContainerHierarchyMatchingScorer;
-import org.atlasapi.equiv.scorers.CrewMemberScorer;
-import org.atlasapi.equiv.scorers.DescriptionMatchingScorer;
-import org.atlasapi.equiv.scorers.DescriptionTitleMatchingScorer;
-import org.atlasapi.equiv.scorers.EquivalenceScorer;
-import org.atlasapi.equiv.scorers.SequenceContainerScorer;
-import org.atlasapi.equiv.scorers.SequenceItemScorer;
-import org.atlasapi.equiv.scorers.SeriesSequenceItemScorer;
-import org.atlasapi.equiv.scorers.SongCrewMemberExtractor;
-import org.atlasapi.equiv.scorers.SubscriptionCatchupBrandDetector;
-import org.atlasapi.equiv.scorers.TitleMatchingContainerScorer;
-import org.atlasapi.equiv.scorers.TitleMatchingItemScorer;
-import org.atlasapi.equiv.scorers.TitleSubsetBroadcastItemScorer;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
 import org.atlasapi.equiv.update.EquivalenceUpdater;
 import org.atlasapi.equiv.update.MultipleSourceEquivalenceUpdater;
-import org.atlasapi.equiv.update.NullEquivalenceUpdater;
 import org.atlasapi.equiv.update.SourceSpecificEquivalenceUpdater;
+import org.atlasapi.equiv.update.updaters.configuration.UpdaterConfiguration;
+import org.atlasapi.equiv.update.updaters.configuration.UpdaterConfigurationRegistry;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.channel.ChannelResolver;
-import org.atlasapi.media.entity.Broadcast;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Item;
-import org.atlasapi.media.entity.Publisher;
-import org.atlasapi.media.entity.Song;
 import org.atlasapi.messaging.v3.ContentEquivalenceAssertionMessage;
 import org.atlasapi.messaging.v3.JacksonMessageSerializer;
 import org.atlasapi.messaging.v3.KafkaMessagingModule;
@@ -92,72 +37,26 @@ import org.atlasapi.persistence.content.SearchResolver;
 import org.atlasapi.persistence.lookup.LookupWriter;
 import org.atlasapi.persistence.lookup.entry.LookupEntryStore;
 
-import com.metabroadcast.common.collect.MoreSets;
 import com.metabroadcast.common.queue.MessageSender;
-import com.metabroadcast.common.time.DateTimeZones;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Sets;
-import org.joda.time.DateTime;
-import org.joda.time.Duration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
-import static com.google.common.base.Predicates.in;
-import static com.google.common.base.Predicates.not;
-import static org.atlasapi.equiv.generators.AliasResolvingEquivalenceGenerator.aliasResolvingGenerator;
-import static org.atlasapi.media.entity.Publisher.AMAZON_UK;
-import static org.atlasapi.media.entity.Publisher.AMAZON_UNBOX;
-import static org.atlasapi.media.entity.Publisher.AMC_EBS;
-import static org.atlasapi.media.entity.Publisher.BBC;
-import static org.atlasapi.media.entity.Publisher.BBC_MUSIC;
-import static org.atlasapi.media.entity.Publisher.BBC_REDUX;
-import static org.atlasapi.media.entity.Publisher.BETTY;
-import static org.atlasapi.media.entity.Publisher.BT_SPORT_EBS;
-import static org.atlasapi.media.entity.Publisher.BT_TVE_VOD;
-import static org.atlasapi.media.entity.Publisher.BT_VOD;
-import static org.atlasapi.media.entity.Publisher.C4_PRESS;
-import static org.atlasapi.media.entity.Publisher.FACEBOOK;
-import static org.atlasapi.media.entity.Publisher.ITUNES;
-import static org.atlasapi.media.entity.Publisher.LOVEFILM;
-import static org.atlasapi.media.entity.Publisher.NETFLIX;
-import static org.atlasapi.media.entity.Publisher.PA;
-import static org.atlasapi.media.entity.Publisher.PREVIEW_NETWORKS;
-import static org.atlasapi.media.entity.Publisher.RADIO_TIMES;
-import static org.atlasapi.media.entity.Publisher.RADIO_TIMES_UPCOMING;
-import static org.atlasapi.media.entity.Publisher.RDIO;
-import static org.atlasapi.media.entity.Publisher.RTE;
-import static org.atlasapi.media.entity.Publisher.SOUNDCLOUD;
-import static org.atlasapi.media.entity.Publisher.SPOTIFY;
-import static org.atlasapi.media.entity.Publisher.TALK_TALK;
-import static org.atlasapi.media.entity.Publisher.VF_AE;
-import static org.atlasapi.media.entity.Publisher.VF_BBC;
-import static org.atlasapi.media.entity.Publisher.VF_C5;
-import static org.atlasapi.media.entity.Publisher.VF_ITV;
-import static org.atlasapi.media.entity.Publisher.VF_VIACOM;
-import static org.atlasapi.media.entity.Publisher.VF_VUBIQUITY;
-import static org.atlasapi.media.entity.Publisher.YOUTUBE;
-import static org.atlasapi.media.entity.Publisher.YOUVIEW;
-import static org.atlasapi.media.entity.Publisher.YOUVIEW_BT;
-import static org.atlasapi.media.entity.Publisher.YOUVIEW_BT_STAGE;
-import static org.atlasapi.media.entity.Publisher.YOUVIEW_SCOTLAND_RADIO;
-import static org.atlasapi.media.entity.Publisher.YOUVIEW_SCOTLAND_RADIO_STAGE;
-import static org.atlasapi.media.entity.Publisher.YOUVIEW_STAGE;
-
+@SuppressWarnings("PublicConstructor")
 @Configuration
-@Import({KafkaMessagingModule.class})
+@Import({ KafkaMessagingModule.class })
 public class EquivModule {
 
-    private static double DEFAULT_EXACT_TITLE_MATCH_SCORE = 2;
-	private @Value("${equiv.results.directory}") String equivResultsDirectory;
-	private @Value("${messaging.destination.equiv.assert}") String equivAssertDest;
-	private @Value("${equiv.excludedUris}") String excludedUris;
-    
+    private @Value("${equiv.results.directory}") String equivResultsDirectory;
+    private @Value("${messaging.destination.equiv.assert}") String equivAssertDest;
+    private @Value("${equiv.excludedUris}") String excludedUris;
+
     private @Autowired ScheduleResolver scheduleResolver;
     private @Autowired SearchResolver searchResolver;
     private @Autowired ContentResolver contentResolver;
@@ -165,812 +64,88 @@ public class EquivModule {
     private @Autowired EquivalenceSummaryStore equivSummaryStore;
     private @Autowired LookupWriter lookupWriter;
     private @Autowired LookupEntryStore lookupEntryStore;
-    
+
     private @Autowired KafkaMessagingModule messaging;
 
-    public @Bean RecentEquivalenceResultStore equivalenceResultStore() {
-        return new RecentEquivalenceResultStore(new FileEquivalenceResultStore(new File(equivResultsDirectory)));
+    @Bean
+    public EquivalenceUpdater<Content> contentUpdater() {
+        EquivalenceUpdaterProviderDependencies dependencies = EquivalenceUpdaterProviderDependencies
+                .builder()
+                .withScheduleResolver(scheduleResolver)
+                .withSearchResolver(searchResolver)
+                .withContentResolver(contentResolver)
+                .withChannelResolver(channelResolver)
+                .withEquivSummaryStore(equivSummaryStore)
+                .withLookupWriter(lookupWriter)
+                .withLookupEntryStore(lookupEntryStore)
+                .withEquivalenceResultStore(equivalenceResultStore())
+                .withMessageSender(equivAssertDestination())
+                .withExcludedUris(excludedUrisFromProperties())
+                .build();
+
+        UpdaterConfigurationRegistry registry = UpdaterConfigurationRegistry.create();
+
+        MultipleSourceEquivalenceUpdater updaters = MultipleSourceEquivalenceUpdater.create();
+
+        for (UpdaterConfiguration configuration : registry.getUpdaterConfigurations()) {
+            EquivalenceUpdater<Item> itemEquivalenceUpdater = configuration
+                    .getItemEquivalenceUpdaterType()
+                    .getProvider()
+                    .getUpdater(
+                            dependencies,
+                            configuration.getItemEquivalenceTargetSources()
+                    );
+
+            EquivalenceUpdater<Container> topLevelContainerEquivalenceUpdater = configuration
+                    .getTopLevelContainerEquivalenceUpdaterType()
+                    .getProvider()
+                    .getUpdater(
+                            dependencies,
+                            configuration.getTopLevelContainerTargetSources()
+                    );
+
+            EquivalenceUpdater<Container> nonTopLevelContainerEquivalenceUpdater = configuration
+                    .getNonTopLevelContainerEquivalenceUpdaterType()
+                    .getProvider()
+                    .getUpdater(
+                            dependencies,
+                            configuration.getNonTopLevelContainerTargetSources()
+                    );
+
+            updaters.register(
+                    configuration.getSource(),
+                    SourceSpecificEquivalenceUpdater
+                            .builder(configuration.getSource())
+                            .withItemUpdater(itemEquivalenceUpdater)
+                            .withTopLevelContainerUpdater(topLevelContainerEquivalenceUpdater)
+                            .withNonTopLevelContainerUpdater(nonTopLevelContainerEquivalenceUpdater)
+                            .build()
+            );
+        }
+
+        return updaters;
     }
 
-    private EquivalenceResultHandler<Container> containerResultHandlers(Iterable<Publisher> publishers) {
-        return new BroadcastingEquivalenceResultHandler<Container>(ImmutableList.of(
-            new LookupWritingEquivalenceHandler<Container>(lookupWriter, publishers),
-            new EpisodeMatchingEquivalenceHandler(contentResolver, equivSummaryStore, lookupWriter, publishers),
-            new ResultWritingEquivalenceHandler<Container>(equivalenceResultStore()),
-            new EquivalenceSummaryWritingHandler<Container>(equivSummaryStore),
-                MessageQueueingResultHandler.create(
-                    equivAssertDestination(), publishers, lookupEntryStore
-            )
-        ));
+    @Bean
+    public RecentEquivalenceResultStore equivalenceResultStore() {
+        return new RecentEquivalenceResultStore(
+                new FileEquivalenceResultStore(new File(equivResultsDirectory))
+        );
     }
 
-    private BroadcastingEquivalenceResultHandler<Item> itemResultHandlers(
-            Set<Publisher> acceptablePublishers) {
-        ImmutableList.Builder<EquivalenceResultHandler<Item>> handlers = ImmutableList.builder();
-        handlers
-                .add(EpisodeFilteringEquivalenceResultHandler.relaxed(
-                        new LookupWritingEquivalenceHandler<Item>(lookupWriter,
-                                acceptablePublishers),
-                        equivSummaryStore
-                ))
-                .add(new ResultWritingEquivalenceHandler<Item>(equivalenceResultStore()))
-                .add(new EquivalenceSummaryWritingHandler<Item>(equivSummaryStore));
-        handlers.add(MessageQueueingResultHandler.create(
-                equivAssertDestination(), acceptablePublishers, lookupEntryStore
-        ));
-        return new BroadcastingEquivalenceResultHandler<Item>(handlers.build());
-    }
-
-    @Bean 
+    @Bean
     protected MessageSender<ContentEquivalenceAssertionMessage> equivAssertDestination() {
         return messaging.messageSenderFactory()
-                .makeMessageSender(equivAssertDest, 
-                        JacksonMessageSerializer.forType(ContentEquivalenceAssertionMessage.class));
-    }
-    
-    private static Predicate<Broadcast> YOUVIEW_BROADCAST_FILTER = new Predicate<Broadcast>() {
-        
-        @Override
-        public boolean apply(Broadcast input) {
-            DateTime twoWeeksAgo = new DateTime(DateTimeZones.UTC).minusDays(15);
-            return input.getTransmissionTime().isAfter(twoWeeksAgo);
-        }
-    };
-    
-    private <T extends Content> EquivalenceFilter<T> standardFilter() {
-        return standardFilter(ImmutableList.<EquivalenceFilter<T>>of());
+                .makeMessageSender(
+                        equivAssertDest,
+                        JacksonMessageSerializer.forType(ContentEquivalenceAssertionMessage.class)
+                );
     }
 
-    private <T extends Content> EquivalenceFilter<T> standardFiltersMinusDummy() {
-        return ConjunctiveFilter.valueOf(ImmutableList.of(
-                new MinimumScoreFilter<T>(0.25),
-                new MediaTypeFilter<T>(),
-                new SpecializationFilter<T>(),
-                new PublisherFilter<T>(),
-                new ExclusionListFilter<T>(excludedUrisFromProperties()),
-                new FilmFilter<T>(),
-                new UnpublishedContentFilter<T>()
-        ));
-    }
-
-    private <T extends Content> EquivalenceFilter<T> standardFilter(Iterable<EquivalenceFilter<T>> additional) {
-        return ConjunctiveFilter.valueOf(Iterables.concat(ImmutableList.of(
-            new MinimumScoreFilter<T>(0.25),
-            new MediaTypeFilter<T>(),
-            new SpecializationFilter<T>(),
-            new PublisherFilter<T>(),
-            new ExclusionListFilter<T>(excludedUrisFromProperties()),
-            new FilmFilter<T>(),
-            new DummyContainerFilter<T>(),
-            new UnpublishedContentFilter<T>()
-        ), additional));
-    }
-    
     private ImmutableSet<String> excludedUrisFromProperties() {
-        if(Strings.isNullOrEmpty(excludedUris)) {
+        if (Strings.isNullOrEmpty(excludedUris)) {
             return ImmutableSet.of();
         }
         return ImmutableSet.copyOf(Splitter.on(',').split(excludedUris));
     }
-
-    private ContentEquivalenceUpdater.Builder<Item> standardItemUpdater(Set<Publisher> acceptablePublishers, Set<? extends EquivalenceScorer<Item>> scorers) {
-        return standardItemUpdater(acceptablePublishers, scorers, Predicates.alwaysTrue());
-    }
-    
-    private ContentEquivalenceUpdater.Builder<Item> standardItemUpdater(Set<Publisher> acceptablePublishers, Set<? extends EquivalenceScorer<Item>> scorers, Predicate<? super Broadcast> filter) {
-        return ContentEquivalenceUpdater.<Item> builder()
-            .withGenerators(ImmutableSet.<EquivalenceGenerator<Item>> of(
-                new BroadcastMatchingItemEquivalenceGenerator(scheduleResolver, 
-                    channelResolver, acceptablePublishers, Duration.standardMinutes(5), filter)
-            ))
-            .withExcludedUris(excludedUrisFromProperties())
-            .withScorers(scorers)
-            .withCombiner(new NullScoreAwareAveragingCombiner<Item>())
-            .withFilter(this.standardFilter())
-            .withExtractor(PercentThresholdAboveNextBestMatchEquivalenceExtractor.atLeastNTimesGreater(1.5))
-            .withHandler(new BroadcastingEquivalenceResultHandler<Item>(ImmutableList.of(
-                EpisodeFilteringEquivalenceResultHandler.relaxed(
-                    new LookupWritingEquivalenceHandler<Item>(lookupWriter, acceptablePublishers),
-                    equivSummaryStore
-                ),
-                new ResultWritingEquivalenceHandler<Item>(equivalenceResultStore()),
-                new EquivalenceSummaryWritingHandler<Item>(equivSummaryStore),
-                MessageQueueingResultHandler.create(
-                        equivAssertDestination(), acceptablePublishers, lookupEntryStore
-                )
-            )));
-    }
-
-    private ContentEquivalenceUpdater.Builder<Item> standardItemUpdaterMinusDummyFilter(
-            Set<Publisher> acceptablePublishers,
-            Set<? extends EquivalenceScorer<Item>> scorers,
-            Predicate<? super Broadcast> filter
-    ) {
-        return ContentEquivalenceUpdater.<Item> builder()
-                .withGenerators(ImmutableSet.<EquivalenceGenerator<Item>> of(
-                        new BroadcastMatchingItemEquivalenceGenerator(
-                                scheduleResolver,
-                                channelResolver,
-                                acceptablePublishers,
-                                Duration.standardMinutes(5),
-                                filter
-                        )
-                ))
-                .withExcludedUris(excludedUrisFromProperties())
-                .withScorers(scorers)
-                .withCombiner(new NullScoreAwareAveragingCombiner<Item>())
-                .withFilter(standardFiltersMinusDummy())
-                .withExtractor(
-                        PercentThresholdAboveNextBestMatchEquivalenceExtractor
-                                .atLeastNTimesGreater(1.5))
-                .withHandler(new BroadcastingEquivalenceResultHandler<Item>(ImmutableList.of(
-                        EpisodeFilteringEquivalenceResultHandler.relaxed(
-                                new LookupWritingEquivalenceHandler<Item>(
-                                        lookupWriter,
-                                        acceptablePublishers
-                                ),
-                                equivSummaryStore
-                        ),
-                        new ResultWritingEquivalenceHandler<Item>(equivalenceResultStore()),
-                        new EquivalenceSummaryWritingHandler<Item>(equivSummaryStore),
-                        MessageQueueingResultHandler.create(
-                                equivAssertDestination(), acceptablePublishers, lookupEntryStore
-                        )
-                )));
-    }
-
-    private ContentEquivalenceUpdater.Builder<Item> ebsItemUpdater(
-            Set<Publisher> acceptablePublishers,
-            Set<? extends EquivalenceScorer<Item>> scorers
-    ) {
-
-        NullScoreAwareAveragingCombiner<Item> combiner =
-                new NullScoreAwareAveragingCombiner<>(true);
-
-        return ContentEquivalenceUpdater.<Item> builder()
-                .withGenerators(ImmutableSet.<EquivalenceGenerator<Item>> of(
-                        new BroadcastMatchingItemEquivalenceGenerator(
-                                scheduleResolver,
-                                channelResolver,
-                                acceptablePublishers,
-                                Duration.standardMinutes(5),
-                                Predicates.alwaysTrue())
-                ))
-                .withExcludedUris(excludedUrisFromProperties())
-                .withScorers(scorers)
-                .withCombiner(combiner)
-                .withFilter(this.standardFilter())
-                .withExtractor(
-                        PercentThresholdAboveNextBestMatchEquivalenceExtractor
-                                .atLeastNTimesGreater(1.5)
-                )
-                .withHandler(new BroadcastingEquivalenceResultHandler<Item>(ImmutableList.of(
-                        EpisodeFilteringEquivalenceResultHandler.relaxed(
-                                new LookupWritingEquivalenceHandler<Item>(
-                                        lookupWriter,
-                                        acceptablePublishers),
-                                equivSummaryStore
-                        ),
-                        new ResultWritingEquivalenceHandler<Item>(equivalenceResultStore()),
-                        new EquivalenceSummaryWritingHandler<Item>(equivSummaryStore),
-                        MessageQueueingResultHandler.create(
-                                equivAssertDestination(), acceptablePublishers, lookupEntryStore
-                        )
-                )));
-    }
-    
-    private EquivalenceUpdater<Container> topLevelContainerUpdater(Set<Publisher> publishers) {
-        return ContentEquivalenceUpdater.<Container> builder()
-            .withExcludedUris(excludedUrisFromProperties())
-            .withGenerators(ImmutableSet.of(
-                TitleSearchGenerator.create(searchResolver, Container.class, publishers, DEFAULT_EXACT_TITLE_MATCH_SCORE),
-                ScalingEquivalenceGenerator.scale(
-                    new ContainerChildEquivalenceGenerator(contentResolver, equivSummaryStore),
-                    20)
-                ))
-            .withScorers(ImmutableSet.<EquivalenceScorer<Container>> of(
-                new TitleMatchingContainerScorer(DEFAULT_EXACT_TITLE_MATCH_SCORE)
-            ))
-            .withCombiner(new RequiredScoreFilteringCombiner<Container>(
-                new NullScoreAwareAveragingCombiner<Container>(),
-                            TitleMatchingContainerScorer.NAME
-            ))
-            .withFilter(this.standardFilter())
-            .withExtractor(PercentThresholdAboveNextBestMatchEquivalenceExtractor.atLeastNTimesGreater(1.5))
-            .withHandler(containerResultHandlers(publishers))
-            .build();
-    }
-
-    private EquivalenceUpdater<Container> topLevelContainerUpdaterMinusDummyFilter(
-            Set<Publisher> publishers
-    ) {
-        return ContentEquivalenceUpdater.<Container> builder()
-                .withExcludedUris(excludedUrisFromProperties())
-                .withGenerators(ImmutableSet.of(
-                        TitleSearchGenerator.create(searchResolver, Container.class, publishers, DEFAULT_EXACT_TITLE_MATCH_SCORE),
-                        ScalingEquivalenceGenerator.scale(
-                                new ContainerChildEquivalenceGenerator(contentResolver, equivSummaryStore),
-                                20)
-                ))
-                .withScorers(ImmutableSet.<EquivalenceScorer<Container>> of(
-                        new TitleMatchingContainerScorer(DEFAULT_EXACT_TITLE_MATCH_SCORE)
-                ))
-                .withCombiner(new RequiredScoreFilteringCombiner<Container>(
-                        new NullScoreAwareAveragingCombiner<Container>(),
-                        TitleMatchingContainerScorer.NAME
-                ))
-                .withFilter(standardFiltersMinusDummy())
-                .withExtractor(PercentThresholdAboveNextBestMatchEquivalenceExtractor.atLeastNTimesGreater(1.5))
-                .withHandler(containerResultHandlers(publishers))
-                .build();
-    }
-
-    @Bean 
-    public EquivalenceUpdater<Content> contentUpdater() {
-        
-        Set<Publisher> musicPublishers = ImmutableSet.of(BBC_MUSIC, YOUTUBE, 
-            SPOTIFY, SOUNDCLOUD, RDIO, AMAZON_UK);
-        Set<Publisher> roviPublishers = ImmutableSet.copyOf(Sets.filter(Publisher.all(), 
-            new Predicate<Publisher>(){
-                @Override
-                public boolean apply(Publisher input) {
-                    return input.key().endsWith("rovicorp.com");
-                }
-            }
-        ));
-        
-        //Generally acceptable publishers.
-        ImmutableSet<Publisher> acceptablePublishers = ImmutableSet.copyOf(Sets.difference(
-            Publisher.all(), 
-            Sets.union(
-                ImmutableSet.of(PREVIEW_NETWORKS, BBC_REDUX, RADIO_TIMES, LOVEFILM, NETFLIX, YOUVIEW,
-                        YOUVIEW_STAGE, YOUVIEW_BT, YOUVIEW_BT_STAGE, BT_SPORT_EBS, C4_PRESS, RADIO_TIMES_UPCOMING),
-                Sets.union(musicPublishers, roviPublishers)
-            )
-        ));
-        
-        EquivalenceUpdater<Item> standardItemUpdater =
-                standardItemUpdater(
-                        MoreSets.add(acceptablePublishers, LOVEFILM),
-                        ImmutableSet.of(
-                                new TitleMatchingItemScorer(),
-                                new SequenceItemScorer(Score.ONE),
-                                new DescriptionTitleMatchingScorer(),
-                                DescriptionMatchingScorer.makeScorer()
-                        )
-                ).build();
-
-        EquivalenceUpdater<Item> rtUpcomingItemUpdater =
-                standardItemUpdaterMinusDummyFilter(
-                        ImmutableSet.of(AMAZON_UNBOX),
-                        ImmutableSet.of(
-                                new TitleMatchingItemScorer(),
-                                new SequenceItemScorer(Score.ONE),
-                                new DescriptionTitleMatchingScorer(),
-                                DescriptionMatchingScorer.makeScorer()
-                        ),
-                        Predicates.alwaysTrue()
-                ).build();
-
-        EquivalenceUpdater<Item> ebsItemUpdater =
-                ebsItemUpdater(
-                        MoreSets.add(acceptablePublishers, LOVEFILM),
-                        ImmutableSet.of(
-                                new TitleMatchingItemScorer(),
-                                new SequenceItemScorer(Score.ONE),
-                                new DescriptionTitleMatchingScorer(),
-                                DescriptionMatchingScorer.makeScorer()
-                        )
-                ).build();
-
-        EquivalenceUpdater<Container> topLevelContainerUpdater =
-                topLevelContainerUpdater(MoreSets.add(acceptablePublishers, LOVEFILM));
-
-        Set<Publisher> nonStandardPublishers = ImmutableSet.copyOf(Sets.union(
-            ImmutableSet.of(ITUNES, BBC_REDUX, RADIO_TIMES, FACEBOOK, LOVEFILM, NETFLIX,
-                    RTE, YOUVIEW, YOUVIEW_STAGE, YOUVIEW_BT, YOUVIEW_BT_STAGE, TALK_TALK,
-                    PA, BT_VOD, BT_TVE_VOD, BETTY, AMC_EBS, BT_SPORT_EBS, C4_PRESS, RADIO_TIMES_UPCOMING),
-            Sets.union(musicPublishers, roviPublishers)
-        ));
-
-        MultipleSourceEquivalenceUpdater updaters = MultipleSourceEquivalenceUpdater.create();
-
-        for (Publisher publisher : Iterables.filter(Publisher.all(), not(in(nonStandardPublishers)))) {
-            updaters.register(publisher, SourceSpecificEquivalenceUpdater.builder(publisher)
-                .withItemUpdater(standardItemUpdater)
-                .withTopLevelContainerUpdater(topLevelContainerUpdater)
-                .withNonTopLevelContainerUpdater(standardSeriesUpdater(acceptablePublishers))
-                .build());
-        }
-
-        updaters.register(
-                RADIO_TIMES_UPCOMING,
-                SourceSpecificEquivalenceUpdater.builder(RADIO_TIMES_UPCOMING)
-                        .withItemUpdater(rtUpcomingItemUpdater)
-                        .withTopLevelContainerUpdater(topLevelContainerUpdaterMinusDummyFilter(
-                                ImmutableSet.of(AMAZON_UNBOX)
-                        ))
-                        .withNonTopLevelContainerUpdater(standardSeriesUpdater(
-                                ImmutableSet.of(AMAZON_UNBOX)
-                        ))
-                        .build());
-
-        updaters.register(BT_SPORT_EBS, SourceSpecificEquivalenceUpdater.builder(BT_SPORT_EBS)
-                .withItemUpdater(ebsItemUpdater)
-                .withTopLevelContainerUpdater(topLevelContainerUpdater)
-                .withNonTopLevelContainerUpdater(standardSeriesUpdater(acceptablePublishers))
-                .build());
-
-        updaters.register(AMC_EBS, SourceSpecificEquivalenceUpdater.builder(AMC_EBS)
-                .withItemUpdater(standardItemUpdater)
-                .withTopLevelContainerUpdater(topLevelContainerUpdater)
-                .withNonTopLevelContainerUpdater(standardSeriesUpdater(ImmutableSet.of(AMC_EBS, PA)))
-                .build());
-
-        updaters.register(RADIO_TIMES, SourceSpecificEquivalenceUpdater.builder(RADIO_TIMES)
-                .withItemUpdater(rtItemEquivalenceUpdater())
-                .withTopLevelContainerUpdater(NullEquivalenceUpdater.get())
-                .withNonTopLevelContainerUpdater(NullEquivalenceUpdater.get())
-                .build());
-
-        registerYouViewUpdaterForPublisher(
-                YOUVIEW, 
-                Sets.union(Sets.difference(acceptablePublishers, ImmutableSet.of(YOUVIEW_STAGE)), ImmutableSet.of(YOUVIEW)), 
-                updaters);
-        
-        registerYouViewUpdaterForPublisher(
-                YOUVIEW_STAGE, 
-                Sets.union(Sets.difference(acceptablePublishers, ImmutableSet.of(YOUVIEW)), ImmutableSet.of(YOUVIEW_STAGE)), 
-                updaters);
-        
-        registerYouViewUpdaterForPublisher(
-                YOUVIEW_BT, 
-                Sets.union(Sets.difference(acceptablePublishers, ImmutableSet.of(YOUVIEW_BT_STAGE)), ImmutableSet.of(YOUVIEW_BT)), 
-                updaters);
-        
-        registerYouViewUpdaterForPublisher(
-                YOUVIEW_BT_STAGE, 
-                Sets.union(Sets.difference(acceptablePublishers, ImmutableSet.of(YOUVIEW_BT)), ImmutableSet.of(YOUVIEW_BT_STAGE)), 
-                updaters);
-        
-        registerYouViewUpdaterForPublisher(
-                YOUVIEW_SCOTLAND_RADIO, 
-                Sets.union(Sets.difference(acceptablePublishers, ImmutableSet.of(YOUVIEW_SCOTLAND_RADIO_STAGE)), ImmutableSet.of(YOUVIEW_SCOTLAND_RADIO)), 
-                updaters);
-        
-        registerYouViewUpdaterForPublisher(
-                YOUVIEW_SCOTLAND_RADIO_STAGE, 
-                Sets.union(Sets.difference(acceptablePublishers, ImmutableSet.of(YOUVIEW_SCOTLAND_RADIO)), ImmutableSet.of(YOUVIEW_SCOTLAND_RADIO_STAGE)), 
-                updaters);
-
-        Set<Publisher> reduxPublishers = Sets.union(acceptablePublishers, ImmutableSet.of(BBC_REDUX));
-
-        updaters.register(BBC_REDUX, SourceSpecificEquivalenceUpdater.builder(BBC_REDUX)
-                .withItemUpdater(broadcastItemEquivalenceUpdater(reduxPublishers, Score.nullScore(), Predicates.alwaysTrue()))
-                .withTopLevelContainerUpdater(broadcastItemContainerEquivalenceUpdater(reduxPublishers))
-                .withNonTopLevelContainerUpdater(NullEquivalenceUpdater.get())
-                .build());
-
-        updaters.register(C4_PRESS, SourceSpecificEquivalenceUpdater.builder(C4_PRESS)
-                .withItemUpdater(broadcastItemEquivalenceUpdater(
-                        ImmutableSet.of(PA),
-                        Score.nullScore(),
-                        Predicates.alwaysTrue()
-                ))
-                .withTopLevelContainerUpdater(NullEquivalenceUpdater.get())
-                .withNonTopLevelContainerUpdater(NullEquivalenceUpdater.get())
-                .build());
-
-        updaters.register(BETTY, SourceSpecificEquivalenceUpdater.builder(BETTY)
-                .withItemUpdater(aliasIdentifiedBroadcastItemEquivalenceUpdater(ImmutableSet.of(
-                        BETTY,
-                        YOUVIEW)))
-                .withTopLevelContainerUpdater(NullEquivalenceUpdater.get())
-                .withNonTopLevelContainerUpdater(NullEquivalenceUpdater.get())
-                .build());
-        
-        Set<Publisher> facebookAcceptablePublishers = Sets.union(acceptablePublishers, ImmutableSet.of(FACEBOOK));
-        updaters.register(FACEBOOK, SourceSpecificEquivalenceUpdater.builder(FACEBOOK)
-                .withItemUpdater(NullEquivalenceUpdater.get())
-                .withTopLevelContainerUpdater( facebookContainerEquivalenceUpdater(facebookAcceptablePublishers))
-                .withNonTopLevelContainerUpdater(NullEquivalenceUpdater.get())
-                .build());
-
-        updaters.register(ITUNES, SourceSpecificEquivalenceUpdater.builder(ITUNES)
-                .withItemUpdater(vodItemUpdater(acceptablePublishers).build())
-                .withTopLevelContainerUpdater(vodContainerUpdater(acceptablePublishers))
-                .withNonTopLevelContainerUpdater(NullEquivalenceUpdater.get())
-                .build());
-
-        Set<Publisher> lfPublishers = Sets.union(acceptablePublishers, ImmutableSet.of(LOVEFILM));
-        updaters.register(LOVEFILM, SourceSpecificEquivalenceUpdater.builder(LOVEFILM)
-                .withItemUpdater(vodItemUpdater(lfPublishers)
-                        .withScorer(new SeriesSequenceItemScorer()).build())
-                .withTopLevelContainerUpdater(vodContainerUpdater(lfPublishers))
-                .withNonTopLevelContainerUpdater(NullEquivalenceUpdater.get())
-                .build());
-        
-        Set<Publisher> netflixPublishers = ImmutableSet.of(BBC, NETFLIX);
-        updaters.register(NETFLIX, SourceSpecificEquivalenceUpdater.builder(NETFLIX)
-                .withItemUpdater(vodItemUpdater(netflixPublishers).build())
-                .withTopLevelContainerUpdater(vodContainerUpdater(netflixPublishers))
-                .withNonTopLevelContainerUpdater(NullEquivalenceUpdater.get())
-                .build());
-        
-        Set<Publisher> amazonUnboxPublishers = ImmutableSet.of(AMAZON_UNBOX, PA);
-        updaters.register(AMAZON_UNBOX, SourceSpecificEquivalenceUpdater.builder(AMAZON_UNBOX)
-                .withItemUpdater(vodItemUpdater(amazonUnboxPublishers).build())
-                .withTopLevelContainerUpdater(vodContainerUpdater(amazonUnboxPublishers))
-                .withNonTopLevelContainerUpdater(NullEquivalenceUpdater.get())
-                .build());
-
-        Set<Publisher> rtePublishers = ImmutableSet.of(PA);
-        updaters.register(RTE, SourceSpecificEquivalenceUpdater.builder(RTE)
-                .withTopLevelContainerUpdater(rteVodContainerUpdater(rtePublishers))
-                .withItemUpdater(NullEquivalenceUpdater.get())
-                .withNonTopLevelContainerUpdater(NullEquivalenceUpdater.get())
-                .build());
-        
-        updaters.register(TALK_TALK, SourceSpecificEquivalenceUpdater.builder(TALK_TALK)
-                .withItemUpdater(vodItemUpdater(acceptablePublishers).build())
-                .withTopLevelContainerUpdater(vodContainerUpdater(acceptablePublishers))
-                .withNonTopLevelContainerUpdater(standardSeriesUpdater(acceptablePublishers))
-                .build());
-        
-        Set<Publisher> btVodPublishers = ImmutableSet.of(PA);
-        updaters.register(BT_VOD, SourceSpecificEquivalenceUpdater.builder(BT_VOD)
-                .withItemUpdater(vodItemUpdater(btVodPublishers)
-                        .withScorer(new SeriesSequenceItemScorer()).build())
-                .withTopLevelContainerUpdater(vodContainerUpdater(btVodPublishers))
-                .withNonTopLevelContainerUpdater(standardSeriesUpdater(btVodPublishers))
-                .build());
-        
-        Set<Publisher> btTveVodPublishers = ImmutableSet.of(PA);
-        updaters.register(BT_TVE_VOD, SourceSpecificEquivalenceUpdater.builder(BT_TVE_VOD)
-                .withItemUpdater(btVodItemUpdater(btTveVodPublishers)
-                        .withScorer(new SeriesSequenceItemScorer()).build())
-                .withTopLevelContainerUpdater(btTveVodContainerUpdater(btTveVodPublishers))
-                .withNonTopLevelContainerUpdater(standardSeriesUpdater(btTveVodPublishers))
-                .build());
-
-        Set<Publisher> vfPublishers = ImmutableSet.of(VF_AE, VF_BBC, VF_C5, VF_ITV, VF_VIACOM, VF_VUBIQUITY);
-        Set<Publisher> vfVodPublishers = ImmutableSet.of(PA);
-
-        for (Publisher publisher : vfPublishers) {
-            updaters.register(publisher, SourceSpecificEquivalenceUpdater.builder(publisher)
-                    .withItemUpdater(btVodItemUpdater(vfVodPublishers)
-                            .withScorer(new SeriesSequenceItemScorer()).build())
-                    .withTopLevelContainerUpdater(btTveVodContainerUpdater(btTveVodPublishers))
-                    .withNonTopLevelContainerUpdater(standardSeriesUpdater(btTveVodPublishers))
-                    .build());
-        }
-                
-        Set<Publisher> itunesAndMusicPublishers = Sets.union(musicPublishers, ImmutableSet.of(ITUNES));
-        ContentEquivalenceUpdater<Item> muiscPublisherUpdater = ContentEquivalenceUpdater.<Item>builder()
-            .withGenerator(
-                new TitleSearchGenerator<Item>(searchResolver, Song.class, itunesAndMusicPublishers, new SongTitleTransform(), 100, DEFAULT_EXACT_TITLE_MATCH_SCORE)
-            ).withScorer(new CrewMemberScorer(new SongCrewMemberExtractor()))
-                .withExcludedUris(excludedUrisFromProperties())
-            .withCombiner(new NullScoreAwareAveragingCombiner<Item>())
-            .withFilter(AlwaysTrueFilter.get())
-            .withExtractor(new MusicEquivalenceExtractor())
-            .withHandler(new BroadcastingEquivalenceResultHandler<Item>(ImmutableList.of(
-                EpisodeFilteringEquivalenceResultHandler.relaxed(
-                    new LookupWritingEquivalenceHandler<Item>(lookupWriter, itunesAndMusicPublishers),
-                    equivSummaryStore
-                ),
-                new ResultWritingEquivalenceHandler<Item>(equivalenceResultStore()),
-                new EquivalenceSummaryWritingHandler<Item>(equivSummaryStore)
-            )))
-            .build();
-        
-        for (Publisher publisher : musicPublishers) {
-            updaters.register(publisher, SourceSpecificEquivalenceUpdater.builder(publisher)
-                    .withItemUpdater(muiscPublisherUpdater)
-                    .withTopLevelContainerUpdater(NullEquivalenceUpdater.get())
-                    .withNonTopLevelContainerUpdater(NullEquivalenceUpdater.get())
-                    .build());
-        }
-        
-        ImmutableSet<Publisher> roviMatchPublishers = ImmutableSet.of(
-            Publisher.BBC, Publisher.PA, Publisher.YOUVIEW, Publisher.BBC_NITRO, 
-            Publisher.BBC_REDUX, Publisher.ITV, Publisher.C4_PMLSD,
-            Publisher.C4_PMLSD_P06,Publisher.FIVE
-        );
-        updaters.register(Publisher.ROVI_EN_GB, roviUpdater(Publisher.ROVI_EN_GB, roviMatchPublishers));
-        updaters.register(Publisher.ROVI_EN_US, roviUpdater(Publisher.ROVI_EN_US, roviMatchPublishers));
-        
-        
-        return updaters; 
-    }
-
-    private void registerYouViewUpdaterForPublisher(Publisher publisher, Set<Publisher> matchTo, MultipleSourceEquivalenceUpdater updaters) {
-        updaters.register(publisher, SourceSpecificEquivalenceUpdater.builder(publisher)
-                .withItemUpdater(broadcastItemEquivalenceUpdater(matchTo, Score.negativeOne(), YOUVIEW_BROADCAST_FILTER))
-                .withTopLevelContainerUpdater(broadcastItemContainerEquivalenceUpdater(matchTo))
-                .withNonTopLevelContainerUpdater(NullEquivalenceUpdater.get())
-                .build());
-        
-    }
-
-    private ContentEquivalenceUpdater<Container> standardSeriesUpdater(
-            Set<Publisher> acceptablePublishers) {
-        return ContentEquivalenceUpdater.<Container>builder()
-            .withExcludedUris(excludedUrisFromProperties())
-            .withGenerator(new ContainerCandidatesContainerEquivalenceGenerator(contentResolver, equivSummaryStore))
-            .withScorer(new SequenceContainerScorer())
-            .withCombiner(new NullScoreAwareAveragingCombiner<Container>())
-            .withFilter(this.standardFilter(ImmutableList.of(
-                new ContainerHierarchyFilter()
-            )))
-            .withExtractor(PercentThresholdEquivalenceExtractor.moreThanPercent(90))
-            .withHandler(new BroadcastingEquivalenceResultHandler<Container>(ImmutableList.of(
-                new LookupWritingEquivalenceHandler<Container>(lookupWriter, acceptablePublishers),
-                new ResultWritingEquivalenceHandler<Container>(equivalenceResultStore()),
-                new EquivalenceSummaryWritingHandler<Container>(equivSummaryStore)
-            )))
-            .build();
-    }
-
-    private SourceSpecificEquivalenceUpdater roviUpdater(Publisher roviSource, ImmutableSet<Publisher> roviMatchPublishers) {
-        SourceSpecificEquivalenceUpdater roviUpdater = SourceSpecificEquivalenceUpdater.builder(roviSource)
-            .withItemUpdater(ContentEquivalenceUpdater.<Item> builder()
-                    .withExcludedUris(excludedUrisFromProperties())
-                    .withGenerators(ImmutableSet.of(
-                            new BroadcastMatchingItemEquivalenceGenerator(scheduleResolver, channelResolver, roviMatchPublishers, Duration.standardMinutes(10)),
-                            new ContainerCandidatesItemEquivalenceGenerator(contentResolver, equivSummaryStore),
-                            new FilmEquivalenceGenerator(searchResolver, roviMatchPublishers, true)
-                        ))
-                        .withScorers(ImmutableSet.of(
-                            new TitleMatchingItemScorer(),
-                            new SequenceItemScorer(Score.ONE)
-                        ))
-                        .withCombiner(new RequiredScoreFilteringCombiner<Item>(
-                            new NullScoreAwareAveragingCombiner<Item>(),
-                            TitleMatchingItemScorer.NAME
-                        ))
-                        .withFilter(this.standardFilter())
-                        .withExtractor(PercentThresholdEquivalenceExtractor.moreThanPercent(90))
-                        .withHandler(new BroadcastingEquivalenceResultHandler<Item>(ImmutableList.of(
-                            EpisodeFilteringEquivalenceResultHandler.strict(
-                                new LookupWritingEquivalenceHandler<Item>(lookupWriter, roviMatchPublishers),
-                                equivSummaryStore
-                            ),
-                            new ResultWritingEquivalenceHandler<Item>(equivalenceResultStore()),
-                            new EquivalenceSummaryWritingHandler<Item>(equivSummaryStore)
-                        ))).build())
-            .withNonTopLevelContainerUpdater(NullEquivalenceUpdater.get())
-            .withTopLevelContainerUpdater(topLevelContainerUpdater(roviMatchPublishers))
-            .build();
-        return roviUpdater;
-    }
-
-    private EquivalenceUpdater<Container> facebookContainerEquivalenceUpdater(Set<Publisher> facebookAcceptablePublishers) {
-        return ContentEquivalenceUpdater.<Container> builder()
-            .withExcludedUris(excludedUrisFromProperties())
-            .withGenerators(ImmutableSet.of(
-                    TitleSearchGenerator.create(searchResolver, Container.class, facebookAcceptablePublishers, DEFAULT_EXACT_TITLE_MATCH_SCORE),
-                    aliasResolvingGenerator(contentResolver, Container.class)
-            ))
-            .withScorers(ImmutableSet.of())
-            .withCombiner(NullScoreAwareAveragingCombiner.get())
-            .withFilter(ConjunctiveFilter.valueOf(ImmutableList.of(
-                new MinimumScoreFilter<Container>(0.25),
-                new SpecializationFilter<Container>(),
-                new UnpublishedContentFilter<>()
-            )))
-            .withExtractor(PercentThresholdEquivalenceExtractor.moreThanPercent(90))
-            .withHandler(containerResultHandlers(facebookAcceptablePublishers))
-            .build();
-    }
-
-    private EquivalenceUpdater<Container> vodContainerUpdater(Set<Publisher> acceptablePublishers) {
-        return ContentEquivalenceUpdater.<Container> builder()
-            .withExcludedUris(excludedUrisFromProperties())
-            .withGenerator(TitleSearchGenerator.create(searchResolver, Container.class, acceptablePublishers, DEFAULT_EXACT_TITLE_MATCH_SCORE)
-            )
-            .withScorers(ImmutableSet.of(
-                new TitleMatchingContainerScorer(DEFAULT_EXACT_TITLE_MATCH_SCORE),
-                new ContainerHierarchyMatchingScorer(
-                        contentResolver, 
-                        Score.negativeOne(), 
-                        new SubscriptionCatchupBrandDetector(contentResolver)
-                    )
-            ))
-            .withCombiner(new RequiredScoreFilteringCombiner<Container>(
-                new NullScoreAwareAveragingCombiner<Container>(),
-                TitleMatchingContainerScorer.NAME,
-                ScoreThreshold.greaterThanOrEqual(DEFAULT_EXACT_TITLE_MATCH_SCORE))
-            )
-            .withFilter(this.standardFilter())
-            .withExtractor(PercentThresholdAboveNextBestMatchEquivalenceExtractor.atLeastNTimesGreater(1.5))
-            .withHandler(containerResultHandlers(acceptablePublishers))
-            .build();
-    }
-
-    private EquivalenceUpdater<Container> rteVodContainerUpdater(
-            Set<Publisher> acceptablePublishers
-    ) {
-        return ContentEquivalenceUpdater.<Container> builder()
-                .withExcludedUris(excludedUrisFromProperties())
-                .withGenerator(TitleSearchGenerator.create(
-                        searchResolver,
-                        Container.class,
-                        acceptablePublishers,
-                        DEFAULT_EXACT_TITLE_MATCH_SCORE
-                        )
-                )
-                .withScorers(ImmutableSet.of(
-                        new TitleMatchingContainerScorer(DEFAULT_EXACT_TITLE_MATCH_SCORE),
-                        new ContainerHierarchyMatchingScorer(
-                                contentResolver,
-                                Score.negativeOne(),
-                                new SubscriptionCatchupBrandDetector(contentResolver)
-                        )
-                ))
-                .withCombiner(new RequiredScoreFilteringCombiner<Container>(
-                        new NullScoreAwareAveragingCombiner<Container>(),
-                        TitleMatchingContainerScorer.NAME,
-                        ScoreThreshold.greaterThanOrEqual(DEFAULT_EXACT_TITLE_MATCH_SCORE))
-                )
-                .withFilter(standardFiltersMinusDummy())
-                .withExtractor(
-                        PercentThresholdAboveNextBestMatchEquivalenceExtractor
-                                .atLeastNTimesGreater(1.5)
-                )
-                .withHandler(containerResultHandlers(acceptablePublishers))
-                .build();
-    }
-
-    private EquivalenceUpdater<Container> btTveVodContainerUpdater(Set<Publisher> acceptablePublishers) {
-        return ContentEquivalenceUpdater.<Container> builder()
-                .withExcludedUris(excludedUrisFromProperties())
-                .withGenerator(TitleSearchGenerator.create(searchResolver, Container.class, acceptablePublishers, DEFAULT_EXACT_TITLE_MATCH_SCORE)
-                )
-                .withScorers(ImmutableSet.of(
-                        new TitleMatchingContainerScorer(DEFAULT_EXACT_TITLE_MATCH_SCORE),
-                        new ContainerHierarchyMatchingScorer(
-                                contentResolver,
-                                Score.valueOf(-0.49d),
-                                new SubscriptionCatchupBrandDetector(contentResolver)
-                        )
-                ))
-                .withCombiner(new RequiredScoreFilteringCombiner<Container>(
-                        new NullScoreAwareAveragingCombiner<Container>(),
-                        TitleMatchingContainerScorer.NAME)
-                )
-                .withFilter(this.standardFilter())
-                .withExtractor(PercentThresholdAboveNextBestMatchEquivalenceExtractor.atLeastNTimesGreater(1.5))
-                .withHandler(containerResultHandlers(acceptablePublishers))
-                .build();
-    }
-
-    private ContentEquivalenceUpdater.Builder<Item> vodItemUpdater(Set<Publisher> acceptablePublishers) {
-        return ContentEquivalenceUpdater.<Item> builder()
-            .withExcludedUris(excludedUrisFromProperties())
-            .withGenerators(ImmutableSet.of(
-                new ContainerCandidatesItemEquivalenceGenerator(contentResolver, equivSummaryStore),
-                new FilmEquivalenceGenerator(searchResolver, acceptablePublishers, true)
-            ))
-            .withScorers(ImmutableSet.of(
-                new TitleMatchingItemScorer(),
-                new SequenceItemScorer(Score.ONE)
-            ))
-            .withCombiner(new RequiredScoreFilteringCombiner<Item>(
-                new NullScoreAwareAveragingCombiner<Item>(),
-                TitleMatchingItemScorer.NAME
-            ))
-            .withFilter(this.standardFilter())
-            .withExtractor(PercentThresholdEquivalenceExtractor.moreThanPercent(90))
-            .withHandler(new BroadcastingEquivalenceResultHandler<Item>(ImmutableList.of(
-                EpisodeFilteringEquivalenceResultHandler.strict(
-                    new LookupWritingEquivalenceHandler<Item>(lookupWriter, acceptablePublishers),
-                    equivSummaryStore
-                ),
-                new ResultWritingEquivalenceHandler<Item>(equivalenceResultStore()),
-                new EquivalenceSummaryWritingHandler<Item>(equivSummaryStore)
-            )));
-    }
-    
-    // 
-    private ContentEquivalenceUpdater.Builder<Item> btVodItemUpdater(Set<Publisher> acceptablePublishers) {
-        return ContentEquivalenceUpdater.<Item> builder()
-            .withExcludedUris(excludedUrisFromProperties())
-            .withGenerators(ImmutableSet.of(
-                new ContainerCandidatesItemEquivalenceGenerator(contentResolver, equivSummaryStore),
-                new FilmEquivalenceGenerator(searchResolver, acceptablePublishers, true)
-            ))
-            .withScorers(ImmutableSet.of(
-                new TitleMatchingItemScorer(),
-                // Hierarchies are known to be inconsistent between the BT VoD
-                // catalogue and others, so we want to ascribe less weight 
-                // to sequence scoring
-                new SequenceItemScorer(Score.valueOf(0.5))
-            ))
-            .withCombiner(new RequiredScoreFilteringCombiner<Item>(
-                new NullScoreAwareAveragingCombiner<Item>(),
-                ImmutableSet.of(TitleMatchingItemScorer.NAME, SequenceItemScorer.SEQUENCE_SCORER)
-            ))
-            .withFilter(this.standardFilter())
-            .withExtractor(PercentThresholdAboveNextBestMatchEquivalenceExtractor.atLeastNTimesGreater(1.5))
-            .withHandler(new BroadcastingEquivalenceResultHandler<Item>(ImmutableList.of(
-                EpisodeFilteringEquivalenceResultHandler.strict(
-                    new LookupWritingEquivalenceHandler<Item>(lookupWriter, acceptablePublishers),
-                    equivSummaryStore
-                ),
-                new ResultWritingEquivalenceHandler<Item>(equivalenceResultStore()),
-                new EquivalenceSummaryWritingHandler<Item>(equivSummaryStore)
-            )));
-    }
-
-    private EquivalenceUpdater<Container> broadcastItemContainerEquivalenceUpdater(Set<Publisher> sources) {
-        return ContentEquivalenceUpdater.<Container> builder()
-            .withExcludedUris(excludedUrisFromProperties())
-            .withGenerators(ImmutableSet.of(
-                TitleSearchGenerator.create(searchResolver, Container.class, sources, DEFAULT_EXACT_TITLE_MATCH_SCORE),
-                new ContainerChildEquivalenceGenerator(contentResolver, equivSummaryStore)
-            ))
-            .withScorers(ImmutableSet.of(new TitleMatchingContainerScorer(DEFAULT_EXACT_TITLE_MATCH_SCORE)))
-            .withCombiner(new RequiredScoreFilteringCombiner<Container>(
-                new NullScoreAwareAveragingCombiner<Container>(),
-                    TitleMatchingContainerScorer.NAME))
-            .withFilter(this.standardFilter())
-            .withExtractor(PercentThresholdAboveNextBestMatchEquivalenceExtractor.atLeastNTimesGreater(1.5))
-            .withHandler(containerResultHandlers(sources))
-            
-            .build();
-    }
-
-    private EquivalenceUpdater<Item> broadcastItemEquivalenceUpdater(Set<Publisher> sources, Score titleMismatch,
-            Predicate<? super Broadcast> filter) {
-        return standardItemUpdater(sources, ImmutableSet.of(
-                new TitleMatchingItemScorer(),
-                new SequenceItemScorer(Score.ONE),
-                new TitleSubsetBroadcastItemScorer(contentResolver, titleMismatch, 80/*percent*/),
-                new BroadcastAliasScorer(Score.nullScore()),
-                new DescriptionTitleMatchingScorer(),
-                DescriptionMatchingScorer.makeScorer()
-        ), filter).build();
-    }
-
-    private EquivalenceUpdater<Item> aliasIdentifiedBroadcastItemEquivalenceUpdater(
-            Set<Publisher> sources) {
-        return ContentEquivalenceUpdater.<Item>builder()
-                .withExcludedUris(excludedUrisFromProperties())
-                .withGenerator(new BroadcastMatchingItemEquivalenceGenerator(scheduleResolver,
-                        channelResolver,
-                        sources,
-                        Duration.standardMinutes(5),
-                        Predicates.alwaysTrue()))
-                .withScorer(new BroadcastAliasScorer(Score.negativeOne()))
-                .withCombiner(new NullScoreAwareAveragingCombiner<Item>())
-                .withFilter(AlwaysTrueFilter.get())
-                .withExtractor(new PercentThresholdEquivalenceExtractor<Item>(0.95))
-                .withHandler(itemResultHandlers(sources))
-                .build();
-    }
-
-    private EquivalenceUpdater<Item> rtItemEquivalenceUpdater() {
-        return ContentEquivalenceUpdater.<Item> builder()
-            .withExcludedUris(excludedUrisFromProperties())
-            .withGenerators(ImmutableSet.of(
-                new RadioTimesFilmEquivalenceGenerator(contentResolver),
-                new FilmEquivalenceGenerator(searchResolver, ImmutableSet.of(Publisher.PREVIEW_NETWORKS), false)
-            ))
-            .withScorers(ImmutableSet.of())
-            .withCombiner(new NullScoreAwareAveragingCombiner<Item>())
-            .withFilter(this.standardFilter())
-            .withExtractor(PercentThresholdEquivalenceExtractor.moreThanPercent(90))
-            .withHandler(new BroadcastingEquivalenceResultHandler<Item>(ImmutableList.of(
-                EpisodeFilteringEquivalenceResultHandler.relaxed(
-                    new LookupWritingEquivalenceHandler<Item>(lookupWriter, 
-                        ImmutableSet.of(RADIO_TIMES, PA, PREVIEW_NETWORKS)),
-                        equivSummaryStore
-                ),
-                new ResultWritingEquivalenceHandler<Item>(equivalenceResultStore()),
-                new EquivalenceSummaryWritingHandler<Item>(equivSummaryStore)
-            )))
-            .build();
-    }
-
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/configuration/DefaultConfiguration.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/configuration/DefaultConfiguration.java
@@ -1,0 +1,128 @@
+package org.atlasapi.equiv.update.updaters.configuration;
+
+import org.atlasapi.media.entity.Publisher;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+
+import static org.atlasapi.media.entity.Publisher.AMAZON_UK;
+import static org.atlasapi.media.entity.Publisher.AMC_EBS;
+import static org.atlasapi.media.entity.Publisher.BBC_MUSIC;
+import static org.atlasapi.media.entity.Publisher.BBC_REDUX;
+import static org.atlasapi.media.entity.Publisher.BETTY;
+import static org.atlasapi.media.entity.Publisher.BT_SPORT_EBS;
+import static org.atlasapi.media.entity.Publisher.BT_TVE_VOD;
+import static org.atlasapi.media.entity.Publisher.BT_VOD;
+import static org.atlasapi.media.entity.Publisher.C4_PRESS;
+import static org.atlasapi.media.entity.Publisher.FACEBOOK;
+import static org.atlasapi.media.entity.Publisher.ITUNES;
+import static org.atlasapi.media.entity.Publisher.LOVEFILM;
+import static org.atlasapi.media.entity.Publisher.NETFLIX;
+import static org.atlasapi.media.entity.Publisher.PA;
+import static org.atlasapi.media.entity.Publisher.PREVIEW_NETWORKS;
+import static org.atlasapi.media.entity.Publisher.RADIO_TIMES;
+import static org.atlasapi.media.entity.Publisher.RADIO_TIMES_UPCOMING;
+import static org.atlasapi.media.entity.Publisher.RDIO;
+import static org.atlasapi.media.entity.Publisher.RTE;
+import static org.atlasapi.media.entity.Publisher.SOUNDCLOUD;
+import static org.atlasapi.media.entity.Publisher.SPOTIFY;
+import static org.atlasapi.media.entity.Publisher.TALK_TALK;
+import static org.atlasapi.media.entity.Publisher.VF_AE;
+import static org.atlasapi.media.entity.Publisher.VF_BBC;
+import static org.atlasapi.media.entity.Publisher.VF_C5;
+import static org.atlasapi.media.entity.Publisher.VF_ITV;
+import static org.atlasapi.media.entity.Publisher.VF_VIACOM;
+import static org.atlasapi.media.entity.Publisher.VF_VUBIQUITY;
+import static org.atlasapi.media.entity.Publisher.YOUTUBE;
+import static org.atlasapi.media.entity.Publisher.YOUVIEW;
+import static org.atlasapi.media.entity.Publisher.YOUVIEW_BT;
+import static org.atlasapi.media.entity.Publisher.YOUVIEW_BT_STAGE;
+import static org.atlasapi.media.entity.Publisher.YOUVIEW_STAGE;
+
+public class DefaultConfiguration {
+
+    public static final ImmutableSet<Publisher> MUSIC_SOURCES = ImmutableSet.of(
+            BBC_MUSIC,
+            YOUTUBE,
+            SPOTIFY,
+            SOUNDCLOUD,
+            RDIO,
+            AMAZON_UK
+    );
+
+    @SuppressWarnings("WeakerAccess")
+    public static final ImmutableSet<Publisher> ROVI_SOURCES = ImmutableSet.copyOf(
+            Sets.filter(
+                    Publisher.all(),
+                    input -> input.key().endsWith("rovicorp.com")
+            )
+    );
+
+    public static final ImmutableSet<Publisher> VF_SOURCES = ImmutableSet.of(
+            VF_AE,
+            VF_BBC,
+            VF_C5,
+            VF_ITV,
+            VF_VIACOM,
+            VF_VUBIQUITY
+    );
+
+    public static final ImmutableSet<Publisher> NON_STANDARD_SOURCES = ImmutableSet.copyOf(
+            Sets.union(
+                    ImmutableSet.of(
+                            ITUNES,
+                            BBC_REDUX,
+                            RADIO_TIMES,
+                            FACEBOOK,
+                            LOVEFILM,
+                            NETFLIX,
+                            RTE,
+                            YOUVIEW,
+                            YOUVIEW_STAGE,
+                            YOUVIEW_BT,
+                            YOUVIEW_BT_STAGE,
+                            TALK_TALK,
+                            PA,
+                            BT_VOD,
+                            BT_TVE_VOD,
+                            BETTY,
+                            AMC_EBS,
+                            BT_SPORT_EBS,
+                            C4_PRESS,
+                            RADIO_TIMES_UPCOMING
+                    ),
+                    Sets.union(
+                            MUSIC_SOURCES,
+                            ROVI_SOURCES
+                    )
+    ));
+
+    public static final ImmutableSet<Publisher> TARGET_SOURCES = ImmutableSet.copyOf(
+            Sets.difference(
+                    Publisher.all(),
+                    Sets.union(
+                            ImmutableSet.of(
+                                    PREVIEW_NETWORKS,
+                                    BBC_REDUX,
+                                    RADIO_TIMES,
+                                    LOVEFILM,
+                                    NETFLIX,
+                                    YOUVIEW,
+                                    YOUVIEW_STAGE,
+                                    YOUVIEW_BT,
+                                    YOUVIEW_BT_STAGE,
+                                    BT_SPORT_EBS,
+                                    C4_PRESS,
+                                    RADIO_TIMES_UPCOMING
+                            ),
+                            Sets.union(
+                                    MUSIC_SOURCES,
+                                    ROVI_SOURCES
+                    )
+            )
+    ));
+
+    private DefaultConfiguration() {
+        // Private to defeat instantiation
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/configuration/UpdaterConfiguration.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/configuration/UpdaterConfiguration.java
@@ -1,0 +1,183 @@
+package org.atlasapi.equiv.update.updaters.configuration;
+
+import org.atlasapi.equiv.update.updaters.types.ContainerEquivalenceUpdaterType;
+import org.atlasapi.equiv.update.updaters.types.ItemEquivalenceUpdaterType;
+import org.atlasapi.media.entity.Publisher;
+
+import com.google.common.collect.ImmutableSet;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class UpdaterConfiguration {
+
+    private final Publisher source;
+
+    private final ItemEquivalenceUpdaterType itemEquivalenceUpdaterType;
+    private final ImmutableSet<Publisher> itemEquivalenceTargetSources;
+
+    private final ContainerEquivalenceUpdaterType topLevelContainerEquivalenceUpdaterType;
+    private final ImmutableSet<Publisher> topLevelContainerTargetSources;
+
+    private final ContainerEquivalenceUpdaterType nonTopLevelContainerEquivalenceUpdaterType;
+    private final ImmutableSet<Publisher> nonTopLevelContainerTargetSources;
+
+    private UpdaterConfiguration(
+            Publisher source,
+            ItemEquivalenceUpdaterType itemEquivalenceUpdaterType,
+            ImmutableSet<Publisher> itemEquivalenceTargetSources,
+            ContainerEquivalenceUpdaterType topLevelContainerEquivalenceUpdaterType,
+            ImmutableSet<Publisher> topLevelContainerTargetSources,
+            ContainerEquivalenceUpdaterType nonTopLevelContainerEquivalenceUpdaterType,
+            ImmutableSet<Publisher> nonTopLevelContainerTargetSources
+    ) {
+        this.source = checkNotNull(source);
+
+        this.itemEquivalenceUpdaterType = checkNotNull(itemEquivalenceUpdaterType);
+        this.itemEquivalenceTargetSources = ImmutableSet.copyOf(itemEquivalenceTargetSources);
+
+        this.topLevelContainerEquivalenceUpdaterType = checkNotNull(
+                topLevelContainerEquivalenceUpdaterType
+        );
+        this.topLevelContainerTargetSources = ImmutableSet.copyOf(topLevelContainerTargetSources);
+
+        this.nonTopLevelContainerEquivalenceUpdaterType = checkNotNull(
+                nonTopLevelContainerEquivalenceUpdaterType
+        );
+        this.nonTopLevelContainerTargetSources = ImmutableSet.copyOf(
+                nonTopLevelContainerTargetSources
+        );
+    }
+
+    public static SourceStep builder() {
+        return new Builder();
+    }
+
+    public Publisher getSource() {
+        return source;
+    }
+
+    public ItemEquivalenceUpdaterType getItemEquivalenceUpdaterType() {
+        return itemEquivalenceUpdaterType;
+    }
+
+    public ImmutableSet<Publisher> getItemEquivalenceTargetSources() {
+        return itemEquivalenceTargetSources;
+    }
+
+    public ContainerEquivalenceUpdaterType getTopLevelContainerEquivalenceUpdaterType() {
+        return topLevelContainerEquivalenceUpdaterType;
+    }
+
+    public ImmutableSet<Publisher> getTopLevelContainerTargetSources() {
+        return topLevelContainerTargetSources;
+    }
+
+    public ContainerEquivalenceUpdaterType getNonTopLevelContainerEquivalenceUpdaterType() {
+        return nonTopLevelContainerEquivalenceUpdaterType;
+    }
+
+    public ImmutableSet<Publisher> getNonTopLevelContainerTargetSources() {
+        return nonTopLevelContainerTargetSources;
+    }
+
+    public interface SourceStep {
+
+        ItemEquivalenceUpdaterStep withSource(Publisher source);
+    }
+
+    public interface ItemEquivalenceUpdaterStep {
+
+        TopLevelContainerEquivalenceUpdaterStep withItemEquivalenceUpdater(
+                ItemEquivalenceUpdaterType itemEquivalenceUpdaterType,
+                ImmutableSet<Publisher> itemEquivalenceTargetSources
+        );
+    }
+
+    public interface TopLevelContainerEquivalenceUpdaterStep {
+
+        NonTopLevelContainerEquivalenceUpdaterStep withTopLevelContainerEquivalenceUpdater(
+                ContainerEquivalenceUpdaterType topLevelContainerEquivalenceUpdaterType,
+                ImmutableSet<Publisher> topLevelContainerTargetSources
+        );
+    }
+
+    public interface NonTopLevelContainerEquivalenceUpdaterStep {
+
+        BuildStep withNonTopLevelContainerEquivalenceUpdater(
+                ContainerEquivalenceUpdaterType nonTopLevelContainerEquivalenceUpdaterType,
+                ImmutableSet<Publisher> nonTopLevelContainerTargetSources
+        );
+    }
+
+    public interface BuildStep {
+
+        UpdaterConfiguration build();
+    }
+
+    public static class Builder
+            implements SourceStep, ItemEquivalenceUpdaterStep,
+            TopLevelContainerEquivalenceUpdaterStep, NonTopLevelContainerEquivalenceUpdaterStep,
+            BuildStep {
+
+        private Publisher source;
+        private ItemEquivalenceUpdaterType itemEquivalenceUpdaterType;
+        private ImmutableSet<Publisher> itemEquivalenceTargetSources;
+        private ContainerEquivalenceUpdaterType topLevelContainerEquivalenceUpdaterType;
+        private ImmutableSet<Publisher> topLevelContainerTargetSources;
+        private ContainerEquivalenceUpdaterType nonTopLevelContainerEquivalenceUpdaterType;
+        private ImmutableSet<Publisher> nonTopLevelContainerTargetSources;
+
+        private Builder() {
+        }
+
+        @Override
+        public ItemEquivalenceUpdaterStep withSource(Publisher source) {
+            this.source = source;
+            return this;
+        }
+
+        @Override
+        public TopLevelContainerEquivalenceUpdaterStep withItemEquivalenceUpdater(
+                ItemEquivalenceUpdaterType itemEquivalenceUpdaterType,
+                ImmutableSet<Publisher> itemEquivalenceTargetSources
+        ) {
+            this.itemEquivalenceUpdaterType = itemEquivalenceUpdaterType;
+            this.itemEquivalenceTargetSources = itemEquivalenceTargetSources;
+            return this;
+        }
+
+        @Override
+        public NonTopLevelContainerEquivalenceUpdaterStep withTopLevelContainerEquivalenceUpdater(
+                ContainerEquivalenceUpdaterType topLevelContainerEquivalenceUpdaterType,
+                ImmutableSet<Publisher> topLevelContainerTargetSources
+        ) {
+            this.topLevelContainerEquivalenceUpdaterType = topLevelContainerEquivalenceUpdaterType;
+            this.topLevelContainerTargetSources = topLevelContainerTargetSources;
+            return this;
+        }
+
+        @Override
+        public BuildStep withNonTopLevelContainerEquivalenceUpdater(
+                ContainerEquivalenceUpdaterType nonTopLevelContainerEquivalenceUpdaterType,
+                ImmutableSet<Publisher> nonTopLevelContainerTargetSources
+        ) {
+            this.nonTopLevelContainerEquivalenceUpdaterType =
+                    nonTopLevelContainerEquivalenceUpdaterType;
+            this.nonTopLevelContainerTargetSources = topLevelContainerTargetSources;
+            return this;
+        }
+
+        @Override
+        public UpdaterConfiguration build() {
+            return new UpdaterConfiguration(
+                    this.source,
+                    this.itemEquivalenceUpdaterType,
+                    this.itemEquivalenceTargetSources,
+                    this.topLevelContainerEquivalenceUpdaterType,
+                    this.topLevelContainerTargetSources,
+                    this.nonTopLevelContainerEquivalenceUpdaterType,
+                    this.nonTopLevelContainerTargetSources
+            );
+        }
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/configuration/UpdaterConfigurationRegistry.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/configuration/UpdaterConfigurationRegistry.java
@@ -1,0 +1,720 @@
+package org.atlasapi.equiv.update.updaters.configuration;
+
+import org.atlasapi.media.entity.Publisher;
+
+import com.metabroadcast.common.collect.MoreSets;
+import com.metabroadcast.common.stream.MoreCollectors;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+
+import static org.atlasapi.equiv.update.updaters.configuration.DefaultConfiguration.MUSIC_SOURCES;
+import static org.atlasapi.equiv.update.updaters.configuration.DefaultConfiguration
+        .NON_STANDARD_SOURCES;
+import static org.atlasapi.equiv.update.updaters.configuration.DefaultConfiguration.TARGET_SOURCES;
+import static org.atlasapi.equiv.update.updaters.configuration.DefaultConfiguration.VF_SOURCES;
+import static org.atlasapi.equiv.update.updaters.types.ContainerEquivalenceUpdaterType
+        .BROADCAST_ITEM_CONTAINER;
+import static org.atlasapi.equiv.update.updaters.types.ContainerEquivalenceUpdaterType
+        .BT_VOD_CONTAINER;
+import static org.atlasapi.equiv.update.updaters.types.ContainerEquivalenceUpdaterType
+        .FACEBOOK_CONTAINER;
+import static org.atlasapi.equiv.update.updaters.types.ContainerEquivalenceUpdaterType
+        .NOP_CONTAINER;
+import static org.atlasapi.equiv.update.updaters.types.ContainerEquivalenceUpdaterType
+        .RTE_VOD_CONTAINER;
+import static org.atlasapi.equiv.update.updaters.types.ContainerEquivalenceUpdaterType
+        .RT_UPCOMING_TOP_LEVEL_CONTAINER;
+import static org.atlasapi.equiv.update.updaters.types.ContainerEquivalenceUpdaterType
+        .STANDARD_SERIES;
+import static org.atlasapi.equiv.update.updaters.types.ContainerEquivalenceUpdaterType
+        .STANDARD_TOP_LEVEL_CONTAINER;
+import static org.atlasapi.equiv.update.updaters.types.ContainerEquivalenceUpdaterType
+        .VOD_CONTAINER;
+import static org.atlasapi.equiv.update.updaters.types.ItemEquivalenceUpdaterType.BETTY_ITEM;
+import static org.atlasapi.equiv.update.updaters.types.ItemEquivalenceUpdaterType.BROADCAST_ITEM;
+import static org.atlasapi.equiv.update.updaters.types.ItemEquivalenceUpdaterType.BT_VOD_ITEM;
+import static org.atlasapi.equiv.update.updaters.types.ItemEquivalenceUpdaterType.EBS_ITEM;
+import static org.atlasapi.equiv.update.updaters.types.ItemEquivalenceUpdaterType.MUSIC_ITEM;
+import static org.atlasapi.equiv.update.updaters.types.ItemEquivalenceUpdaterType.NOP_ITEM;
+import static org.atlasapi.equiv.update.updaters.types.ItemEquivalenceUpdaterType.ROVI_ITEM;
+import static org.atlasapi.equiv.update.updaters.types.ItemEquivalenceUpdaterType.RT_ITEM;
+import static org.atlasapi.equiv.update.updaters.types.ItemEquivalenceUpdaterType.RT_UPCOMING_ITEM;
+import static org.atlasapi.equiv.update.updaters.types.ItemEquivalenceUpdaterType.STANDARD_ITEM;
+import static org.atlasapi.equiv.update.updaters.types.ItemEquivalenceUpdaterType.VOD_ITEM;
+import static org.atlasapi.equiv.update.updaters.types.ItemEquivalenceUpdaterType
+        .VOD_WITH_SERIES_SEQUENCE_ITEM;
+import static org.atlasapi.equiv.update.updaters.types.ItemEquivalenceUpdaterType.YOUVIEW_ITEM;
+import static org.atlasapi.media.entity.Publisher.AMAZON_UNBOX;
+import static org.atlasapi.media.entity.Publisher.AMC_EBS;
+import static org.atlasapi.media.entity.Publisher.BBC;
+import static org.atlasapi.media.entity.Publisher.BBC_REDUX;
+import static org.atlasapi.media.entity.Publisher.BETTY;
+import static org.atlasapi.media.entity.Publisher.BT_SPORT_EBS;
+import static org.atlasapi.media.entity.Publisher.BT_TVE_VOD;
+import static org.atlasapi.media.entity.Publisher.BT_VOD;
+import static org.atlasapi.media.entity.Publisher.C4_PRESS;
+import static org.atlasapi.media.entity.Publisher.FACEBOOK;
+import static org.atlasapi.media.entity.Publisher.ITUNES;
+import static org.atlasapi.media.entity.Publisher.LOVEFILM;
+import static org.atlasapi.media.entity.Publisher.NETFLIX;
+import static org.atlasapi.media.entity.Publisher.PA;
+import static org.atlasapi.media.entity.Publisher.PREVIEW_NETWORKS;
+import static org.atlasapi.media.entity.Publisher.RADIO_TIMES;
+import static org.atlasapi.media.entity.Publisher.RADIO_TIMES_UPCOMING;
+import static org.atlasapi.media.entity.Publisher.ROVI_EN_GB;
+import static org.atlasapi.media.entity.Publisher.ROVI_EN_US;
+import static org.atlasapi.media.entity.Publisher.RTE;
+import static org.atlasapi.media.entity.Publisher.TALK_TALK;
+import static org.atlasapi.media.entity.Publisher.YOUVIEW;
+import static org.atlasapi.media.entity.Publisher.YOUVIEW_BT;
+import static org.atlasapi.media.entity.Publisher.YOUVIEW_BT_STAGE;
+import static org.atlasapi.media.entity.Publisher.YOUVIEW_SCOTLAND_RADIO;
+import static org.atlasapi.media.entity.Publisher.YOUVIEW_SCOTLAND_RADIO_STAGE;
+import static org.atlasapi.media.entity.Publisher.YOUVIEW_STAGE;
+
+public class UpdaterConfigurationRegistry {
+
+    private final ImmutableList<UpdaterConfiguration> updaterConfigurations;
+
+    private UpdaterConfigurationRegistry() {
+        this.updaterConfigurations = makeConfigurations();
+    }
+
+    public static UpdaterConfigurationRegistry create() {
+        return new UpdaterConfigurationRegistry();
+    }
+
+    public ImmutableList<UpdaterConfiguration> getUpdaterConfigurations() {
+        return updaterConfigurations;
+    }
+
+    private ImmutableList<UpdaterConfiguration> makeConfigurations() {
+        ImmutableList.Builder<UpdaterConfiguration> configurations = ImmutableList.builder();
+
+        configurations.addAll(makeDefaultConfigurations());
+
+        configurations.add(
+                makeRadioTimesUpcomingConfiguration(),
+                makeEbsConfiguration(),
+                makeAmcEbsConfiguration(),
+                makeRadioTimesConfiguration(),
+                makeBbcReduxConfiguration(),
+                makeC4PressConfiguration(),
+                makeBettyConfiguration(),
+                makeFacebookConfiguration(),
+                makeITunesConfiguration(),
+                makeLovefilmConfiguration(),
+                makeNetflixConfiguration(),
+                makeAmazonUnboxConfiguration(),
+                makeTalkTalkConfiguration(),
+                makeRteConfiguration()
+        );
+
+        configurations.add(
+                makeBtVodConfiguration(),
+                makeBtTveVodConfiguration()
+        );
+
+        configurations.add(
+                makeYouviewConfiguration(),
+                makeYouviewStageConfiguration(),
+                makeYouviewBtConfiguration(),
+                makeYouviewBtStageConfiguration(),
+                makeYouviewScotlandRadioConfiguration(),
+                makeYouviewScotlandRadioStageConfiguration()
+        );
+
+        configurations.addAll(
+                makeVfConfigurations()
+        );
+
+        configurations.addAll(
+                makeRoviConfigurations()
+        );
+
+        configurations.addAll(
+                makeMusicConfigurations()
+        );
+
+        return configurations.build();
+    }
+
+    private ImmutableList<UpdaterConfiguration> makeDefaultConfigurations() {
+        return Publisher.all()
+                .stream()
+                .filter(source -> !NON_STANDARD_SOURCES.contains(source))
+                .map(this::makeDefaultConfiguration)
+                .collect(MoreCollectors.toImmutableList());
+    }
+
+    private UpdaterConfiguration makeDefaultConfiguration(Publisher publisher) {
+        return UpdaterConfiguration.builder()
+                .withSource(publisher)
+                .withItemEquivalenceUpdater(
+                        STANDARD_ITEM,
+                        MoreSets.add(TARGET_SOURCES, LOVEFILM)
+                )
+                .withTopLevelContainerEquivalenceUpdater(
+                        STANDARD_TOP_LEVEL_CONTAINER,
+                        MoreSets.add(TARGET_SOURCES, LOVEFILM)
+                )
+                .withNonTopLevelContainerEquivalenceUpdater(
+                        STANDARD_SERIES,
+                        TARGET_SOURCES
+                )
+                .build();
+    }
+
+    private UpdaterConfiguration makeRadioTimesUpcomingConfiguration() {
+        return UpdaterConfiguration.builder()
+                .withSource(RADIO_TIMES_UPCOMING)
+                .withItemEquivalenceUpdater(
+                        RT_UPCOMING_ITEM,
+                        ImmutableSet.of(AMAZON_UNBOX)
+                )
+                .withTopLevelContainerEquivalenceUpdater(
+                        RT_UPCOMING_TOP_LEVEL_CONTAINER,
+                        ImmutableSet.of(AMAZON_UNBOX)
+                )
+                .withNonTopLevelContainerEquivalenceUpdater(
+                        STANDARD_SERIES,
+                        ImmutableSet.of(AMAZON_UNBOX)
+                )
+                .build();
+    }
+
+    private UpdaterConfiguration makeEbsConfiguration() {
+        return UpdaterConfiguration.builder()
+                .withSource(BT_SPORT_EBS)
+                .withItemEquivalenceUpdater(
+                        EBS_ITEM,
+                        MoreSets.add(TARGET_SOURCES, LOVEFILM)
+                )
+                .withTopLevelContainerEquivalenceUpdater(
+                        STANDARD_TOP_LEVEL_CONTAINER,
+                        MoreSets.add(TARGET_SOURCES, LOVEFILM)
+                )
+                .withNonTopLevelContainerEquivalenceUpdater(
+                        STANDARD_SERIES,
+                        TARGET_SOURCES
+                )
+                .build();
+    }
+
+    private UpdaterConfiguration makeAmcEbsConfiguration() {
+        return UpdaterConfiguration.builder()
+                .withSource(AMC_EBS)
+                .withItemEquivalenceUpdater(
+                        STANDARD_ITEM,
+                        MoreSets.add(TARGET_SOURCES, LOVEFILM)
+                )
+                .withTopLevelContainerEquivalenceUpdater(
+                        STANDARD_TOP_LEVEL_CONTAINER,
+                        MoreSets.add(TARGET_SOURCES, LOVEFILM)
+                )
+                .withNonTopLevelContainerEquivalenceUpdater(
+                        STANDARD_SERIES,
+                        ImmutableSet.of(AMC_EBS, PA)
+                )
+                .build();
+    }
+
+    private UpdaterConfiguration makeRadioTimesConfiguration() {
+        return UpdaterConfiguration.builder()
+                .withSource(RADIO_TIMES)
+                .withItemEquivalenceUpdater(
+                        RT_ITEM,
+                        ImmutableSet.of(PREVIEW_NETWORKS)
+                )
+                .withTopLevelContainerEquivalenceUpdater(
+                        NOP_CONTAINER,
+                        ImmutableSet.of()
+                )
+                .withNonTopLevelContainerEquivalenceUpdater(
+                        NOP_CONTAINER,
+                        ImmutableSet.of()
+                )
+                .build();
+    }
+
+    private UpdaterConfiguration makeYouviewConfiguration() {
+        ImmutableSet<Publisher> targetSources = Sets.union(
+                Sets.difference(
+                        TARGET_SOURCES,
+                        ImmutableSet.of(YOUVIEW_STAGE)
+                ),
+                ImmutableSet.of(YOUVIEW)
+        )
+                .immutableCopy();
+
+        return UpdaterConfiguration.builder()
+                .withSource(YOUVIEW)
+                .withItemEquivalenceUpdater(
+                        YOUVIEW_ITEM,
+                        targetSources
+                )
+                .withTopLevelContainerEquivalenceUpdater(
+                        BROADCAST_ITEM_CONTAINER,
+                        targetSources
+                )
+                .withNonTopLevelContainerEquivalenceUpdater(
+                        NOP_CONTAINER,
+                        ImmutableSet.of()
+                )
+                .build();
+    }
+
+    private UpdaterConfiguration makeYouviewStageConfiguration() {
+        ImmutableSet<Publisher> targetSources = Sets.union(
+                Sets.difference(
+                        TARGET_SOURCES,
+                        ImmutableSet.of(YOUVIEW)
+                ),
+                ImmutableSet.of(YOUVIEW_STAGE)
+        )
+                .immutableCopy();
+
+        return UpdaterConfiguration.builder()
+                .withSource(YOUVIEW_STAGE)
+                .withItemEquivalenceUpdater(
+                        YOUVIEW_ITEM,
+                        targetSources
+                )
+                .withTopLevelContainerEquivalenceUpdater(
+                        BROADCAST_ITEM_CONTAINER,
+                        targetSources
+                )
+                .withNonTopLevelContainerEquivalenceUpdater(
+                        NOP_CONTAINER,
+                        ImmutableSet.of()
+                )
+                .build();
+    }
+
+    private UpdaterConfiguration makeYouviewBtConfiguration() {
+        ImmutableSet<Publisher> targetSources = Sets.union(
+                Sets.difference(
+                        TARGET_SOURCES,
+                        ImmutableSet.of(YOUVIEW_BT_STAGE)
+                ),
+                ImmutableSet.of(YOUVIEW_BT)
+        )
+                .immutableCopy();
+
+        return UpdaterConfiguration.builder()
+                .withSource(YOUVIEW_BT)
+                .withItemEquivalenceUpdater(
+                        YOUVIEW_ITEM,
+                        targetSources
+                )
+                .withTopLevelContainerEquivalenceUpdater(
+                        BROADCAST_ITEM_CONTAINER,
+                        targetSources
+                )
+                .withNonTopLevelContainerEquivalenceUpdater(
+                        NOP_CONTAINER,
+                        ImmutableSet.of()
+                )
+                .build();
+    }
+
+    private UpdaterConfiguration makeYouviewBtStageConfiguration() {
+        ImmutableSet<Publisher> targetSources = Sets.union(
+                Sets.difference(
+                        TARGET_SOURCES,
+                        ImmutableSet.of(YOUVIEW_BT)
+                ),
+                ImmutableSet.of(YOUVIEW_BT_STAGE)
+        )
+                .immutableCopy();
+
+        return UpdaterConfiguration.builder()
+                .withSource(YOUVIEW_BT_STAGE)
+                .withItemEquivalenceUpdater(
+                        YOUVIEW_ITEM,
+                        targetSources
+                )
+                .withTopLevelContainerEquivalenceUpdater(
+                        BROADCAST_ITEM_CONTAINER,
+                        targetSources
+                )
+                .withNonTopLevelContainerEquivalenceUpdater(
+                        NOP_CONTAINER,
+                        ImmutableSet.of()
+                )
+                .build();
+    }
+
+    private UpdaterConfiguration makeYouviewScotlandRadioConfiguration() {
+        ImmutableSet<Publisher> targetSources = Sets.union(
+                Sets.difference(
+                        TARGET_SOURCES,
+                        ImmutableSet.of(YOUVIEW_SCOTLAND_RADIO_STAGE)
+                ),
+                ImmutableSet.of(YOUVIEW_SCOTLAND_RADIO)
+        )
+                .immutableCopy();
+
+        return UpdaterConfiguration.builder()
+                .withSource(YOUVIEW_SCOTLAND_RADIO)
+                .withItemEquivalenceUpdater(
+                        YOUVIEW_ITEM,
+                        targetSources
+                )
+                .withTopLevelContainerEquivalenceUpdater(
+                        BROADCAST_ITEM_CONTAINER,
+                        targetSources
+                )
+                .withNonTopLevelContainerEquivalenceUpdater(
+                        NOP_CONTAINER,
+                        ImmutableSet.of()
+                )
+                .build();
+    }
+
+    private UpdaterConfiguration makeYouviewScotlandRadioStageConfiguration() {
+        ImmutableSet<Publisher> targetSources = Sets.union(
+                Sets.difference(
+                        TARGET_SOURCES,
+                        ImmutableSet.of(YOUVIEW_SCOTLAND_RADIO)
+                ),
+                ImmutableSet.of(YOUVIEW_SCOTLAND_RADIO_STAGE)
+        )
+                .immutableCopy();
+
+        return UpdaterConfiguration.builder()
+                .withSource(YOUVIEW_SCOTLAND_RADIO_STAGE)
+                .withItemEquivalenceUpdater(
+                        YOUVIEW_ITEM,
+                        targetSources
+                )
+                .withTopLevelContainerEquivalenceUpdater(
+                        BROADCAST_ITEM_CONTAINER,
+                        targetSources
+                )
+                .withNonTopLevelContainerEquivalenceUpdater(
+                        NOP_CONTAINER,
+                        ImmutableSet.of()
+                )
+                .build();
+    }
+
+    private UpdaterConfiguration makeBbcReduxConfiguration() {
+        ImmutableSet<Publisher> targetSources = MoreSets.add(
+                TARGET_SOURCES,
+                BBC_REDUX
+        );
+
+        return UpdaterConfiguration.builder()
+                .withSource(BBC_REDUX)
+                .withItemEquivalenceUpdater(
+                        BROADCAST_ITEM,
+                        targetSources
+                )
+                .withTopLevelContainerEquivalenceUpdater(
+                        BROADCAST_ITEM_CONTAINER,
+                        targetSources
+
+                )
+                .withNonTopLevelContainerEquivalenceUpdater(
+                        NOP_CONTAINER,
+                        ImmutableSet.of()
+                )
+                .build();
+    }
+
+    private UpdaterConfiguration makeC4PressConfiguration() {
+        return UpdaterConfiguration.builder()
+                .withSource(C4_PRESS)
+                .withItemEquivalenceUpdater(
+                        BROADCAST_ITEM,
+                        ImmutableSet.of(PA)
+                )
+                .withTopLevelContainerEquivalenceUpdater(
+                        NOP_CONTAINER,
+                        ImmutableSet.of()
+                )
+                .withNonTopLevelContainerEquivalenceUpdater(
+                        NOP_CONTAINER,
+                        ImmutableSet.of()
+                )
+                .build();
+    }
+
+    private UpdaterConfiguration makeBettyConfiguration() {
+        return UpdaterConfiguration.builder()
+                .withSource(BETTY)
+                .withItemEquivalenceUpdater(
+                        BETTY_ITEM,
+                        ImmutableSet.of(BETTY, YOUVIEW)
+                )
+                .withTopLevelContainerEquivalenceUpdater(
+                        NOP_CONTAINER,
+                        ImmutableSet.of()
+                )
+                .withNonTopLevelContainerEquivalenceUpdater(
+                        NOP_CONTAINER,
+                        ImmutableSet.of()
+                )
+                .build();
+    }
+
+    private UpdaterConfiguration makeFacebookConfiguration() {
+        return UpdaterConfiguration.builder()
+                .withSource(FACEBOOK)
+                .withItemEquivalenceUpdater(
+                        NOP_ITEM,
+                        ImmutableSet.of()
+                )
+                .withTopLevelContainerEquivalenceUpdater(
+                        FACEBOOK_CONTAINER,
+                        Sets.union(
+                                TARGET_SOURCES,
+                                ImmutableSet.of(FACEBOOK)
+                        )
+                                .immutableCopy()
+                )
+                .withNonTopLevelContainerEquivalenceUpdater(
+                        NOP_CONTAINER,
+                        ImmutableSet.of()
+                )
+                .build();
+    }
+
+    private UpdaterConfiguration makeITunesConfiguration() {
+        return UpdaterConfiguration.builder()
+                .withSource(ITUNES)
+                .withItemEquivalenceUpdater(
+                        VOD_ITEM,
+                        TARGET_SOURCES
+                )
+                .withTopLevelContainerEquivalenceUpdater(
+                        VOD_CONTAINER,
+                        TARGET_SOURCES
+                )
+                .withNonTopLevelContainerEquivalenceUpdater(
+                        NOP_CONTAINER,
+                        ImmutableSet.of()
+                )
+                .build();
+    }
+
+    private UpdaterConfiguration makeLovefilmConfiguration() {
+        ImmutableSet<Publisher> targetSources = Sets.union(
+                TARGET_SOURCES,
+                ImmutableSet.of(LOVEFILM)
+        )
+                .immutableCopy();
+
+        return UpdaterConfiguration.builder()
+                .withSource(LOVEFILM)
+                .withItemEquivalenceUpdater(
+                        VOD_WITH_SERIES_SEQUENCE_ITEM,
+                        targetSources
+                )
+                .withTopLevelContainerEquivalenceUpdater(
+                        VOD_CONTAINER,
+                        targetSources
+                )
+                .withNonTopLevelContainerEquivalenceUpdater(
+                        NOP_CONTAINER,
+                        ImmutableSet.of()
+                )
+                .build();
+    }
+
+    private UpdaterConfiguration makeNetflixConfiguration() {
+        ImmutableSet<Publisher> targetSources = ImmutableSet.of(BBC, NETFLIX);
+
+        return UpdaterConfiguration.builder()
+                .withSource(NETFLIX)
+                .withItemEquivalenceUpdater(
+                        VOD_ITEM,
+                        targetSources
+                )
+                .withTopLevelContainerEquivalenceUpdater(
+                        VOD_CONTAINER,
+                        targetSources
+                )
+                .withNonTopLevelContainerEquivalenceUpdater(
+                        NOP_CONTAINER,
+                        ImmutableSet.of()
+                )
+                .build();
+    }
+
+    private UpdaterConfiguration makeAmazonUnboxConfiguration() {
+        ImmutableSet<Publisher> targetSources = ImmutableSet.of(AMAZON_UNBOX, PA);
+
+        return UpdaterConfiguration.builder()
+                .withSource(AMAZON_UNBOX)
+                .withItemEquivalenceUpdater(
+                        VOD_ITEM,
+                        targetSources
+                )
+                .withTopLevelContainerEquivalenceUpdater(
+                        VOD_CONTAINER,
+                        targetSources
+                )
+                .withNonTopLevelContainerEquivalenceUpdater(
+                        NOP_CONTAINER,
+                        ImmutableSet.of()
+                )
+                .build();
+    }
+
+    private UpdaterConfiguration makeTalkTalkConfiguration() {
+        return UpdaterConfiguration.builder()
+                .withSource(TALK_TALK)
+                .withItemEquivalenceUpdater(
+                        VOD_ITEM,
+                        TARGET_SOURCES
+                )
+                .withTopLevelContainerEquivalenceUpdater(
+                        VOD_CONTAINER,
+                        TARGET_SOURCES
+                )
+                .withNonTopLevelContainerEquivalenceUpdater(
+                        STANDARD_SERIES,
+                        TARGET_SOURCES
+                )
+                .build();
+    }
+
+    private UpdaterConfiguration makeBtVodConfiguration() {
+        return UpdaterConfiguration.builder()
+                .withSource(BT_VOD)
+                .withItemEquivalenceUpdater(
+                        VOD_WITH_SERIES_SEQUENCE_ITEM,
+                        ImmutableSet.of(PA)
+                )
+                .withTopLevelContainerEquivalenceUpdater(
+                        VOD_CONTAINER,
+                        ImmutableSet.of(PA)
+                )
+                .withNonTopLevelContainerEquivalenceUpdater(
+                        STANDARD_SERIES,
+                        ImmutableSet.of(PA)
+                )
+                .build();
+    }
+
+    private UpdaterConfiguration makeBtTveVodConfiguration() {
+        ImmutableSet<Publisher> targetSources = ImmutableSet.of(PA);
+
+        return UpdaterConfiguration.builder()
+                .withSource(BT_TVE_VOD)
+                .withItemEquivalenceUpdater(
+                        BT_VOD_ITEM,
+                        targetSources
+                )
+                .withTopLevelContainerEquivalenceUpdater(
+                        BT_VOD_CONTAINER,
+                        targetSources
+                )
+                .withNonTopLevelContainerEquivalenceUpdater(
+                        STANDARD_SERIES,
+                        targetSources
+                )
+                .build();
+    }
+
+    private ImmutableList<UpdaterConfiguration> makeVfConfigurations() {
+        ImmutableSet<Publisher> targetSources = ImmutableSet.of(PA);
+
+        return VF_SOURCES.stream()
+                .map(source -> UpdaterConfiguration.builder()
+                        .withSource(source)
+                        .withItemEquivalenceUpdater(
+                                BT_VOD_ITEM,
+                                targetSources
+                        )
+                        .withTopLevelContainerEquivalenceUpdater(
+                                BT_VOD_CONTAINER,
+                                targetSources
+                        )
+                        .withNonTopLevelContainerEquivalenceUpdater(
+                                STANDARD_SERIES,
+                                targetSources
+                        )
+                        .build())
+                .collect(MoreCollectors.toImmutableList());
+    }
+
+    private UpdaterConfiguration makeRteConfiguration() {
+        return UpdaterConfiguration.builder()
+                .withSource(RTE)
+                .withItemEquivalenceUpdater(
+                        NOP_ITEM,
+                        ImmutableSet.of()
+                )
+                .withTopLevelContainerEquivalenceUpdater(
+                        RTE_VOD_CONTAINER,
+                        ImmutableSet.of(PA)
+                )
+                .withNonTopLevelContainerEquivalenceUpdater(
+                        NOP_CONTAINER,
+                        ImmutableSet.of()
+                )
+                .build();
+    }
+
+    private ImmutableList<UpdaterConfiguration> makeRoviConfigurations() {
+        ImmutableSet<Publisher> targetSources = ImmutableSet.of(
+                Publisher.BBC,
+                Publisher.PA,
+                Publisher.YOUVIEW,
+                Publisher.BBC_NITRO,
+                Publisher.BBC_REDUX,
+                Publisher.ITV,
+                Publisher.C4_PMLSD,
+                Publisher.C4_PMLSD_P06,
+                Publisher.FIVE
+        );
+
+        return ImmutableList.of(ROVI_EN_GB, ROVI_EN_US)
+                .stream()
+                .map(source -> UpdaterConfiguration.builder()
+                        .withSource(source)
+                        .withItemEquivalenceUpdater(
+                                ROVI_ITEM,
+                                targetSources
+                        )
+                        .withTopLevelContainerEquivalenceUpdater(
+                                STANDARD_TOP_LEVEL_CONTAINER,
+                                targetSources
+                        )
+                        .withNonTopLevelContainerEquivalenceUpdater(
+                                NOP_CONTAINER,
+                                ImmutableSet.of()
+                        )
+                        .build())
+                .collect(MoreCollectors.toImmutableList());
+    }
+
+    private ImmutableList<UpdaterConfiguration> makeMusicConfigurations() {
+        return MUSIC_SOURCES.stream()
+                .map(source -> UpdaterConfiguration.builder()
+                        .withSource(source)
+                        .withItemEquivalenceUpdater(
+                                MUSIC_ITEM,
+                                Sets.union(
+                                        MUSIC_SOURCES,
+                                        ImmutableSet.of(ITUNES)
+                                )
+                                        .immutableCopy()
+                        )
+                        .withTopLevelContainerEquivalenceUpdater(
+                                NOP_CONTAINER,
+                                ImmutableSet.of()
+                        )
+                        .withNonTopLevelContainerEquivalenceUpdater(
+                                NOP_CONTAINER,
+                                ImmutableSet.of()
+                        )
+                        .build())
+                .collect(MoreCollectors.toImmutableList());
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/package-info.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/package-info.java
@@ -1,0 +1,4 @@
+@NonNullByDefault
+package org.atlasapi.equiv.update.updaters;
+
+import com.metabroadcast.common.annotation.NonNullByDefault;

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/EquivalenceUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/EquivalenceUpdaterProvider.java
@@ -1,0 +1,15 @@
+package org.atlasapi.equiv.update.updaters.providers;
+
+import java.util.Set;
+
+import org.atlasapi.equiv.update.EquivalenceUpdater;
+import org.atlasapi.media.entity.Content;
+import org.atlasapi.media.entity.Publisher;
+
+public interface EquivalenceUpdaterProvider<T extends Content> {
+
+    EquivalenceUpdater<T> getUpdater(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    );
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/EquivalenceUpdaterProviderDependencies.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/EquivalenceUpdaterProviderDependencies.java
@@ -1,0 +1,254 @@
+package org.atlasapi.equiv.update.updaters.providers;
+
+import org.atlasapi.equiv.EquivalenceSummaryStore;
+import org.atlasapi.equiv.results.persistence.RecentEquivalenceResultStore;
+import org.atlasapi.media.channel.ChannelResolver;
+import org.atlasapi.messaging.v3.ContentEquivalenceAssertionMessage;
+import org.atlasapi.persistence.content.ContentResolver;
+import org.atlasapi.persistence.content.ScheduleResolver;
+import org.atlasapi.persistence.content.SearchResolver;
+import org.atlasapi.persistence.lookup.LookupWriter;
+import org.atlasapi.persistence.lookup.entry.LookupEntryStore;
+
+import com.metabroadcast.common.queue.MessageSender;
+
+import com.google.common.collect.ImmutableSet;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class EquivalenceUpdaterProviderDependencies {
+
+    private final ScheduleResolver scheduleResolver;
+    private final SearchResolver searchResolver;
+    private final ContentResolver contentResolver;
+    private final ChannelResolver channelResolver;
+    private final EquivalenceSummaryStore equivSummaryStore;
+    private final LookupWriter lookupWriter;
+    private final LookupEntryStore lookupEntryStore;
+    private final RecentEquivalenceResultStore equivalenceResultStore;
+    private final MessageSender<ContentEquivalenceAssertionMessage> messageSender;
+    private final ImmutableSet<String> excludedUris;
+
+    private EquivalenceUpdaterProviderDependencies(
+            ScheduleResolver scheduleResolver,
+            SearchResolver searchResolver,
+            ContentResolver contentResolver,
+            ChannelResolver channelResolver,
+            EquivalenceSummaryStore equivSummaryStore,
+            LookupWriter lookupWriter,
+            LookupEntryStore lookupEntryStore,
+            RecentEquivalenceResultStore equivalenceResultStore,
+            MessageSender<ContentEquivalenceAssertionMessage> messageSender,
+            ImmutableSet<String> excludedUris
+    ) {
+        this.scheduleResolver = checkNotNull(scheduleResolver);
+        this.searchResolver = checkNotNull(searchResolver);
+        this.contentResolver = checkNotNull(contentResolver);
+        this.channelResolver = checkNotNull(channelResolver);
+        this.equivSummaryStore = checkNotNull(equivSummaryStore);
+        this.lookupWriter = checkNotNull(lookupWriter);
+        this.lookupEntryStore = checkNotNull(lookupEntryStore);
+        this.equivalenceResultStore = checkNotNull(equivalenceResultStore);
+        this.messageSender = checkNotNull(messageSender);
+        this.excludedUris = ImmutableSet.copyOf(excludedUris);
+    }
+
+    public static ScheduleResolverStep builder() {
+        return new Builder();
+    }
+
+    public ScheduleResolver getScheduleResolver() {
+        return scheduleResolver;
+    }
+
+    public SearchResolver getSearchResolver() {
+        return searchResolver;
+    }
+
+    public ContentResolver getContentResolver() {
+        return contentResolver;
+    }
+
+    public ChannelResolver getChannelResolver() {
+        return channelResolver;
+    }
+
+    public EquivalenceSummaryStore getEquivSummaryStore() {
+        return equivSummaryStore;
+    }
+
+    public LookupWriter getLookupWriter() {
+        return lookupWriter;
+    }
+
+    public LookupEntryStore getLookupEntryStore() {
+        return lookupEntryStore;
+    }
+
+    public RecentEquivalenceResultStore getEquivalenceResultStore() {
+        return equivalenceResultStore;
+    }
+
+    public MessageSender<ContentEquivalenceAssertionMessage> getMessageSender() {
+        return messageSender;
+    }
+
+    public ImmutableSet<String> getExcludedUris() {
+        return excludedUris;
+    }
+
+    public interface ScheduleResolverStep {
+
+        SearchResolverStep withScheduleResolver(ScheduleResolver scheduleResolver);
+    }
+
+    public interface SearchResolverStep {
+
+        ContentResolverStep withSearchResolver(SearchResolver searchResolver);
+    }
+
+    public interface ContentResolverStep {
+
+        ChannelResolverStep withContentResolver(ContentResolver contentResolver);
+    }
+
+    public interface ChannelResolverStep {
+
+        EquivSummaryStoreStep withChannelResolver(ChannelResolver channelResolver);
+    }
+
+    public interface EquivSummaryStoreStep {
+
+        LookupWriterStep withEquivSummaryStore(EquivalenceSummaryStore equivSummaryStore);
+    }
+
+    public interface LookupWriterStep {
+
+        LookupEntryStoreStep withLookupWriter(LookupWriter lookupWriter);
+    }
+
+    public interface LookupEntryStoreStep {
+
+        EquivalenceResultStoreStep withLookupEntryStore(LookupEntryStore lookupEntryStore);
+    }
+
+    public interface EquivalenceResultStoreStep {
+
+        MessageSenderStep withEquivalenceResultStore(
+                RecentEquivalenceResultStore equivalenceResultStore);
+    }
+
+    public interface MessageSenderStep {
+
+        ExcludedUrisStep withMessageSender(
+                MessageSender<ContentEquivalenceAssertionMessage> messageSender);
+    }
+
+    public interface ExcludedUrisStep {
+
+        BuildStep withExcludedUris(ImmutableSet<String> excludedUris);
+    }
+
+    public interface BuildStep {
+
+        EquivalenceUpdaterProviderDependencies build();
+    }
+
+    public static class Builder
+            implements ScheduleResolverStep, SearchResolverStep, ContentResolverStep,
+            ChannelResolverStep, EquivSummaryStoreStep, LookupWriterStep, LookupEntryStoreStep,
+            EquivalenceResultStoreStep, MessageSenderStep, ExcludedUrisStep, BuildStep {
+
+        private ScheduleResolver scheduleResolver;
+        private SearchResolver searchResolver;
+        private ContentResolver contentResolver;
+        private ChannelResolver channelResolver;
+        private EquivalenceSummaryStore equivSummaryStore;
+        private LookupWriter lookupWriter;
+        private LookupEntryStore lookupEntryStore;
+        private RecentEquivalenceResultStore equivalenceResultStore;
+        private MessageSender<ContentEquivalenceAssertionMessage> messageSender;
+        private ImmutableSet<String> excludedUris;
+
+        private Builder() {
+        }
+
+        @Override
+        public SearchResolverStep withScheduleResolver(ScheduleResolver scheduleResolver) {
+            this.scheduleResolver = scheduleResolver;
+            return this;
+        }
+
+        @Override
+        public ContentResolverStep withSearchResolver(SearchResolver searchResolver) {
+            this.searchResolver = searchResolver;
+            return this;
+        }
+
+        @Override
+        public ChannelResolverStep withContentResolver(ContentResolver contentResolver) {
+            this.contentResolver = contentResolver;
+            return this;
+        }
+
+        @Override
+        public EquivSummaryStoreStep withChannelResolver(ChannelResolver channelResolver) {
+            this.channelResolver = channelResolver;
+            return this;
+        }
+
+        @Override
+        public LookupWriterStep withEquivSummaryStore(EquivalenceSummaryStore equivSummaryStore) {
+            this.equivSummaryStore = equivSummaryStore;
+            return this;
+        }
+
+        @Override
+        public LookupEntryStoreStep withLookupWriter(LookupWriter lookupWriter) {
+            this.lookupWriter = lookupWriter;
+            return this;
+        }
+
+        @Override
+        public EquivalenceResultStoreStep withLookupEntryStore(LookupEntryStore lookupEntryStore) {
+            this.lookupEntryStore = lookupEntryStore;
+            return this;
+        }
+
+        @Override
+        public MessageSenderStep withEquivalenceResultStore(
+                RecentEquivalenceResultStore equivalenceResultStore) {
+            this.equivalenceResultStore = equivalenceResultStore;
+            return this;
+        }
+
+        @Override
+        public ExcludedUrisStep withMessageSender(
+                MessageSender<ContentEquivalenceAssertionMessage> messageSender) {
+            this.messageSender = messageSender;
+            return this;
+        }
+
+        @Override
+        public BuildStep withExcludedUris(ImmutableSet<String> excludedUris) {
+            this.excludedUris = excludedUris;
+            return this;
+        }
+
+        @Override
+        public EquivalenceUpdaterProviderDependencies build() {
+            return new EquivalenceUpdaterProviderDependencies(
+                    this.scheduleResolver,
+                    this.searchResolver,
+                    this.contentResolver,
+                    this.channelResolver,
+                    this.equivSummaryStore,
+                    this.lookupWriter,
+                    this.lookupEntryStore,
+                    this.equivalenceResultStore,
+                    this.messageSender,
+                    this.excludedUris
+            );
+        }
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/BroadcastItemContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/BroadcastItemContainerUpdaterProvider.java
@@ -1,0 +1,117 @@
+package org.atlasapi.equiv.update.updaters.providers.container;
+
+import java.util.Set;
+
+import org.atlasapi.equiv.generators.ContainerChildEquivalenceGenerator;
+import org.atlasapi.equiv.generators.TitleSearchGenerator;
+import org.atlasapi.equiv.handlers.BroadcastingEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EpisodeMatchingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
+import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.MessageQueueingResultHandler;
+import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
+import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
+import org.atlasapi.equiv.results.combining.RequiredScoreFilteringCombiner;
+import org.atlasapi.equiv.results.extractors.PercentThresholdAboveNextBestMatchEquivalenceExtractor;
+import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
+import org.atlasapi.equiv.results.filters.DummyContainerFilter;
+import org.atlasapi.equiv.results.filters.ExclusionListFilter;
+import org.atlasapi.equiv.results.filters.FilmFilter;
+import org.atlasapi.equiv.results.filters.MediaTypeFilter;
+import org.atlasapi.equiv.results.filters.MinimumScoreFilter;
+import org.atlasapi.equiv.results.filters.PublisherFilter;
+import org.atlasapi.equiv.results.filters.SpecializationFilter;
+import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
+import org.atlasapi.equiv.scorers.TitleMatchingContainerScorer;
+import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
+import org.atlasapi.equiv.update.EquivalenceUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Container;
+import org.atlasapi.media.entity.Publisher;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+public class BroadcastItemContainerUpdaterProvider
+        implements EquivalenceUpdaterProvider<Container> {
+
+    private BroadcastItemContainerUpdaterProvider() {
+    }
+
+    public static BroadcastItemContainerUpdaterProvider create() {
+        return new BroadcastItemContainerUpdaterProvider();
+    }
+
+    @Override
+    public EquivalenceUpdater<Container> getUpdater(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return ContentEquivalenceUpdater.<Container>builder()
+                .withExcludedUris(
+                        dependencies.getExcludedUris()
+                )
+                .withGenerators(
+                        ImmutableSet.of(
+                                TitleSearchGenerator.create(
+                                        dependencies.getSearchResolver(),
+                                        Container.class,
+                                        targetPublishers,
+                                        2
+                                ),
+                                new ContainerChildEquivalenceGenerator(
+                                        dependencies.getContentResolver(),
+                                        dependencies.getEquivSummaryStore()
+                                )
+                        ))
+                .withScorers(
+                        ImmutableSet.of(new TitleMatchingContainerScorer(2)))
+                .withCombiner(
+                        new RequiredScoreFilteringCombiner<>(
+                                new NullScoreAwareAveragingCombiner<>(),
+                                TitleMatchingContainerScorer.NAME
+                        ))
+                .withFilter(
+                        ConjunctiveFilter.valueOf(ImmutableList.of(
+                                new MinimumScoreFilter<>(0.25),
+                                new MediaTypeFilter<>(),
+                                new SpecializationFilter<>(),
+                                new PublisherFilter<>(),
+                                new ExclusionListFilter<>(dependencies.getExcludedUris()),
+                                new FilmFilter<>(),
+                                new DummyContainerFilter<>(),
+                                new UnpublishedContentFilter<>()
+                        )))
+                .withExtractor(
+                        PercentThresholdAboveNextBestMatchEquivalenceExtractor
+                                .atLeastNTimesGreater(1.5)
+                )
+                .withHandler(
+                        new BroadcastingEquivalenceResultHandler<>(ImmutableList.of(
+                                new LookupWritingEquivalenceHandler<>(
+                                        dependencies.getLookupWriter(),
+                                        targetPublishers
+                                ),
+                                new EpisodeMatchingEquivalenceHandler(
+                                        dependencies.getContentResolver(),
+                                        dependencies.getEquivSummaryStore(),
+                                        dependencies.getLookupWriter(),
+                                        targetPublishers
+                                ),
+                                new ResultWritingEquivalenceHandler<>(
+                                        dependencies.getEquivalenceResultStore()
+                                ),
+                                new EquivalenceSummaryWritingHandler<>(
+                                        dependencies.getEquivSummaryStore()
+                                ),
+                                MessageQueueingResultHandler.create(
+                                        dependencies.getMessageSender(),
+                                        targetPublishers,
+                                        dependencies.getLookupEntryStore()
+                                )
+                        )))
+
+                .build();
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/BtVodContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/BtVodContainerUpdaterProvider.java
@@ -1,0 +1,124 @@
+package org.atlasapi.equiv.update.updaters.providers.container;
+
+import java.util.Set;
+
+import org.atlasapi.equiv.generators.TitleSearchGenerator;
+import org.atlasapi.equiv.handlers.BroadcastingEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EpisodeMatchingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
+import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.MessageQueueingResultHandler;
+import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
+import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
+import org.atlasapi.equiv.results.combining.RequiredScoreFilteringCombiner;
+import org.atlasapi.equiv.results.extractors.PercentThresholdAboveNextBestMatchEquivalenceExtractor;
+import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
+import org.atlasapi.equiv.results.filters.DummyContainerFilter;
+import org.atlasapi.equiv.results.filters.ExclusionListFilter;
+import org.atlasapi.equiv.results.filters.FilmFilter;
+import org.atlasapi.equiv.results.filters.MediaTypeFilter;
+import org.atlasapi.equiv.results.filters.MinimumScoreFilter;
+import org.atlasapi.equiv.results.filters.PublisherFilter;
+import org.atlasapi.equiv.results.filters.SpecializationFilter;
+import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
+import org.atlasapi.equiv.results.scores.Score;
+import org.atlasapi.equiv.scorers.ContainerHierarchyMatchingScorer;
+import org.atlasapi.equiv.scorers.SubscriptionCatchupBrandDetector;
+import org.atlasapi.equiv.scorers.TitleMatchingContainerScorer;
+import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
+import org.atlasapi.equiv.update.EquivalenceUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Container;
+import org.atlasapi.media.entity.Publisher;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+public class BtVodContainerUpdaterProvider implements EquivalenceUpdaterProvider<Container> {
+
+    private BtVodContainerUpdaterProvider() {
+    }
+
+    public static BtVodContainerUpdaterProvider create() {
+        return new BtVodContainerUpdaterProvider();
+    }
+
+    @Override
+    public EquivalenceUpdater<Container> getUpdater(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return ContentEquivalenceUpdater.<Container>builder()
+                .withExcludedUris(
+                        dependencies.getExcludedUris()
+                )
+                .withGenerator(
+                        TitleSearchGenerator.create(
+                                dependencies.getSearchResolver(),
+                                Container.class,
+                                targetPublishers,
+                                2
+                        )
+                )
+                .withScorers(
+                        ImmutableSet.of(
+                                new TitleMatchingContainerScorer(2),
+                                new ContainerHierarchyMatchingScorer(
+                                        dependencies.getContentResolver(),
+                                        Score.valueOf(-0.49d),
+                                        new SubscriptionCatchupBrandDetector(
+                                                dependencies.getContentResolver()
+                                        )
+                                )
+                        )
+                )
+                .withCombiner(
+                        new RequiredScoreFilteringCombiner<>(
+                                new NullScoreAwareAveragingCombiner<>(),
+                                TitleMatchingContainerScorer.NAME
+                        )
+                )
+                .withFilter(
+                        ConjunctiveFilter.valueOf(ImmutableList.of(
+                                new MinimumScoreFilter<>(0.25),
+                                new MediaTypeFilter<>(),
+                                new SpecializationFilter<>(),
+                                new PublisherFilter<>(),
+                                new ExclusionListFilter<>(dependencies.getExcludedUris()),
+                                new FilmFilter<>(),
+                                new DummyContainerFilter<>(),
+                                new UnpublishedContentFilter<>()
+                        ))
+                )
+                .withExtractor(
+                        PercentThresholdAboveNextBestMatchEquivalenceExtractor
+                                .atLeastNTimesGreater(1.5)
+                )
+                .withHandler(
+                        new BroadcastingEquivalenceResultHandler<>(ImmutableList.of(
+                                new LookupWritingEquivalenceHandler<>(
+                                        dependencies.getLookupWriter(),
+                                        targetPublishers
+                                ),
+                                new EpisodeMatchingEquivalenceHandler(
+                                        dependencies.getContentResolver(),
+                                        dependencies.getEquivSummaryStore(),
+                                        dependencies.getLookupWriter(),
+                                        targetPublishers
+                                ),
+                                new ResultWritingEquivalenceHandler<>(
+                                        dependencies.getEquivalenceResultStore()
+                                ),
+                                new EquivalenceSummaryWritingHandler<>(
+                                        dependencies.getEquivSummaryStore()
+                                ),
+                                MessageQueueingResultHandler.create(
+                                        dependencies.getMessageSender(),
+                                        targetPublishers,
+                                        dependencies.getLookupEntryStore()
+                                )
+                        )))
+                .build();
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/FacebookContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/FacebookContainerUpdaterProvider.java
@@ -1,0 +1,103 @@
+package org.atlasapi.equiv.update.updaters.providers.container;
+
+import java.util.Set;
+
+import org.atlasapi.equiv.generators.AliasResolvingEquivalenceGenerator;
+import org.atlasapi.equiv.generators.TitleSearchGenerator;
+import org.atlasapi.equiv.handlers.BroadcastingEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EpisodeMatchingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
+import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.MessageQueueingResultHandler;
+import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
+import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
+import org.atlasapi.equiv.results.extractors.PercentThresholdEquivalenceExtractor;
+import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
+import org.atlasapi.equiv.results.filters.MinimumScoreFilter;
+import org.atlasapi.equiv.results.filters.SpecializationFilter;
+import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
+import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
+import org.atlasapi.equiv.update.EquivalenceUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Container;
+import org.atlasapi.media.entity.Publisher;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+public class FacebookContainerUpdaterProvider implements EquivalenceUpdaterProvider<Container> {
+
+    private FacebookContainerUpdaterProvider() {
+    }
+
+    public static FacebookContainerUpdaterProvider create() {
+        return new FacebookContainerUpdaterProvider();
+    }
+
+    @Override
+    public EquivalenceUpdater<Container> getUpdater(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return ContentEquivalenceUpdater.<Container>builder()
+                .withExcludedUris(
+                        dependencies.getExcludedUris()
+                )
+                .withGenerators(
+                        ImmutableSet.of(
+                                TitleSearchGenerator.create(
+                                        dependencies.getSearchResolver(),
+                                        Container.class,
+                                        targetPublishers,
+                                        2
+                                ),
+                                AliasResolvingEquivalenceGenerator.aliasResolvingGenerator(
+                                        dependencies.getContentResolver(),
+                                        Container.class
+                                )
+                ))
+                .withScorers(
+                        ImmutableSet.of()
+                )
+                .withCombiner(
+                        NullScoreAwareAveragingCombiner.get()
+                )
+                .withFilter(
+                        ConjunctiveFilter.valueOf(ImmutableList.of(
+                                new MinimumScoreFilter<>(0.25),
+                                new SpecializationFilter<>(),
+                                new UnpublishedContentFilter<>()
+                        ))
+                )
+                .withExtractor(
+                        PercentThresholdEquivalenceExtractor.moreThanPercent(90)
+                )
+                .withHandler(
+                        new BroadcastingEquivalenceResultHandler<>(ImmutableList.of(
+                                new LookupWritingEquivalenceHandler<>(
+                                        dependencies.getLookupWriter(),
+                                        targetPublishers
+                                ),
+                                new EpisodeMatchingEquivalenceHandler(
+                                        dependencies.getContentResolver(),
+                                        dependencies.getEquivSummaryStore(),
+                                        dependencies.getLookupWriter(),
+                                        targetPublishers
+                                ),
+                                new ResultWritingEquivalenceHandler<>(
+                                        dependencies.getEquivalenceResultStore()
+                                ),
+                                new EquivalenceSummaryWritingHandler<>(
+                                        dependencies.getEquivSummaryStore()
+                                ),
+                                MessageQueueingResultHandler.create(
+                                        dependencies.getMessageSender(),
+                                        targetPublishers,
+                                        dependencies.getLookupEntryStore()
+                                )
+                        ))
+                )
+                .build();
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/NopContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/NopContainerUpdaterProvider.java
@@ -1,0 +1,40 @@
+package org.atlasapi.equiv.update.updaters.providers.container;
+
+import java.util.Set;
+
+import org.atlasapi.equiv.update.EquivalenceUpdater;
+import org.atlasapi.equiv.update.metadata.EquivalenceUpdaterMetadata;
+import org.atlasapi.equiv.update.metadata.NopEquivalenceUpdaterMetadata;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Container;
+import org.atlasapi.media.entity.Publisher;
+
+public class NopContainerUpdaterProvider implements EquivalenceUpdaterProvider<Container> {
+
+    private NopContainerUpdaterProvider() {
+    }
+
+    public static NopContainerUpdaterProvider create() {
+        return new NopContainerUpdaterProvider();
+    }
+
+    @Override
+    public EquivalenceUpdater<Container> getUpdater(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return new EquivalenceUpdater<Container>() {
+
+            @Override
+            public boolean updateEquivalences(Container subject) {
+                return false;
+            }
+
+            @Override
+            public EquivalenceUpdaterMetadata getMetadata(Set<Publisher> sources) {
+                return NopEquivalenceUpdaterMetadata.create();
+            }
+        };
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/RtUpcomingTopLevelContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/RtUpcomingTopLevelContainerUpdaterProvider.java
@@ -1,0 +1,127 @@
+package org.atlasapi.equiv.update.updaters.providers.container;
+
+import java.util.Set;
+
+import org.atlasapi.equiv.generators.ContainerChildEquivalenceGenerator;
+import org.atlasapi.equiv.generators.ScalingEquivalenceGenerator;
+import org.atlasapi.equiv.generators.TitleSearchGenerator;
+import org.atlasapi.equiv.handlers.BroadcastingEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EpisodeMatchingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
+import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.MessageQueueingResultHandler;
+import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
+import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
+import org.atlasapi.equiv.results.combining.RequiredScoreFilteringCombiner;
+import org.atlasapi.equiv.results.extractors.PercentThresholdAboveNextBestMatchEquivalenceExtractor;
+import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
+import org.atlasapi.equiv.results.filters.ExclusionListFilter;
+import org.atlasapi.equiv.results.filters.FilmFilter;
+import org.atlasapi.equiv.results.filters.MediaTypeFilter;
+import org.atlasapi.equiv.results.filters.MinimumScoreFilter;
+import org.atlasapi.equiv.results.filters.PublisherFilter;
+import org.atlasapi.equiv.results.filters.SpecializationFilter;
+import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
+import org.atlasapi.equiv.scorers.EquivalenceScorer;
+import org.atlasapi.equiv.scorers.TitleMatchingContainerScorer;
+import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
+import org.atlasapi.equiv.update.EquivalenceUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Container;
+import org.atlasapi.media.entity.Publisher;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+public class RtUpcomingTopLevelContainerUpdaterProvider
+        implements EquivalenceUpdaterProvider<Container> {
+
+    private RtUpcomingTopLevelContainerUpdaterProvider() {
+    }
+
+    public static RtUpcomingTopLevelContainerUpdaterProvider create() {
+        return new RtUpcomingTopLevelContainerUpdaterProvider();
+    }
+
+    @Override
+    public EquivalenceUpdater<Container> getUpdater(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return ContentEquivalenceUpdater.<Container>builder()
+                .withExcludedUris(
+                        dependencies.getExcludedUris()
+                )
+                .withGenerators(
+                        ImmutableSet.of(
+                                TitleSearchGenerator.create(
+                                        dependencies.getSearchResolver(),
+                                        Container.class,
+                                        targetPublishers,
+                                        2
+                                ),
+                                ScalingEquivalenceGenerator.scale(
+                                        new ContainerChildEquivalenceGenerator(
+                                                dependencies.getContentResolver(),
+                                                dependencies.getEquivSummaryStore()
+                                        ),
+                                        20
+                                )
+                        )
+                )
+                .withScorers(
+                        ImmutableSet.<EquivalenceScorer<Container>>of(
+                                new TitleMatchingContainerScorer(2)
+                        )
+                )
+                .withCombiner(
+                        new RequiredScoreFilteringCombiner<>(
+                                new NullScoreAwareAveragingCombiner<>(),
+                                TitleMatchingContainerScorer.NAME
+                        )
+                )
+                .withFilter(
+                        ConjunctiveFilter.valueOf(ImmutableList.of(
+                                new MinimumScoreFilter<>(0.25),
+                                new MediaTypeFilter<>(),
+                                new SpecializationFilter<>(),
+                                new PublisherFilter<>(),
+                                new ExclusionListFilter<>(dependencies.getExcludedUris()),
+                                new FilmFilter<>(),
+                                new UnpublishedContentFilter<>()
+                        ))
+                )
+                .withExtractor(
+                        PercentThresholdAboveNextBestMatchEquivalenceExtractor
+                                .atLeastNTimesGreater(1.5)
+                )
+                .withHandler(
+                        new BroadcastingEquivalenceResultHandler<>(
+                                ImmutableList.of(
+                                        new LookupWritingEquivalenceHandler<>(
+                                                dependencies.getLookupWriter(),
+                                                targetPublishers
+                                        ),
+                                        new EpisodeMatchingEquivalenceHandler(
+                                                dependencies.getContentResolver(),
+                                                dependencies.getEquivSummaryStore(),
+                                                dependencies.getLookupWriter(),
+                                                targetPublishers
+                                        ),
+                                        new ResultWritingEquivalenceHandler<>(
+                                                dependencies.getEquivalenceResultStore()
+                                        ),
+                                        new EquivalenceSummaryWritingHandler<>(
+                                                dependencies.getEquivSummaryStore()
+                                        ),
+                                        MessageQueueingResultHandler.create(
+                                                dependencies.getMessageSender(),
+                                                targetPublishers,
+                                                dependencies.getLookupEntryStore()
+                                        )
+                                ))
+                )
+                .build();
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/RteContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/RteContainerUpdaterProvider.java
@@ -1,0 +1,125 @@
+package org.atlasapi.equiv.update.updaters.providers.container;
+
+import java.util.Set;
+
+import org.atlasapi.equiv.generators.TitleSearchGenerator;
+import org.atlasapi.equiv.handlers.BroadcastingEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EpisodeMatchingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
+import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.MessageQueueingResultHandler;
+import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
+import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
+import org.atlasapi.equiv.results.combining.RequiredScoreFilteringCombiner;
+import org.atlasapi.equiv.results.extractors.PercentThresholdAboveNextBestMatchEquivalenceExtractor;
+import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
+import org.atlasapi.equiv.results.filters.ExclusionListFilter;
+import org.atlasapi.equiv.results.filters.FilmFilter;
+import org.atlasapi.equiv.results.filters.MediaTypeFilter;
+import org.atlasapi.equiv.results.filters.MinimumScoreFilter;
+import org.atlasapi.equiv.results.filters.PublisherFilter;
+import org.atlasapi.equiv.results.filters.SpecializationFilter;
+import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
+import org.atlasapi.equiv.results.scores.Score;
+import org.atlasapi.equiv.results.scores.ScoreThreshold;
+import org.atlasapi.equiv.scorers.ContainerHierarchyMatchingScorer;
+import org.atlasapi.equiv.scorers.SubscriptionCatchupBrandDetector;
+import org.atlasapi.equiv.scorers.TitleMatchingContainerScorer;
+import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
+import org.atlasapi.equiv.update.EquivalenceUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Container;
+import org.atlasapi.media.entity.Publisher;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+public class RteContainerUpdaterProvider implements EquivalenceUpdaterProvider<Container> {
+
+    private RteContainerUpdaterProvider() {
+    }
+
+    public static RteContainerUpdaterProvider create() {
+        return new RteContainerUpdaterProvider();
+    }
+
+    @Override
+    public EquivalenceUpdater<Container> getUpdater(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return ContentEquivalenceUpdater.<Container>builder()
+                .withExcludedUris(
+                        dependencies.getExcludedUris()
+                )
+                .withGenerator(
+                        TitleSearchGenerator.create(
+                                dependencies.getSearchResolver(),
+                                Container.class,
+                                targetPublishers,
+                                2
+                        )
+                )
+                .withScorers(
+                        ImmutableSet.of(
+                                new TitleMatchingContainerScorer(2),
+                                new ContainerHierarchyMatchingScorer(
+                                        dependencies.getContentResolver(),
+                                        Score.negativeOne(),
+                                        new SubscriptionCatchupBrandDetector(
+                                                dependencies.getContentResolver()
+                                        )
+                                )
+                        )
+                )
+                .withCombiner(
+                        new RequiredScoreFilteringCombiner<>(
+                                new NullScoreAwareAveragingCombiner<>(),
+                                TitleMatchingContainerScorer.NAME,
+                                ScoreThreshold.greaterThanOrEqual(2)
+                        )
+                )
+                .withFilter(
+                        ConjunctiveFilter.valueOf(ImmutableList.of(
+                                new MinimumScoreFilter<>(0.25),
+                                new MediaTypeFilter<>(),
+                                new SpecializationFilter<>(),
+                                new PublisherFilter<>(),
+                                new ExclusionListFilter<>(dependencies.getExcludedUris()),
+                                new FilmFilter<>(),
+                                new UnpublishedContentFilter<>()
+                        ))
+                )
+                .withExtractor(
+                        PercentThresholdAboveNextBestMatchEquivalenceExtractor
+                                .atLeastNTimesGreater(1.5)
+                )
+                .withHandler(
+                        new BroadcastingEquivalenceResultHandler<>(ImmutableList.of(
+                                new LookupWritingEquivalenceHandler<>(
+                                        dependencies.getLookupWriter(),
+                                        targetPublishers
+                                ),
+                                new EpisodeMatchingEquivalenceHandler(
+                                        dependencies.getContentResolver(),
+                                        dependencies.getEquivSummaryStore(),
+                                        dependencies.getLookupWriter(),
+                                        targetPublishers
+                                ),
+                                new ResultWritingEquivalenceHandler<>(
+                                        dependencies.getEquivalenceResultStore()
+                                ),
+                                new EquivalenceSummaryWritingHandler<>(
+                                        dependencies.getEquivSummaryStore()
+                                ),
+                                MessageQueueingResultHandler.create(
+                                        dependencies.getMessageSender(),
+                                        targetPublishers,
+                                        dependencies.getLookupEntryStore()
+                                )
+                        ))
+                )
+                .build();
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/StandardSeriesUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/StandardSeriesUpdaterProvider.java
@@ -1,0 +1,93 @@
+package org.atlasapi.equiv.update.updaters.providers.container;
+
+import java.util.Set;
+
+import org.atlasapi.equiv.generators.ContainerCandidatesContainerEquivalenceGenerator;
+import org.atlasapi.equiv.handlers.BroadcastingEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
+import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
+import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
+import org.atlasapi.equiv.results.extractors.PercentThresholdEquivalenceExtractor;
+import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
+import org.atlasapi.equiv.results.filters.ContainerHierarchyFilter;
+import org.atlasapi.equiv.results.filters.DummyContainerFilter;
+import org.atlasapi.equiv.results.filters.ExclusionListFilter;
+import org.atlasapi.equiv.results.filters.FilmFilter;
+import org.atlasapi.equiv.results.filters.MediaTypeFilter;
+import org.atlasapi.equiv.results.filters.MinimumScoreFilter;
+import org.atlasapi.equiv.results.filters.PublisherFilter;
+import org.atlasapi.equiv.results.filters.SpecializationFilter;
+import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
+import org.atlasapi.equiv.scorers.SequenceContainerScorer;
+import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
+import org.atlasapi.equiv.update.EquivalenceUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Container;
+import org.atlasapi.media.entity.Publisher;
+
+import com.google.common.collect.ImmutableList;
+
+public class StandardSeriesUpdaterProvider implements EquivalenceUpdaterProvider<Container> {
+
+    private StandardSeriesUpdaterProvider() {
+    }
+
+    public static StandardSeriesUpdaterProvider create() {
+        return new StandardSeriesUpdaterProvider();
+    }
+
+    @Override
+    public EquivalenceUpdater<Container> getUpdater(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return ContentEquivalenceUpdater.<Container>builder()
+                .withExcludedUris(
+                        dependencies.getExcludedUris()
+                )
+                .withGenerator(
+                        new ContainerCandidatesContainerEquivalenceGenerator(
+                                dependencies.getContentResolver(),
+                                dependencies.getEquivSummaryStore()
+                        )
+                )
+                .withScorer(
+                        new SequenceContainerScorer()
+                )
+                .withCombiner(
+                        new NullScoreAwareAveragingCombiner<>()
+                )
+                .withFilter(
+                        ConjunctiveFilter.valueOf(ImmutableList.of(
+                                new MinimumScoreFilter<>(0.25),
+                                new MediaTypeFilter<>(),
+                                new SpecializationFilter<>(),
+                                new PublisherFilter<>(),
+                                new ExclusionListFilter<>(dependencies.getExcludedUris()),
+                                new FilmFilter<>(),
+                                new DummyContainerFilter<>(),
+                                new UnpublishedContentFilter<>(),
+                                new ContainerHierarchyFilter()
+                        ))
+                )
+                .withExtractor(
+                        PercentThresholdEquivalenceExtractor.moreThanPercent(90)
+                )
+                .withHandler(
+                        new BroadcastingEquivalenceResultHandler<>(ImmutableList.of(
+                                new LookupWritingEquivalenceHandler<>(
+                                        dependencies.getLookupWriter(),
+                                        targetPublishers
+                                ),
+                                new ResultWritingEquivalenceHandler<>(
+                                        dependencies.getEquivalenceResultStore()
+                                ),
+                                new EquivalenceSummaryWritingHandler<>(
+                                        dependencies.getEquivSummaryStore()
+                                )
+                )))
+                .build();
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/StandardTopLevelContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/StandardTopLevelContainerUpdaterProvider.java
@@ -1,0 +1,127 @@
+package org.atlasapi.equiv.update.updaters.providers.container;
+
+import java.util.Set;
+
+import org.atlasapi.equiv.generators.ContainerChildEquivalenceGenerator;
+import org.atlasapi.equiv.generators.ScalingEquivalenceGenerator;
+import org.atlasapi.equiv.generators.TitleSearchGenerator;
+import org.atlasapi.equiv.handlers.BroadcastingEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EpisodeMatchingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
+import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.MessageQueueingResultHandler;
+import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
+import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
+import org.atlasapi.equiv.results.combining.RequiredScoreFilteringCombiner;
+import org.atlasapi.equiv.results.extractors.PercentThresholdAboveNextBestMatchEquivalenceExtractor;
+import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
+import org.atlasapi.equiv.results.filters.DummyContainerFilter;
+import org.atlasapi.equiv.results.filters.ExclusionListFilter;
+import org.atlasapi.equiv.results.filters.FilmFilter;
+import org.atlasapi.equiv.results.filters.MediaTypeFilter;
+import org.atlasapi.equiv.results.filters.MinimumScoreFilter;
+import org.atlasapi.equiv.results.filters.PublisherFilter;
+import org.atlasapi.equiv.results.filters.SpecializationFilter;
+import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
+import org.atlasapi.equiv.scorers.EquivalenceScorer;
+import org.atlasapi.equiv.scorers.TitleMatchingContainerScorer;
+import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
+import org.atlasapi.equiv.update.EquivalenceUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Container;
+import org.atlasapi.media.entity.Publisher;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+public class StandardTopLevelContainerUpdaterProvider
+        implements EquivalenceUpdaterProvider<Container> {
+
+    private StandardTopLevelContainerUpdaterProvider() { }
+
+    public static StandardTopLevelContainerUpdaterProvider create() {
+        return new StandardTopLevelContainerUpdaterProvider();
+    }
+
+    @Override
+    public EquivalenceUpdater<Container> getUpdater(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return ContentEquivalenceUpdater.<Container> builder()
+                .withExcludedUris(
+                        dependencies.getExcludedUris()
+                )
+                .withGenerators(
+                        ImmutableSet.of(
+                                TitleSearchGenerator.create(
+                                        dependencies.getSearchResolver(),
+                                        Container.class,
+                                        targetPublishers,
+                                        2
+                                ),
+                                ScalingEquivalenceGenerator.scale(
+                                        new ContainerChildEquivalenceGenerator(
+                                                dependencies.getContentResolver(),
+                                                dependencies.getEquivSummaryStore()
+                                        ),
+                                        20
+                                )
+                        )
+                )
+                .withScorers(
+                        ImmutableSet.<EquivalenceScorer<Container>> of(
+                                new TitleMatchingContainerScorer((double) 2)
+                        )
+                )
+                .withCombiner(
+                        new RequiredScoreFilteringCombiner<>(
+                                new NullScoreAwareAveragingCombiner<>(),
+                                TitleMatchingContainerScorer.NAME
+                        )
+                )
+                .withFilter(
+                        ConjunctiveFilter.valueOf(ImmutableList.of(
+                                new MinimumScoreFilter<>(0.25),
+                                new MediaTypeFilter<>(),
+                                new SpecializationFilter<>(),
+                                new PublisherFilter<>(),
+                                new ExclusionListFilter<>(dependencies.getExcludedUris()),
+                                new FilmFilter<>(),
+                                new DummyContainerFilter<>(),
+                                new UnpublishedContentFilter<>()
+                        ))
+                )
+                .withExtractor(
+                        PercentThresholdAboveNextBestMatchEquivalenceExtractor
+                                .atLeastNTimesGreater(1.5)
+                )
+                .withHandler(
+                        new BroadcastingEquivalenceResultHandler<>(ImmutableList.of(
+                                new LookupWritingEquivalenceHandler<>(
+                                        dependencies.getLookupWriter(),
+                                        targetPublishers
+                                ),
+                                new EpisodeMatchingEquivalenceHandler(
+                                        dependencies.getContentResolver(),
+                                        dependencies.getEquivSummaryStore(),
+                                        dependencies.getLookupWriter(),
+                                        targetPublishers
+                                ),
+                                new ResultWritingEquivalenceHandler<>(
+                                        dependencies.getEquivalenceResultStore()
+                                ),
+                                new EquivalenceSummaryWritingHandler<>(
+                                        dependencies.getEquivSummaryStore()
+                                ),
+                                MessageQueueingResultHandler.create(
+                                        dependencies.getMessageSender(),
+                                        targetPublishers,
+                                        dependencies.getLookupEntryStore()
+                                )
+                        ))
+                )
+                .build();
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/VodContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/VodContainerUpdaterProvider.java
@@ -1,0 +1,127 @@
+package org.atlasapi.equiv.update.updaters.providers.container;
+
+import java.util.Set;
+
+import org.atlasapi.equiv.generators.TitleSearchGenerator;
+import org.atlasapi.equiv.handlers.BroadcastingEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EpisodeMatchingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
+import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.MessageQueueingResultHandler;
+import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
+import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
+import org.atlasapi.equiv.results.combining.RequiredScoreFilteringCombiner;
+import org.atlasapi.equiv.results.extractors.PercentThresholdAboveNextBestMatchEquivalenceExtractor;
+import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
+import org.atlasapi.equiv.results.filters.DummyContainerFilter;
+import org.atlasapi.equiv.results.filters.ExclusionListFilter;
+import org.atlasapi.equiv.results.filters.FilmFilter;
+import org.atlasapi.equiv.results.filters.MediaTypeFilter;
+import org.atlasapi.equiv.results.filters.MinimumScoreFilter;
+import org.atlasapi.equiv.results.filters.PublisherFilter;
+import org.atlasapi.equiv.results.filters.SpecializationFilter;
+import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
+import org.atlasapi.equiv.results.scores.Score;
+import org.atlasapi.equiv.results.scores.ScoreThreshold;
+import org.atlasapi.equiv.scorers.ContainerHierarchyMatchingScorer;
+import org.atlasapi.equiv.scorers.SubscriptionCatchupBrandDetector;
+import org.atlasapi.equiv.scorers.TitleMatchingContainerScorer;
+import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
+import org.atlasapi.equiv.update.EquivalenceUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Container;
+import org.atlasapi.media.entity.Publisher;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+public class VodContainerUpdaterProvider implements EquivalenceUpdaterProvider<Container> {
+
+    private VodContainerUpdaterProvider() {
+    }
+
+    public static VodContainerUpdaterProvider create() {
+        return new VodContainerUpdaterProvider();
+    }
+
+    @Override
+    public EquivalenceUpdater<Container> getUpdater(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return ContentEquivalenceUpdater.<Container>builder()
+                .withExcludedUris(
+                        dependencies.getExcludedUris()
+                )
+                .withGenerator(
+                        TitleSearchGenerator.create(
+                                dependencies.getSearchResolver(),
+                                Container.class,
+                                targetPublishers,
+                                2
+                        )
+                )
+                .withScorers(
+                        ImmutableSet.of(
+                                new TitleMatchingContainerScorer(2),
+                                new ContainerHierarchyMatchingScorer(
+                                        dependencies.getContentResolver(),
+                                        Score.negativeOne(),
+                                        new SubscriptionCatchupBrandDetector(
+                                                dependencies.getContentResolver()
+                                        )
+                                )
+                        )
+                )
+                .withCombiner(
+                        new RequiredScoreFilteringCombiner<>(
+                                new NullScoreAwareAveragingCombiner<>(),
+                                TitleMatchingContainerScorer.NAME,
+                                ScoreThreshold.greaterThanOrEqual(2)
+                        )
+                )
+                .withFilter(
+                        ConjunctiveFilter.valueOf(ImmutableList.of(
+                                new MinimumScoreFilter<>(0.25),
+                                new MediaTypeFilter<>(),
+                                new SpecializationFilter<>(),
+                                new PublisherFilter<>(),
+                                new ExclusionListFilter<>(dependencies.getExcludedUris()),
+                                new FilmFilter<>(),
+                                new DummyContainerFilter<>(),
+                                new UnpublishedContentFilter<>()
+                        ))
+                )
+                .withExtractor(
+                        PercentThresholdAboveNextBestMatchEquivalenceExtractor
+                                .atLeastNTimesGreater(1.5)
+                )
+                .withHandler(
+                        new BroadcastingEquivalenceResultHandler<>(ImmutableList.of(
+                                new LookupWritingEquivalenceHandler<>(
+                                        dependencies.getLookupWriter(),
+                                        targetPublishers
+                                ),
+                                new EpisodeMatchingEquivalenceHandler(
+                                        dependencies.getContentResolver(),
+                                        dependencies.getEquivSummaryStore(),
+                                        dependencies.getLookupWriter(),
+                                        targetPublishers
+                                ),
+                                new ResultWritingEquivalenceHandler<>(
+                                        dependencies.getEquivalenceResultStore()
+                                ),
+                                new EquivalenceSummaryWritingHandler<>(
+                                        dependencies.getEquivSummaryStore()
+                                ),
+                                MessageQueueingResultHandler.create(
+                                        dependencies.getMessageSender(),
+                                        targetPublishers,
+                                        dependencies.getLookupEntryStore()
+                                )
+                        ))
+                )
+                .build();
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/package-info.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/package-info.java
@@ -1,0 +1,4 @@
+@NonNullByDefault
+package org.atlasapi.equiv.update.updaters.providers.container;
+
+import com.metabroadcast.common.annotation.NonNullByDefault;

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BettyItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BettyItemUpdaterProvider.java
@@ -1,0 +1,90 @@
+package org.atlasapi.equiv.update.updaters.providers.item;
+
+import java.util.Set;
+
+import org.atlasapi.equiv.generators.BroadcastMatchingItemEquivalenceGenerator;
+import org.atlasapi.equiv.handlers.BroadcastingEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
+import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.MessageQueueingResultHandler;
+import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
+import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
+import org.atlasapi.equiv.results.extractors.PercentThresholdEquivalenceExtractor;
+import org.atlasapi.equiv.results.filters.AlwaysTrueFilter;
+import org.atlasapi.equiv.results.scores.Score;
+import org.atlasapi.equiv.scorers.BroadcastAliasScorer;
+import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
+import org.atlasapi.equiv.update.EquivalenceUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Publisher;
+
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+import org.joda.time.Duration;
+
+public class BettyItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+
+    private BettyItemUpdaterProvider() {
+    }
+
+    public static BettyItemUpdaterProvider create() {
+        return new BettyItemUpdaterProvider();
+    }
+
+    @Override
+    public EquivalenceUpdater<Item> getUpdater(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+
+        return ContentEquivalenceUpdater.<Item>builder()
+                .withExcludedUris(
+                        dependencies.getExcludedUris()
+                )
+                .withGenerator(new BroadcastMatchingItemEquivalenceGenerator(
+                        dependencies.getScheduleResolver(),
+                        dependencies.getChannelResolver(),
+                        targetPublishers,
+                        Duration.standardMinutes(5),
+                        Predicates.alwaysTrue()
+                ))
+                .withScorer(
+                        new BroadcastAliasScorer(Score.negativeOne())
+                )
+                .withCombiner(
+                        new NullScoreAwareAveragingCombiner<>()
+                )
+                .withFilter(
+                        AlwaysTrueFilter.get()
+                )
+                .withExtractor(
+                        new PercentThresholdEquivalenceExtractor<>(0.95)
+                )
+                .withHandler(
+                        new BroadcastingEquivalenceResultHandler<>(ImmutableList.of(
+                                EpisodeFilteringEquivalenceResultHandler.relaxed(
+                                        new LookupWritingEquivalenceHandler<>(
+                                                dependencies.getLookupWriter(),
+                                                targetPublishers
+                                        ),
+                                        dependencies.getEquivSummaryStore()
+                                ),
+                                new ResultWritingEquivalenceHandler<>(
+                                        dependencies.getEquivalenceResultStore()
+                                ),
+                                new EquivalenceSummaryWritingHandler<>(
+                                        dependencies.getEquivSummaryStore()
+                                ),
+                                MessageQueueingResultHandler.create(
+                                        dependencies.getMessageSender(),
+                                        targetPublishers,
+                                        dependencies.getLookupEntryStore()
+                                )
+                        ))
+                )
+                .build();
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BroadcastItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BroadcastItemUpdaterProvider.java
@@ -1,0 +1,126 @@
+package org.atlasapi.equiv.update.updaters.providers.item;
+
+import java.util.Set;
+
+import org.atlasapi.equiv.generators.BroadcastMatchingItemEquivalenceGenerator;
+import org.atlasapi.equiv.generators.EquivalenceGenerator;
+import org.atlasapi.equiv.handlers.BroadcastingEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
+import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.MessageQueueingResultHandler;
+import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
+import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
+import org.atlasapi.equiv.results.extractors.PercentThresholdAboveNextBestMatchEquivalenceExtractor;
+import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
+import org.atlasapi.equiv.results.filters.DummyContainerFilter;
+import org.atlasapi.equiv.results.filters.ExclusionListFilter;
+import org.atlasapi.equiv.results.filters.FilmFilter;
+import org.atlasapi.equiv.results.filters.MediaTypeFilter;
+import org.atlasapi.equiv.results.filters.MinimumScoreFilter;
+import org.atlasapi.equiv.results.filters.PublisherFilter;
+import org.atlasapi.equiv.results.filters.SpecializationFilter;
+import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
+import org.atlasapi.equiv.results.scores.Score;
+import org.atlasapi.equiv.scorers.BroadcastAliasScorer;
+import org.atlasapi.equiv.scorers.DescriptionMatchingScorer;
+import org.atlasapi.equiv.scorers.DescriptionTitleMatchingScorer;
+import org.atlasapi.equiv.scorers.SequenceItemScorer;
+import org.atlasapi.equiv.scorers.TitleMatchingItemScorer;
+import org.atlasapi.equiv.scorers.TitleSubsetBroadcastItemScorer;
+import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
+import org.atlasapi.equiv.update.EquivalenceUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Publisher;
+
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.joda.time.Duration;
+
+public class BroadcastItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+
+    private BroadcastItemUpdaterProvider() {
+    }
+
+    public static BroadcastItemUpdaterProvider create() {
+        return new BroadcastItemUpdaterProvider();
+    }
+
+    @Override
+    public EquivalenceUpdater<Item> getUpdater(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return ContentEquivalenceUpdater.<Item>builder()
+                .withGenerators(
+                        ImmutableSet.<EquivalenceGenerator<Item>>of(
+                                new BroadcastMatchingItemEquivalenceGenerator(
+                                        dependencies.getScheduleResolver(),
+                                        dependencies.getChannelResolver(),
+                                        targetPublishers,
+                                        Duration.standardMinutes(5),
+                                        Predicates.alwaysTrue()
+                                )
+                        ))
+                .withExcludedUris(
+                        dependencies.getExcludedUris()
+                )
+                .withScorers(
+                        ImmutableSet.of(
+                                new TitleMatchingItemScorer(),
+                                new SequenceItemScorer(Score.ONE),
+                                new TitleSubsetBroadcastItemScorer(
+                                        dependencies.getContentResolver(),
+                                        Score.nullScore(),
+                                        80
+                                ),
+                                new BroadcastAliasScorer(Score.nullScore()),
+                                new DescriptionTitleMatchingScorer(),
+                                DescriptionMatchingScorer.makeScorer()
+                        ))
+                .withCombiner(
+                        new NullScoreAwareAveragingCombiner<>()
+                )
+                .withFilter(
+                        ConjunctiveFilter.valueOf(ImmutableList.of(
+                                new MinimumScoreFilter<>(0.25),
+                                new MediaTypeFilter<>(),
+                                new SpecializationFilter<>(),
+                                new PublisherFilter<>(),
+                                new ExclusionListFilter<>(dependencies.getExcludedUris()),
+                                new FilmFilter<>(),
+                                new DummyContainerFilter<>(),
+                                new UnpublishedContentFilter<>()
+                        )))
+                .withExtractor(
+                        PercentThresholdAboveNextBestMatchEquivalenceExtractor
+                                .atLeastNTimesGreater(1.5)
+                )
+                .withHandler(
+                        new BroadcastingEquivalenceResultHandler<>(ImmutableList.of(
+                                EpisodeFilteringEquivalenceResultHandler.relaxed(
+                                        new LookupWritingEquivalenceHandler<>(
+                                                dependencies.getLookupWriter(),
+                                                targetPublishers
+                                        ),
+                                        dependencies.getEquivSummaryStore()
+                                ),
+                                new ResultWritingEquivalenceHandler<>(
+                                        dependencies.getEquivalenceResultStore()
+                                ),
+                                new EquivalenceSummaryWritingHandler<>(
+                                        dependencies.getEquivSummaryStore()
+                                ),
+                                MessageQueueingResultHandler.create(
+                                        dependencies.getMessageSender(),
+                                        targetPublishers,
+                                        dependencies.getLookupEntryStore()
+                                )
+                        ))
+                )
+                .build();
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BtVodItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BtVodItemUpdaterProvider.java
@@ -1,0 +1,122 @@
+package org.atlasapi.equiv.update.updaters.providers.item;
+
+import java.util.Set;
+
+import org.atlasapi.equiv.generators.ContainerCandidatesItemEquivalenceGenerator;
+import org.atlasapi.equiv.generators.FilmEquivalenceGenerator;
+import org.atlasapi.equiv.handlers.BroadcastingEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
+import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
+import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
+import org.atlasapi.equiv.results.combining.RequiredScoreFilteringCombiner;
+import org.atlasapi.equiv.results.extractors.PercentThresholdAboveNextBestMatchEquivalenceExtractor;
+import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
+import org.atlasapi.equiv.results.filters.DummyContainerFilter;
+import org.atlasapi.equiv.results.filters.ExclusionListFilter;
+import org.atlasapi.equiv.results.filters.FilmFilter;
+import org.atlasapi.equiv.results.filters.MediaTypeFilter;
+import org.atlasapi.equiv.results.filters.MinimumScoreFilter;
+import org.atlasapi.equiv.results.filters.PublisherFilter;
+import org.atlasapi.equiv.results.filters.SpecializationFilter;
+import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
+import org.atlasapi.equiv.results.scores.Score;
+import org.atlasapi.equiv.scorers.SequenceItemScorer;
+import org.atlasapi.equiv.scorers.SeriesSequenceItemScorer;
+import org.atlasapi.equiv.scorers.TitleMatchingItemScorer;
+import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
+import org.atlasapi.equiv.update.EquivalenceUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Publisher;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+public class BtVodItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+
+    private BtVodItemUpdaterProvider() {
+    }
+
+    public static BtVodItemUpdaterProvider create() {
+        return new BtVodItemUpdaterProvider();
+    }
+
+    @Override
+    public EquivalenceUpdater<Item> getUpdater(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return ContentEquivalenceUpdater.<Item>builder()
+                .withExcludedUris(
+                        dependencies.getExcludedUris()
+                )
+                .withGenerators(
+                        ImmutableSet.of(
+                                new ContainerCandidatesItemEquivalenceGenerator(
+                                        dependencies.getContentResolver(),
+                                        dependencies.getEquivSummaryStore()
+                                ),
+                                new FilmEquivalenceGenerator(
+                                        dependencies.getSearchResolver(),
+                                        targetPublishers,
+                                        true
+                                )
+                        )
+                )
+                .withScorers(
+                        ImmutableSet.of(
+                                new TitleMatchingItemScorer(),
+                                // Hierarchies are known to be inconsistent between the BT VoD
+                                // catalogue and others, so we want to ascribe less weight
+                                // to sequence scoring
+                                new SequenceItemScorer(Score.valueOf(0.5)),
+                                new SeriesSequenceItemScorer()
+                        )
+                )
+                .withCombiner(
+                        new RequiredScoreFilteringCombiner<>(
+                                new NullScoreAwareAveragingCombiner<>(),
+                                ImmutableSet.of(
+                                        TitleMatchingItemScorer.NAME,
+                                        SequenceItemScorer.SEQUENCE_SCORER
+                                )
+                        )
+                )
+                .withFilter(
+                        ConjunctiveFilter.valueOf(ImmutableList.of(
+                                new MinimumScoreFilter<>(0.25),
+                                new MediaTypeFilter<>(),
+                                new SpecializationFilter<>(),
+                                new PublisherFilter<>(),
+                                new ExclusionListFilter<>(dependencies.getExcludedUris()),
+                                new FilmFilter<>(),
+                                new DummyContainerFilter<>(),
+                                new UnpublishedContentFilter<>()
+                        ))
+                )
+                .withExtractor(
+                        PercentThresholdAboveNextBestMatchEquivalenceExtractor
+                                .atLeastNTimesGreater(1.5)
+                )
+                .withHandler(
+                        new BroadcastingEquivalenceResultHandler<>(ImmutableList.of(
+                                EpisodeFilteringEquivalenceResultHandler.strict(
+                                        new LookupWritingEquivalenceHandler<>(
+                                                dependencies.getLookupWriter(),
+                                                targetPublishers
+                                        ),
+                                        dependencies.getEquivSummaryStore()
+                                ),
+                                new ResultWritingEquivalenceHandler<>(
+                                        dependencies.getEquivalenceResultStore()
+                                ),
+                                new EquivalenceSummaryWritingHandler<>(
+                                        dependencies.getEquivSummaryStore()
+                                )
+                        )))
+                .build();
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/EbsItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/EbsItemUpdaterProvider.java
@@ -1,0 +1,120 @@
+package org.atlasapi.equiv.update.updaters.providers.item;
+
+import java.util.Set;
+
+import org.atlasapi.equiv.generators.BroadcastMatchingItemEquivalenceGenerator;
+import org.atlasapi.equiv.generators.EquivalenceGenerator;
+import org.atlasapi.equiv.handlers.BroadcastingEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
+import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.MessageQueueingResultHandler;
+import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
+import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
+import org.atlasapi.equiv.results.extractors.PercentThresholdAboveNextBestMatchEquivalenceExtractor;
+import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
+import org.atlasapi.equiv.results.filters.DummyContainerFilter;
+import org.atlasapi.equiv.results.filters.ExclusionListFilter;
+import org.atlasapi.equiv.results.filters.FilmFilter;
+import org.atlasapi.equiv.results.filters.MediaTypeFilter;
+import org.atlasapi.equiv.results.filters.MinimumScoreFilter;
+import org.atlasapi.equiv.results.filters.PublisherFilter;
+import org.atlasapi.equiv.results.filters.SpecializationFilter;
+import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
+import org.atlasapi.equiv.results.scores.Score;
+import org.atlasapi.equiv.scorers.DescriptionMatchingScorer;
+import org.atlasapi.equiv.scorers.DescriptionTitleMatchingScorer;
+import org.atlasapi.equiv.scorers.SequenceItemScorer;
+import org.atlasapi.equiv.scorers.TitleMatchingItemScorer;
+import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
+import org.atlasapi.equiv.update.EquivalenceUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Publisher;
+
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.joda.time.Duration;
+
+public class EbsItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+
+    private EbsItemUpdaterProvider() { }
+
+    public static EbsItemUpdaterProvider create() {
+        return new EbsItemUpdaterProvider();
+    }
+
+    @Override
+    public EquivalenceUpdater<Item> getUpdater(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return ContentEquivalenceUpdater.<Item>builder()
+                .withGenerators(
+                        ImmutableSet.<EquivalenceGenerator<Item>>of(
+                                new BroadcastMatchingItemEquivalenceGenerator(
+                                        dependencies.getScheduleResolver(),
+                                        dependencies.getChannelResolver(),
+                                        targetPublishers,
+                                        Duration.standardMinutes(5),
+                                        Predicates.alwaysTrue()
+                                )
+                        )
+                )
+                .withExcludedUris(
+                        dependencies.getExcludedUris()
+                )
+                .withScorers(
+                        ImmutableSet.of(
+                                new TitleMatchingItemScorer(),
+                                new SequenceItemScorer(Score.ONE),
+                                new DescriptionTitleMatchingScorer(),
+                                DescriptionMatchingScorer.makeScorer()
+                        )
+                )
+                .withCombiner(
+                        new NullScoreAwareAveragingCombiner<>(true)
+                )
+                .withFilter(
+                        ConjunctiveFilter.valueOf(ImmutableList.of(
+                                new MinimumScoreFilter<>(0.25),
+                                new MediaTypeFilter<>(),
+                                new SpecializationFilter<>(),
+                                new PublisherFilter<>(),
+                                new ExclusionListFilter<>(dependencies.getExcludedUris()),
+                                new FilmFilter<>(),
+                                new DummyContainerFilter<>(),
+                                new UnpublishedContentFilter<>()
+                        ))
+                )
+                .withExtractor(
+                        PercentThresholdAboveNextBestMatchEquivalenceExtractor
+                                .atLeastNTimesGreater(1.5)
+                )
+                .withHandler(
+                        new BroadcastingEquivalenceResultHandler<>(ImmutableList.of(
+                                EpisodeFilteringEquivalenceResultHandler.relaxed(
+                                        new LookupWritingEquivalenceHandler<>(
+                                                dependencies.getLookupWriter(),
+                                                targetPublishers
+                                        ),
+                                        dependencies.getEquivSummaryStore()
+                                ),
+                                new ResultWritingEquivalenceHandler<>(
+                                        dependencies.getEquivalenceResultStore()
+                                ),
+                                new EquivalenceSummaryWritingHandler<>(
+                                        dependencies.getEquivSummaryStore()
+                                ),
+                                MessageQueueingResultHandler.create(
+                                        dependencies.getMessageSender(),
+                                        targetPublishers,
+                                        dependencies.getLookupEntryStore()
+                                )
+                        ))
+                )
+                .build();
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/MusicItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/MusicItemUpdaterProvider.java
@@ -1,0 +1,85 @@
+package org.atlasapi.equiv.update.updaters.providers.item;
+
+import java.util.Set;
+
+import org.atlasapi.equiv.generators.SongTitleTransform;
+import org.atlasapi.equiv.generators.TitleSearchGenerator;
+import org.atlasapi.equiv.handlers.BroadcastingEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
+import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
+import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
+import org.atlasapi.equiv.results.extractors.MusicEquivalenceExtractor;
+import org.atlasapi.equiv.results.filters.AlwaysTrueFilter;
+import org.atlasapi.equiv.scorers.CrewMemberScorer;
+import org.atlasapi.equiv.scorers.SongCrewMemberExtractor;
+import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
+import org.atlasapi.equiv.update.EquivalenceUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Publisher;
+import org.atlasapi.media.entity.Song;
+
+import com.google.common.collect.ImmutableList;
+
+public class MusicItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+
+    private MusicItemUpdaterProvider() {
+    }
+
+    public static MusicItemUpdaterProvider create() {
+        return new MusicItemUpdaterProvider();
+    }
+
+    @Override
+    public EquivalenceUpdater<Item> getUpdater(
+            EquivalenceUpdaterProviderDependencies dependencies, Set<Publisher> targetPublishers
+    ) {
+        return ContentEquivalenceUpdater.<Item>builder()
+                .withGenerator(
+                        new TitleSearchGenerator<>(
+                                dependencies.getSearchResolver(),
+                                Song.class,
+                                targetPublishers,
+                                new SongTitleTransform(),
+                                100,
+                                2
+                        )
+                )
+                .withScorer(
+                        new CrewMemberScorer(new SongCrewMemberExtractor())
+                )
+                .withExcludedUris(
+                        dependencies.getExcludedUris()
+                )
+                .withCombiner(
+                        new NullScoreAwareAveragingCombiner<>()
+                )
+                .withFilter(
+                        AlwaysTrueFilter.get()
+                )
+                .withExtractor(
+                        new MusicEquivalenceExtractor()
+                )
+                .withHandler(
+                        new BroadcastingEquivalenceResultHandler<>(ImmutableList.of(
+                                EpisodeFilteringEquivalenceResultHandler.relaxed(
+                                        new LookupWritingEquivalenceHandler<>(
+                                                dependencies.getLookupWriter(),
+                                                targetPublishers
+                                        ),
+                                        dependencies.getEquivSummaryStore()
+                                ),
+                                new ResultWritingEquivalenceHandler<>(
+                                        dependencies.getEquivalenceResultStore()
+                                ),
+                                new EquivalenceSummaryWritingHandler<>(
+                                        dependencies.getEquivSummaryStore()
+                                )
+                        ))
+                )
+                .build();
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/NopItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/NopItemUpdaterProvider.java
@@ -1,0 +1,40 @@
+package org.atlasapi.equiv.update.updaters.providers.item;
+
+import java.util.Set;
+
+import org.atlasapi.equiv.update.EquivalenceUpdater;
+import org.atlasapi.equiv.update.metadata.EquivalenceUpdaterMetadata;
+import org.atlasapi.equiv.update.metadata.NopEquivalenceUpdaterMetadata;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Publisher;
+
+public class NopItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+
+    private NopItemUpdaterProvider() {
+    }
+
+    public static NopItemUpdaterProvider create() {
+        return new NopItemUpdaterProvider();
+    }
+
+    @Override
+    public EquivalenceUpdater<Item> getUpdater(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return new EquivalenceUpdater<Item>() {
+
+            @Override
+            public boolean updateEquivalences(Item subject) {
+                return false;
+            }
+
+            @Override
+            public EquivalenceUpdaterMetadata getMetadata(Set<Publisher> sources) {
+                return NopEquivalenceUpdaterMetadata.create();
+            }
+        };
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/RoviItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/RoviItemUpdaterProvider.java
@@ -1,0 +1,122 @@
+package org.atlasapi.equiv.update.updaters.providers.item;
+
+import java.util.Set;
+
+import org.atlasapi.equiv.generators.BroadcastMatchingItemEquivalenceGenerator;
+import org.atlasapi.equiv.generators.ContainerCandidatesItemEquivalenceGenerator;
+import org.atlasapi.equiv.generators.FilmEquivalenceGenerator;
+import org.atlasapi.equiv.handlers.BroadcastingEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
+import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
+import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
+import org.atlasapi.equiv.results.combining.RequiredScoreFilteringCombiner;
+import org.atlasapi.equiv.results.extractors.PercentThresholdEquivalenceExtractor;
+import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
+import org.atlasapi.equiv.results.filters.DummyContainerFilter;
+import org.atlasapi.equiv.results.filters.ExclusionListFilter;
+import org.atlasapi.equiv.results.filters.FilmFilter;
+import org.atlasapi.equiv.results.filters.MediaTypeFilter;
+import org.atlasapi.equiv.results.filters.MinimumScoreFilter;
+import org.atlasapi.equiv.results.filters.PublisherFilter;
+import org.atlasapi.equiv.results.filters.SpecializationFilter;
+import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
+import org.atlasapi.equiv.results.scores.Score;
+import org.atlasapi.equiv.scorers.SequenceItemScorer;
+import org.atlasapi.equiv.scorers.TitleMatchingItemScorer;
+import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
+import org.atlasapi.equiv.update.EquivalenceUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Publisher;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.joda.time.Duration;
+
+public class RoviItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+
+    private RoviItemUpdaterProvider() {
+    }
+
+    public static RoviItemUpdaterProvider create() {
+        return new RoviItemUpdaterProvider();
+    }
+
+    @Override
+    public EquivalenceUpdater<Item> getUpdater(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return ContentEquivalenceUpdater.<Item>builder()
+                .withExcludedUris(
+                        dependencies.getExcludedUris()
+                )
+                .withGenerators(
+                        ImmutableSet.of(
+                                new BroadcastMatchingItemEquivalenceGenerator(
+                                        dependencies.getScheduleResolver(),
+                                        dependencies.getChannelResolver(),
+                                        targetPublishers,
+                                        Duration.standardMinutes(10)
+                                ),
+                                new ContainerCandidatesItemEquivalenceGenerator(
+                                        dependencies.getContentResolver(),
+                                        dependencies.getEquivSummaryStore()
+                                ),
+                                new FilmEquivalenceGenerator(
+                                        dependencies.getSearchResolver(),
+                                        targetPublishers,
+                                        true
+                                )
+                        )
+                )
+                .withScorers(
+                        ImmutableSet.of(
+                                new TitleMatchingItemScorer(),
+                                new SequenceItemScorer(Score.ONE)
+                        )
+                )
+                .withCombiner(
+                        new RequiredScoreFilteringCombiner<>(
+                                new NullScoreAwareAveragingCombiner<>(),
+                                TitleMatchingItemScorer.NAME
+                        )
+                )
+                .withFilter(
+                        ConjunctiveFilter.valueOf(ImmutableList.of(
+                                new MinimumScoreFilter<>(0.25),
+                                new MediaTypeFilter<>(),
+                                new SpecializationFilter<>(),
+                                new PublisherFilter<>(),
+                                new ExclusionListFilter<>(dependencies.getExcludedUris()),
+                                new FilmFilter<>(),
+                                new DummyContainerFilter<>(),
+                                new UnpublishedContentFilter<>()
+                        ))
+                )
+                .withExtractor(
+                        PercentThresholdEquivalenceExtractor.moreThanPercent(90)
+                )
+                .withHandler(
+                        new BroadcastingEquivalenceResultHandler<>(ImmutableList.of(
+                                EpisodeFilteringEquivalenceResultHandler.strict(
+                                        new LookupWritingEquivalenceHandler<>(
+                                                dependencies.getLookupWriter(),
+                                                targetPublishers
+                                        ),
+                                        dependencies.getEquivSummaryStore()
+                                ),
+                                new ResultWritingEquivalenceHandler<>(
+                                        dependencies.getEquivalenceResultStore()
+                                ),
+                                new EquivalenceSummaryWritingHandler<>(
+                                        dependencies.getEquivSummaryStore()
+                                )
+                        ))
+                )
+                .build();
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/RtItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/RtItemUpdaterProvider.java
@@ -1,0 +1,106 @@
+package org.atlasapi.equiv.update.updaters.providers.item;
+
+import java.util.Set;
+
+import org.atlasapi.equiv.generators.FilmEquivalenceGenerator;
+import org.atlasapi.equiv.generators.RadioTimesFilmEquivalenceGenerator;
+import org.atlasapi.equiv.handlers.BroadcastingEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
+import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
+import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
+import org.atlasapi.equiv.results.extractors.PercentThresholdEquivalenceExtractor;
+import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
+import org.atlasapi.equiv.results.filters.DummyContainerFilter;
+import org.atlasapi.equiv.results.filters.ExclusionListFilter;
+import org.atlasapi.equiv.results.filters.FilmFilter;
+import org.atlasapi.equiv.results.filters.MediaTypeFilter;
+import org.atlasapi.equiv.results.filters.MinimumScoreFilter;
+import org.atlasapi.equiv.results.filters.PublisherFilter;
+import org.atlasapi.equiv.results.filters.SpecializationFilter;
+import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
+import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
+import org.atlasapi.equiv.update.EquivalenceUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Publisher;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import static org.atlasapi.media.entity.Publisher.PA;
+import static org.atlasapi.media.entity.Publisher.PREVIEW_NETWORKS;
+import static org.atlasapi.media.entity.Publisher.RADIO_TIMES;
+
+public class RtItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+
+    private RtItemUpdaterProvider() {
+    }
+
+    public static RtItemUpdaterProvider create() {
+        return new RtItemUpdaterProvider();
+    }
+
+    @Override
+    public EquivalenceUpdater<Item> getUpdater(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return ContentEquivalenceUpdater.<Item>builder()
+                .withExcludedUris(
+                        dependencies.getExcludedUris()
+                )
+                .withGenerators(
+                        ImmutableSet.of(
+                                new RadioTimesFilmEquivalenceGenerator(
+                                        dependencies.getContentResolver()
+                                ),
+                                new FilmEquivalenceGenerator(
+                                        dependencies.getSearchResolver(),
+                                        targetPublishers,
+                                        false
+                                )
+                        )
+                )
+                .withScorers(
+                        ImmutableSet.of()
+                )
+                .withCombiner(
+                        new NullScoreAwareAveragingCombiner<>()
+                )
+                .withFilter(
+                        ConjunctiveFilter.valueOf(ImmutableList.of(
+                                new MinimumScoreFilter<>(0.25),
+                                new MediaTypeFilter<>(),
+                                new SpecializationFilter<>(),
+                                new PublisherFilter<>(),
+                                new ExclusionListFilter<>(dependencies.getExcludedUris()),
+                                new FilmFilter<>(),
+                                new DummyContainerFilter<>(),
+                                new UnpublishedContentFilter<>()
+                        ))
+                )
+                .withExtractor(
+                        PercentThresholdEquivalenceExtractor.moreThanPercent(90)
+                )
+                .withHandler(
+                        new BroadcastingEquivalenceResultHandler<>(ImmutableList.of(
+                                EpisodeFilteringEquivalenceResultHandler.relaxed(
+                                        new LookupWritingEquivalenceHandler<>(
+                                                dependencies.getLookupWriter(),
+                                                ImmutableSet.of(RADIO_TIMES, PA, PREVIEW_NETWORKS)
+                                        ),
+                                        dependencies.getEquivSummaryStore()
+                                ),
+                                new ResultWritingEquivalenceHandler<>(
+                                        dependencies.getEquivalenceResultStore()),
+                                new EquivalenceSummaryWritingHandler<>(
+                                        dependencies.getEquivSummaryStore()
+                                )
+                        ))
+                )
+                .build();
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/RtUpcomingItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/RtUpcomingItemUpdaterProvider.java
@@ -1,0 +1,118 @@
+package org.atlasapi.equiv.update.updaters.providers.item;
+
+import java.util.Set;
+
+import org.atlasapi.equiv.generators.BroadcastMatchingItemEquivalenceGenerator;
+import org.atlasapi.equiv.generators.EquivalenceGenerator;
+import org.atlasapi.equiv.handlers.BroadcastingEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
+import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.MessageQueueingResultHandler;
+import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
+import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
+import org.atlasapi.equiv.results.extractors.PercentThresholdAboveNextBestMatchEquivalenceExtractor;
+import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
+import org.atlasapi.equiv.results.filters.ExclusionListFilter;
+import org.atlasapi.equiv.results.filters.FilmFilter;
+import org.atlasapi.equiv.results.filters.MediaTypeFilter;
+import org.atlasapi.equiv.results.filters.MinimumScoreFilter;
+import org.atlasapi.equiv.results.filters.PublisherFilter;
+import org.atlasapi.equiv.results.filters.SpecializationFilter;
+import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
+import org.atlasapi.equiv.results.scores.Score;
+import org.atlasapi.equiv.scorers.DescriptionMatchingScorer;
+import org.atlasapi.equiv.scorers.DescriptionTitleMatchingScorer;
+import org.atlasapi.equiv.scorers.SequenceItemScorer;
+import org.atlasapi.equiv.scorers.TitleMatchingItemScorer;
+import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
+import org.atlasapi.equiv.update.EquivalenceUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Publisher;
+
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.joda.time.Duration;
+
+public class RtUpcomingItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+
+    private RtUpcomingItemUpdaterProvider() { }
+
+    public static RtUpcomingItemUpdaterProvider create() {
+        return new RtUpcomingItemUpdaterProvider();
+    }
+
+    @Override
+    public EquivalenceUpdater<Item> getUpdater(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return ContentEquivalenceUpdater.<Item>builder()
+                .withGenerators(
+                        ImmutableSet.<EquivalenceGenerator<Item>>of(
+                                new BroadcastMatchingItemEquivalenceGenerator(
+                                        dependencies.getScheduleResolver(),
+                                        dependencies.getChannelResolver(),
+                                        targetPublishers,
+                                        Duration.standardMinutes(5),
+                                        Predicates.alwaysTrue()
+                                )
+                        )
+                )
+                .withExcludedUris(
+                        dependencies.getExcludedUris()
+                )
+                .withScorers(
+                        ImmutableSet.of(
+                                new TitleMatchingItemScorer(),
+                                new SequenceItemScorer(Score.ONE),
+                                new DescriptionTitleMatchingScorer(),
+                                DescriptionMatchingScorer.makeScorer()
+                        )
+                )
+                .withCombiner(
+                        new NullScoreAwareAveragingCombiner<>()
+                )
+                .withFilter(
+                        ConjunctiveFilter.valueOf(ImmutableList.of(
+                                new MinimumScoreFilter<>(0.25),
+                                new MediaTypeFilter<>(),
+                                new SpecializationFilter<>(),
+                                new PublisherFilter<>(),
+                                new ExclusionListFilter<>(dependencies.getExcludedUris()),
+                                new FilmFilter<>(),
+                                new UnpublishedContentFilter<>()
+                        ))
+                )
+                .withExtractor(
+                        PercentThresholdAboveNextBestMatchEquivalenceExtractor
+                                .atLeastNTimesGreater(1.5)
+                )
+                .withHandler(
+                        new BroadcastingEquivalenceResultHandler<>(ImmutableList.of(
+                                EpisodeFilteringEquivalenceResultHandler.relaxed(
+                                        new LookupWritingEquivalenceHandler<>(
+                                                dependencies.getLookupWriter(),
+                                                targetPublishers
+                                        ),
+                                        dependencies.getEquivSummaryStore()
+                                ),
+                                new ResultWritingEquivalenceHandler<>(
+                                        dependencies.getEquivalenceResultStore()
+                                ),
+                                new EquivalenceSummaryWritingHandler<>(
+                                        dependencies.getEquivSummaryStore()
+                                ),
+                                MessageQueueingResultHandler.create(
+                                        dependencies.getMessageSender(),
+                                        targetPublishers,
+                                        dependencies.getLookupEntryStore()
+                                )
+                        ))
+                )
+                .build();
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/StandardItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/StandardItemUpdaterProvider.java
@@ -1,0 +1,120 @@
+package org.atlasapi.equiv.update.updaters.providers.item;
+
+import java.util.Set;
+
+import org.atlasapi.equiv.generators.BroadcastMatchingItemEquivalenceGenerator;
+import org.atlasapi.equiv.generators.EquivalenceGenerator;
+import org.atlasapi.equiv.handlers.BroadcastingEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
+import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.MessageQueueingResultHandler;
+import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
+import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
+import org.atlasapi.equiv.results.extractors.PercentThresholdAboveNextBestMatchEquivalenceExtractor;
+import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
+import org.atlasapi.equiv.results.filters.DummyContainerFilter;
+import org.atlasapi.equiv.results.filters.ExclusionListFilter;
+import org.atlasapi.equiv.results.filters.FilmFilter;
+import org.atlasapi.equiv.results.filters.MediaTypeFilter;
+import org.atlasapi.equiv.results.filters.MinimumScoreFilter;
+import org.atlasapi.equiv.results.filters.PublisherFilter;
+import org.atlasapi.equiv.results.filters.SpecializationFilter;
+import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
+import org.atlasapi.equiv.results.scores.Score;
+import org.atlasapi.equiv.scorers.DescriptionMatchingScorer;
+import org.atlasapi.equiv.scorers.DescriptionTitleMatchingScorer;
+import org.atlasapi.equiv.scorers.SequenceItemScorer;
+import org.atlasapi.equiv.scorers.TitleMatchingItemScorer;
+import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
+import org.atlasapi.equiv.update.EquivalenceUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Publisher;
+
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.joda.time.Duration;
+
+public class StandardItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+
+    private StandardItemUpdaterProvider() {}
+
+    public static StandardItemUpdaterProvider create() {
+        return new StandardItemUpdaterProvider();
+    }
+
+    @Override
+    public EquivalenceUpdater<Item> getUpdater(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return ContentEquivalenceUpdater.<Item>builder()
+                .withGenerators(
+                        ImmutableSet.<EquivalenceGenerator<Item>>of(
+                                new BroadcastMatchingItemEquivalenceGenerator(
+                                        dependencies.getScheduleResolver(),
+                                        dependencies.getChannelResolver(),
+                                        targetPublishers,
+                                        Duration.standardMinutes(5),
+                                        Predicates.alwaysTrue()
+                                )
+                        )
+                )
+                .withExcludedUris(
+                        dependencies.getExcludedUris()
+                )
+                .withScorers(
+                        ImmutableSet.of(
+                                new TitleMatchingItemScorer(),
+                                new SequenceItemScorer(Score.ONE),
+                                new DescriptionTitleMatchingScorer(),
+                                DescriptionMatchingScorer.makeScorer()
+                        )
+                )
+                .withCombiner(
+                        new NullScoreAwareAveragingCombiner<>()
+                )
+                .withFilter(
+                        ConjunctiveFilter.valueOf(ImmutableList.of(
+                                new MinimumScoreFilter<>(0.25),
+                                new MediaTypeFilter<>(),
+                                new SpecializationFilter<>(),
+                                new PublisherFilter<>(),
+                                new ExclusionListFilter<>(dependencies.getExcludedUris()),
+                                new FilmFilter<>(),
+                                new DummyContainerFilter<>(),
+                                new UnpublishedContentFilter<>()
+                        ))
+                )
+                .withExtractor(
+                        PercentThresholdAboveNextBestMatchEquivalenceExtractor
+                                .atLeastNTimesGreater(1.5)
+                )
+                .withHandler(
+                        new BroadcastingEquivalenceResultHandler<>(ImmutableList.of(
+                                EpisodeFilteringEquivalenceResultHandler.relaxed(
+                                        new LookupWritingEquivalenceHandler<>(
+                                                dependencies.getLookupWriter(),
+                                                targetPublishers
+                                        ),
+                                        dependencies.getEquivSummaryStore()
+                                ),
+                                new ResultWritingEquivalenceHandler<>(
+                                        dependencies.getEquivalenceResultStore()
+                                ),
+                                new EquivalenceSummaryWritingHandler<>(
+                                        dependencies.getEquivSummaryStore()
+                                ),
+                                MessageQueueingResultHandler.create(
+                                        dependencies.getMessageSender(),
+                                        targetPublishers,
+                                        dependencies.getLookupEntryStore()
+                                )
+                        ))
+                )
+                .build();
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/VodItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/VodItemUpdaterProvider.java
@@ -1,0 +1,113 @@
+package org.atlasapi.equiv.update.updaters.providers.item;
+
+import java.util.Set;
+
+import org.atlasapi.equiv.generators.ContainerCandidatesItemEquivalenceGenerator;
+import org.atlasapi.equiv.generators.FilmEquivalenceGenerator;
+import org.atlasapi.equiv.handlers.BroadcastingEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
+import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
+import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
+import org.atlasapi.equiv.results.combining.RequiredScoreFilteringCombiner;
+import org.atlasapi.equiv.results.extractors.PercentThresholdEquivalenceExtractor;
+import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
+import org.atlasapi.equiv.results.filters.DummyContainerFilter;
+import org.atlasapi.equiv.results.filters.ExclusionListFilter;
+import org.atlasapi.equiv.results.filters.FilmFilter;
+import org.atlasapi.equiv.results.filters.MediaTypeFilter;
+import org.atlasapi.equiv.results.filters.MinimumScoreFilter;
+import org.atlasapi.equiv.results.filters.PublisherFilter;
+import org.atlasapi.equiv.results.filters.SpecializationFilter;
+import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
+import org.atlasapi.equiv.results.scores.Score;
+import org.atlasapi.equiv.scorers.SequenceItemScorer;
+import org.atlasapi.equiv.scorers.TitleMatchingItemScorer;
+import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
+import org.atlasapi.equiv.update.EquivalenceUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Publisher;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+public class VodItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+
+    private VodItemUpdaterProvider() {
+    }
+
+    public static VodItemUpdaterProvider create() {
+        return new VodItemUpdaterProvider();
+    }
+
+    @Override
+    public EquivalenceUpdater<Item> getUpdater(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return ContentEquivalenceUpdater.<Item>builder()
+                .withExcludedUris(
+                        dependencies.getExcludedUris()
+                )
+                .withGenerators(
+                        ImmutableSet.of(
+                                new ContainerCandidatesItemEquivalenceGenerator(
+                                        dependencies.getContentResolver(),
+                                        dependencies.getEquivSummaryStore()
+                                ),
+                                new FilmEquivalenceGenerator(
+                                        dependencies.getSearchResolver(),
+                                        targetPublishers,
+                                        true)
+                        )
+                )
+                .withScorers(
+                        ImmutableSet.of(
+                                new TitleMatchingItemScorer(),
+                                new SequenceItemScorer(Score.ONE)
+                        )
+                )
+                .withCombiner(
+                        new RequiredScoreFilteringCombiner<>(
+                                new NullScoreAwareAveragingCombiner<>(),
+                                TitleMatchingItemScorer.NAME
+                        )
+                )
+                .withFilter(
+                        ConjunctiveFilter.valueOf(ImmutableList.of(
+                                new MinimumScoreFilter<>(0.25),
+                                new MediaTypeFilter<>(),
+                                new SpecializationFilter<>(),
+                                new PublisherFilter<>(),
+                                new ExclusionListFilter<>(dependencies.getExcludedUris()),
+                                new FilmFilter<>(),
+                                new DummyContainerFilter<>(),
+                                new UnpublishedContentFilter<>()
+                        ))
+                )
+                .withExtractor(
+                        PercentThresholdEquivalenceExtractor.moreThanPercent(90)
+                )
+                .withHandler(
+                        new BroadcastingEquivalenceResultHandler<>(ImmutableList.of(
+                                EpisodeFilteringEquivalenceResultHandler.strict(
+                                        new LookupWritingEquivalenceHandler<>(
+                                                dependencies.getLookupWriter(),
+                                                targetPublishers
+                                        ),
+                                        dependencies.getEquivSummaryStore()
+                                ),
+                                new ResultWritingEquivalenceHandler<>(
+                                        dependencies.getEquivalenceResultStore()
+                                ),
+                                new EquivalenceSummaryWritingHandler<>(
+                                        dependencies.getEquivSummaryStore()
+                                )
+                        ))
+                )
+                .build();
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/VodItemWithSeriesSequenceUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/VodItemWithSeriesSequenceUpdaterProvider.java
@@ -1,0 +1,116 @@
+package org.atlasapi.equiv.update.updaters.providers.item;
+
+import java.util.Set;
+
+import org.atlasapi.equiv.generators.ContainerCandidatesItemEquivalenceGenerator;
+import org.atlasapi.equiv.generators.FilmEquivalenceGenerator;
+import org.atlasapi.equiv.handlers.BroadcastingEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
+import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
+import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
+import org.atlasapi.equiv.results.combining.RequiredScoreFilteringCombiner;
+import org.atlasapi.equiv.results.extractors.PercentThresholdEquivalenceExtractor;
+import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
+import org.atlasapi.equiv.results.filters.DummyContainerFilter;
+import org.atlasapi.equiv.results.filters.ExclusionListFilter;
+import org.atlasapi.equiv.results.filters.FilmFilter;
+import org.atlasapi.equiv.results.filters.MediaTypeFilter;
+import org.atlasapi.equiv.results.filters.MinimumScoreFilter;
+import org.atlasapi.equiv.results.filters.PublisherFilter;
+import org.atlasapi.equiv.results.filters.SpecializationFilter;
+import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
+import org.atlasapi.equiv.results.scores.Score;
+import org.atlasapi.equiv.scorers.SequenceItemScorer;
+import org.atlasapi.equiv.scorers.SeriesSequenceItemScorer;
+import org.atlasapi.equiv.scorers.TitleMatchingItemScorer;
+import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
+import org.atlasapi.equiv.update.EquivalenceUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Publisher;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+public class VodItemWithSeriesSequenceUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+
+    private VodItemWithSeriesSequenceUpdaterProvider() {
+    }
+
+    public static VodItemWithSeriesSequenceUpdaterProvider create() {
+        return new VodItemWithSeriesSequenceUpdaterProvider();
+    }
+
+    @Override
+    public EquivalenceUpdater<Item> getUpdater(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return ContentEquivalenceUpdater.<Item>builder()
+                .withExcludedUris(
+                        dependencies.getExcludedUris()
+                )
+                .withGenerators(
+                        ImmutableSet.of(
+                                new ContainerCandidatesItemEquivalenceGenerator(
+                                        dependencies.getContentResolver(),
+                                        dependencies.getEquivSummaryStore()
+                                ),
+                                new FilmEquivalenceGenerator(
+                                        dependencies.getSearchResolver(),
+                                        targetPublishers,
+                                        true
+                                )
+                        )
+                )
+                .withScorers(
+                        ImmutableSet.of(
+                                new TitleMatchingItemScorer(),
+                                new SequenceItemScorer(Score.ONE),
+                                new SeriesSequenceItemScorer()
+                        )
+                )
+                .withCombiner(
+                        new RequiredScoreFilteringCombiner<>(
+                                new NullScoreAwareAveragingCombiner<>(),
+                                TitleMatchingItemScorer.NAME
+                        )
+                )
+                .withFilter(
+                        ConjunctiveFilter.valueOf(ImmutableList.of(
+                                new MinimumScoreFilter<>(0.25),
+                                new MediaTypeFilter<>(),
+                                new SpecializationFilter<>(),
+                                new PublisherFilter<>(),
+                                new ExclusionListFilter<>(dependencies.getExcludedUris()),
+                                new FilmFilter<>(),
+                                new DummyContainerFilter<>(),
+                                new UnpublishedContentFilter<>()
+                        ))
+                )
+                .withExtractor(
+                        PercentThresholdEquivalenceExtractor.moreThanPercent(90)
+                )
+                .withHandler(
+                        new BroadcastingEquivalenceResultHandler<>(ImmutableList.of(
+                                EpisodeFilteringEquivalenceResultHandler.strict(
+                                        new LookupWritingEquivalenceHandler<>(
+                                                dependencies.getLookupWriter(),
+                                                targetPublishers
+                                        ),
+                                        dependencies.getEquivSummaryStore()
+                                ),
+                                new ResultWritingEquivalenceHandler<>(
+                                        dependencies.getEquivalenceResultStore()
+                                ),
+                                new EquivalenceSummaryWritingHandler<>(
+                                        dependencies.getEquivSummaryStore()
+                                )
+                        ))
+                )
+                .build();
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/YouviewItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/YouviewItemUpdaterProvider.java
@@ -1,0 +1,134 @@
+package org.atlasapi.equiv.update.updaters.providers.item;
+
+import java.util.Set;
+
+import org.atlasapi.equiv.generators.BroadcastMatchingItemEquivalenceGenerator;
+import org.atlasapi.equiv.generators.EquivalenceGenerator;
+import org.atlasapi.equiv.handlers.BroadcastingEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
+import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.MessageQueueingResultHandler;
+import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
+import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
+import org.atlasapi.equiv.results.extractors.PercentThresholdAboveNextBestMatchEquivalenceExtractor;
+import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
+import org.atlasapi.equiv.results.filters.DummyContainerFilter;
+import org.atlasapi.equiv.results.filters.ExclusionListFilter;
+import org.atlasapi.equiv.results.filters.FilmFilter;
+import org.atlasapi.equiv.results.filters.MediaTypeFilter;
+import org.atlasapi.equiv.results.filters.MinimumScoreFilter;
+import org.atlasapi.equiv.results.filters.PublisherFilter;
+import org.atlasapi.equiv.results.filters.SpecializationFilter;
+import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
+import org.atlasapi.equiv.results.scores.Score;
+import org.atlasapi.equiv.scorers.BroadcastAliasScorer;
+import org.atlasapi.equiv.scorers.DescriptionMatchingScorer;
+import org.atlasapi.equiv.scorers.DescriptionTitleMatchingScorer;
+import org.atlasapi.equiv.scorers.SequenceItemScorer;
+import org.atlasapi.equiv.scorers.TitleMatchingItemScorer;
+import org.atlasapi.equiv.scorers.TitleSubsetBroadcastItemScorer;
+import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
+import org.atlasapi.equiv.update.EquivalenceUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Publisher;
+
+import com.metabroadcast.common.time.DateTimeZones;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.joda.time.DateTime;
+import org.joda.time.Duration;
+
+public class YouviewItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+
+    private YouviewItemUpdaterProvider() {
+    }
+
+    public static YouviewItemUpdaterProvider create() {
+        return new YouviewItemUpdaterProvider();
+    }
+
+    @Override
+    public EquivalenceUpdater<Item> getUpdater(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+
+        return ContentEquivalenceUpdater.<Item>builder()
+                .withGenerators(
+                        ImmutableSet.<EquivalenceGenerator<Item>>of(
+                                new BroadcastMatchingItemEquivalenceGenerator(
+                                        dependencies.getScheduleResolver(),
+                                        dependencies.getChannelResolver(),
+                                        targetPublishers,
+                                        Duration.standardMinutes(5),
+                                        input -> input.getTransmissionTime()
+                                                .isAfter(
+                                                        new DateTime(DateTimeZones.UTC)
+                                                                .minusDays(15)
+                                                )
+                                )
+                        ))
+                .withExcludedUris(
+                        dependencies.getExcludedUris()
+                )
+                .withScorers(
+                        ImmutableSet.of(
+                                new TitleMatchingItemScorer(),
+                                new SequenceItemScorer(Score.ONE),
+                                new TitleSubsetBroadcastItemScorer(
+                                        dependencies.getContentResolver(),
+                                        Score.negativeOne(),
+                                        80
+                                ),
+                                new BroadcastAliasScorer(Score.nullScore()),
+                                new DescriptionTitleMatchingScorer(),
+                                DescriptionMatchingScorer.makeScorer()
+                        )
+                )
+                .withCombiner(
+                        new NullScoreAwareAveragingCombiner<>()
+                )
+                .withFilter(
+                        ConjunctiveFilter.valueOf(ImmutableList.of(
+                                new MinimumScoreFilter<>(0.25),
+                                new MediaTypeFilter<>(),
+                                new SpecializationFilter<>(),
+                                new PublisherFilter<>(),
+                                new ExclusionListFilter<>(dependencies.getExcludedUris()),
+                                new FilmFilter<>(),
+                                new DummyContainerFilter<>(),
+                                new UnpublishedContentFilter<>()
+                        ))
+                )
+                .withExtractor(
+                        PercentThresholdAboveNextBestMatchEquivalenceExtractor
+                                .atLeastNTimesGreater(1.5)
+                )
+                .withHandler(
+                        new BroadcastingEquivalenceResultHandler<>(ImmutableList.of(
+                                EpisodeFilteringEquivalenceResultHandler.relaxed(
+                                        new LookupWritingEquivalenceHandler<>(
+                                                dependencies.getLookupWriter(),
+                                                targetPublishers
+                                        ),
+                                        dependencies.getEquivSummaryStore()
+                                ),
+                                new ResultWritingEquivalenceHandler<>(
+                                        dependencies.getEquivalenceResultStore()),
+                                new EquivalenceSummaryWritingHandler<>(
+                                        dependencies.getEquivSummaryStore()
+                                ),
+                                MessageQueueingResultHandler.create(
+                                        dependencies.getMessageSender(),
+                                        targetPublishers,
+                                        dependencies.getLookupEntryStore()
+                                )
+                        ))
+                )
+                .build();
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/package-info.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/package-info.java
@@ -1,0 +1,4 @@
+@NonNullByDefault
+package org.atlasapi.equiv.update.updaters.providers.item;
+
+import com.metabroadcast.common.annotation.NonNullByDefault;

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/package-info.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/package-info.java
@@ -1,0 +1,4 @@
+@NonNullByDefault
+package org.atlasapi.equiv.update.updaters.providers;
+
+import com.metabroadcast.common.annotation.NonNullByDefault;

--- a/src/main/java/org/atlasapi/equiv/update/updaters/types/ContainerEquivalenceUpdaterType.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/types/ContainerEquivalenceUpdaterType.java
@@ -1,0 +1,58 @@
+package org.atlasapi.equiv.update.updaters.types;
+
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.container.BroadcastItemContainerUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.container.BtVodContainerUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.container.FacebookContainerUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.container.NopContainerUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.container
+        .RtUpcomingTopLevelContainerUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.container.RteContainerUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.container.StandardSeriesUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.container
+        .StandardTopLevelContainerUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.container.VodContainerUpdaterProvider;
+import org.atlasapi.media.entity.Container;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public enum ContainerEquivalenceUpdaterType {
+    NOP_CONTAINER(
+            NopContainerUpdaterProvider.create()
+    ),
+    STANDARD_TOP_LEVEL_CONTAINER(
+            StandardTopLevelContainerUpdaterProvider.create()
+    ),
+    STANDARD_SERIES(
+            StandardSeriesUpdaterProvider.create()
+    ),
+    RT_UPCOMING_TOP_LEVEL_CONTAINER(
+            RtUpcomingTopLevelContainerUpdaterProvider.create()
+    ),
+    BROADCAST_ITEM_CONTAINER(
+            BroadcastItemContainerUpdaterProvider.create()
+    ),
+    FACEBOOK_CONTAINER(
+            FacebookContainerUpdaterProvider.create()
+    ),
+    VOD_CONTAINER(
+            VodContainerUpdaterProvider.create()
+    ),
+    BT_VOD_CONTAINER(
+            BtVodContainerUpdaterProvider.create()
+    ),
+    RTE_VOD_CONTAINER(
+            RteContainerUpdaterProvider.create()
+    )
+    ;
+
+    private final EquivalenceUpdaterProvider<Container> provider;
+
+    ContainerEquivalenceUpdaterType(EquivalenceUpdaterProvider<Container> provider) {
+        this.provider = checkNotNull(provider);
+    }
+
+    public EquivalenceUpdaterProvider<Container> getProvider() {
+        return provider;
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/types/ItemEquivalenceUpdaterType.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/types/ItemEquivalenceUpdaterType.java
@@ -1,0 +1,72 @@
+package org.atlasapi.equiv.update.updaters.types;
+
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.item.BettyItemUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.item.BroadcastItemUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.item.BtVodItemUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.item.EbsItemUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.item.MusicItemUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.item.NopItemUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.item.RoviItemUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.item.RtItemUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.item.RtUpcomingItemUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.item.StandardItemUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.item.VodItemUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.item.VodItemWithSeriesSequenceUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.item.YouviewItemUpdaterProvider;
+import org.atlasapi.media.entity.Item;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public enum ItemEquivalenceUpdaterType {
+    NOP_ITEM(
+            NopItemUpdaterProvider.create()
+    ),
+    STANDARD_ITEM(
+            StandardItemUpdaterProvider.create()
+    ),
+    RT_UPCOMING_ITEM(
+            RtUpcomingItemUpdaterProvider.create()
+    ),
+    EBS_ITEM(
+            EbsItemUpdaterProvider.create()
+    ),
+    BROADCAST_ITEM(
+            BroadcastItemUpdaterProvider.create()
+    ),
+    ROVI_ITEM(
+            RoviItemUpdaterProvider.create()
+    ),
+    RT_ITEM(
+            RtItemUpdaterProvider.create()
+    ),
+    YOUVIEW_ITEM(
+            YouviewItemUpdaterProvider.create()
+    ),
+    BETTY_ITEM(
+            BettyItemUpdaterProvider.create()
+    ),
+    VOD_ITEM(
+            VodItemUpdaterProvider.create()
+    ),
+    VOD_WITH_SERIES_SEQUENCE_ITEM(
+            VodItemWithSeriesSequenceUpdaterProvider.create()
+    ),
+    BT_VOD_ITEM(
+            BtVodItemUpdaterProvider.create()
+    ),
+    MUSIC_ITEM(
+            MusicItemUpdaterProvider.create()
+    )
+    ;
+
+    private final EquivalenceUpdaterProvider<Item> provider;
+
+    ItemEquivalenceUpdaterType(EquivalenceUpdaterProvider<Item> provider) {
+        this.provider = checkNotNull(provider);
+    }
+
+    public EquivalenceUpdaterProvider<Item> getProvider() {
+        return provider;
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/types/package-info.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/types/package-info.java
@@ -1,0 +1,4 @@
+@NonNullByDefault
+package org.atlasapi.equiv.update.updaters.types;
+
+import com.metabroadcast.common.annotation.NonNullByDefault;


### PR DESCRIPTION
- The new structure is:
-- EquivalenceUpdaterProvider -> Class which provides a single updater.
   Unlike before  those classes do not share any logic between them
   to avoid coupling different updaters
-- ItemEquivalenceUpdaterType & ContainerEquivalenceUpdaterType ->
   Enums which provide the connection between the configuration and
   specific updaters
-- EquivalenceUpdaterProviderDependencies -> Holder for all the
   different dependencies the updaters may need to simplify
   constructing them
-- DefaultConfiguration -> Holder for hardcoded source groupings, e.g.
   MUSIC_SOURCES, etc.
-- UpdaterConfigurationRegistry -> Contains the updater
   configurations for each source
-- EquivModule -> Is only responsible for injecting the dependencies
   and iterating over the registry to construct and register each
   updater according to its configuration