### PR TITLE
Add Amazon Unbox to sources RT can equiv to

### DIFF
--- a/src/main/java/org/atlasapi/equiv/update/updaters/configuration/UpdaterConfigurationRegistry.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/configuration/UpdaterConfigurationRegistry.java
@@ -35,13 +35,13 @@ import static org.atlasapi.equiv.update.updaters.types.ContainerEquivalenceUpdat
 import static org.atlasapi.equiv.update.updaters.types.ItemEquivalenceUpdaterType.BETTY_ITEM;
 import static org.atlasapi.equiv.update.updaters.types.ItemEquivalenceUpdaterType.BROADCAST_ITEM;
 import static org.atlasapi.equiv.update.updaters.types.ItemEquivalenceUpdaterType.BT_VOD_ITEM;
-import static org.atlasapi.equiv.update.updaters.types.ItemEquivalenceUpdaterType.STRICT_ITEM;
 import static org.atlasapi.equiv.update.updaters.types.ItemEquivalenceUpdaterType.MUSIC_ITEM;
 import static org.atlasapi.equiv.update.updaters.types.ItemEquivalenceUpdaterType.NOP_ITEM;
 import static org.atlasapi.equiv.update.updaters.types.ItemEquivalenceUpdaterType.ROVI_ITEM;
 import static org.atlasapi.equiv.update.updaters.types.ItemEquivalenceUpdaterType.RT_ITEM;
 import static org.atlasapi.equiv.update.updaters.types.ItemEquivalenceUpdaterType.RT_UPCOMING_ITEM;
 import static org.atlasapi.equiv.update.updaters.types.ItemEquivalenceUpdaterType.STANDARD_ITEM;
+import static org.atlasapi.equiv.update.updaters.types.ItemEquivalenceUpdaterType.STRICT_ITEM;
 import static org.atlasapi.equiv.update.updaters.types.ItemEquivalenceUpdaterType.VOD_ITEM;
 import static org.atlasapi.equiv.update.updaters.types.ItemEquivalenceUpdaterType
         .VOD_WITH_SERIES_SEQUENCE_ITEM;
@@ -228,7 +228,7 @@ public class UpdaterConfigurationRegistry {
                 .withSource(RADIO_TIMES)
                 .withItemEquivalenceUpdater(
                         RT_ITEM,
-                        ImmutableSet.of(PREVIEW_NETWORKS)
+                        ImmutableSet.of(PREVIEW_NETWORKS, AMAZON_UNBOX)
                 )
                 .withTopLevelContainerEquivalenceUpdater(
                         NOP_CONTAINER,


### PR DESCRIPTION
- This is to allow equivalence between films in the two datasets that
  do not exist in the PA dataset