### PR TITLE
fix two edge cases in equivalence scorer

### DIFF
--- a/src/main/java/org/atlasapi/equiv/scorers/TitleMatchingItemScorer.java
+++ b/src/main/java/org/atlasapi/equiv/scorers/TitleMatchingItemScorer.java
@@ -160,31 +160,37 @@ public class TitleMatchingItemScorer implements EquivalenceScorer<Item> {
     }
 
     private Score partialTitleScore(String subjectTitle, String suggestionTitle) {
-        if (subjectTitle.indexOf(':') == 0) {
-            subjectTitle = subjectTitle.substring(1);
-        }
-        if (suggestionTitle.indexOf(':') == 0) {
-            suggestionTitle = suggestionTitle.substring(1);
-        }
-        if (subjectTitle.contains(":") && suggestionTitle.contains(":")) {
-            String subjTitle = normalizeWithoutReplacing(subjectTitle);
+
+        String subjectTitleWithoutLeadingColons = removeLeadingColons(subjectTitle);
+        String suggestionTitleWithoutLeadingColons = removeLeadingColons(suggestionTitle);
+
+        String subjTitle = normalizeWithoutReplacing(subjectTitleWithoutLeadingColons);
+        String suggTitle = normalizeWithoutReplacing(suggestionTitleWithoutLeadingColons);
+
+        if (subjTitle.contains(":") && suggTitle.contains(":")) {
+
             subjTitle = subjTitle.substring(0, subjTitle.indexOf(":"));
-            String suggTitle = normalizeWithoutReplacing(suggestionTitle);
             suggTitle = suggTitle.substring(0, suggTitle.indexOf(":"));
             return subjTitle.equals(suggTitle) ? Score.valueOf(1D) : scoreOnMismatch;
-        } else if (subjectTitle.contains(":") && subjectTitle.length() > suggestionTitle.length()) {
-            String subjTitle = normalizeWithoutReplacing(subjectTitle);
-            String suggTitle = normalizeWithoutReplacing(suggestionTitle);
+        } else if (subjTitle.contains(":") && subjTitle.length() > suggTitle.length()) {
+
             String subjSubstring = subjTitle.substring(0, subjTitle.indexOf(":"));
             return subjSubstring.equals(suggTitle) ? Score.valueOf(1D) : scoreOnMismatch;
-        } else if (suggestionTitle.contains(":")) {
-            String subjTitle = normalizeWithoutReplacing(subjectTitle);
-            String suggTitle = normalizeWithoutReplacing(suggestionTitle);
+        } else if (suggTitle.contains(":")) {
+
             String suggSubstring = suggTitle.substring(0, suggestionTitle.indexOf(":"));
             return suggSubstring.equals(subjTitle) ? Score.valueOf(1D) : scoreOnMismatch;
         }
 
         return scoreOnMismatch;
+    }
+
+    private String removeLeadingColons(String title) {
+        Pattern colonsAtStart = Pattern.compile(":+(.*)");
+
+        Matcher titleMatcher = colonsAtStart.matcher(title);
+
+        return titleMatcher.matches() ? titleMatcher.group(1) : title;
     }
 
     private String normalize(String title) {

--- a/src/test/java/org/atlasapi/equiv/scorers/TitleMatchingItemScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/scorers/TitleMatchingItemScorerTest.java
@@ -200,18 +200,21 @@ public class TitleMatchingItemScorerTest extends TestCase {
     public void testForOutOfBoundsException() {
         DefaultDescription desc = new DefaultDescription();
         score(0, scorer.score(itemWithTitle("Storage Hunters"), of(itemWithTitle(":Storage Hunters: UK")), desc));
+        score(2, scorer.score(itemWithTitle("Storage Hunters"), of(itemWithTitle(":Storage Hunters:")), desc));
     }
 
     @Test
     public void testForMultipleColonsToStart() {
         DefaultDescription desc = new DefaultDescription();
         score(0, scorer.score(itemWithTitle("Storage Hunters"), of(itemWithTitle("::::Storage Hunters: UK")), desc));
+        score(2, scorer.score(itemWithTitle("Storage Hunters"), of(itemWithTitle("::::Storage Hunters")), desc));
     }
 
     @Test
     public void testForPrefixRemovalBug() {
         DefaultDescription desc = new DefaultDescription();
         score(0, scorer.score(itemWithTitle("Storage: Bunters"), of(itemWithTitle(" 5 : Storage Hunters")), desc));
+        score(2, scorer.score(itemWithTitle("Storage: Hunters"), of(itemWithTitle(" 5 : Storage Hunters")), desc));
     }
     
     private void score(double expected, ScoredCandidates<Item> scores) {

--- a/src/test/java/org/atlasapi/equiv/scorers/TitleMatchingItemScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/scorers/TitleMatchingItemScorerTest.java
@@ -6,10 +6,10 @@ import junit.framework.TestCase;
 import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.scorers.TitleMatchingItemScorer;
 import org.atlasapi.equiv.scorers.TitleMatchingItemScorer.TitleType;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
+
 import org.junit.Test;
 
 import com.google.common.collect.Iterables;
@@ -199,9 +199,20 @@ public class TitleMatchingItemScorerTest extends TestCase {
     @Test
     public void testForOutOfBoundsException() {
         DefaultDescription desc = new DefaultDescription();
-        score(1, scorer.score(itemWithTitle("Storage Hunters"), of(itemWithTitle(":Storage Hunters: UK")), desc));
+        score(0, scorer.score(itemWithTitle("Storage Hunters"), of(itemWithTitle(":Storage Hunters: UK")), desc));
     }
 
+    @Test
+    public void testForMultipleColonsToStart() {
+        DefaultDescription desc = new DefaultDescription();
+        score(0, scorer.score(itemWithTitle("Storage Hunters"), of(itemWithTitle("::::Storage Hunters: UK")), desc));
+    }
+
+    @Test
+    public void testForPrefixRemovalBug() {
+        DefaultDescription desc = new DefaultDescription();
+        score(0, scorer.score(itemWithTitle("Storage: Bunters"), of(itemWithTitle(" 5 : Storage Hunters")), desc));
+    }
     
     private void score(double expected, ScoredCandidates<Item> scores) {
         Score value = Iterables.getOnlyElement(scores.candidates().entrySet()).getValue();


### PR DESCRIPTION
Edge case 1 - title starts with more than one ':' throwing OOB
Edge case 2 - title starts with a number followed by a colon and matches a regex throwing OOB

Due to these changes, titles with a leading ':' may be less likely to get a partial match, but these should be rare anyway. These changes are reflected in the test alterations