### PR TITLE
reconfigure RT upcoming equivalence

### DIFF
--- a/src/main/java/org/atlasapi/equiv/update/updaters/configuration/UpdaterConfigurationRegistry.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/configuration/UpdaterConfigurationRegistry.java
@@ -28,7 +28,7 @@ import static org.atlasapi.equiv.update.updaters.types.ContainerEquivalenceUpdat
 import static org.atlasapi.equiv.update.updaters.types.ContainerEquivalenceUpdaterType
         .RTE_VOD_CONTAINER;
 import static org.atlasapi.equiv.update.updaters.types.ContainerEquivalenceUpdaterType
-        .RT_UPCOMING_TOP_LEVEL_CONTAINER;
+        .RT_UPCOMING_CONTAINER;
 import static org.atlasapi.equiv.update.updaters.types.ContainerEquivalenceUpdaterType
         .STANDARD_SERIES;
 import static org.atlasapi.equiv.update.updaters.types.ContainerEquivalenceUpdaterType
@@ -199,11 +199,11 @@ public class UpdaterConfigurationRegistry {
                         ImmutableSet.of(AMAZON_UNBOX, PA)
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        RT_UPCOMING_TOP_LEVEL_CONTAINER,
+                        RT_UPCOMING_CONTAINER,
                         ImmutableSet.of(AMAZON_UNBOX, PA)
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        STANDARD_SERIES,
+                        RT_UPCOMING_CONTAINER,
                         ImmutableSet.of(AMAZON_UNBOX, PA)
                 )
                 .build();

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/RtUpcomingContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/RtUpcomingContainerUpdaterProvider.java
@@ -34,14 +34,14 @@ import org.atlasapi.media.entity.Publisher;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
-public class RtUpcomingTopLevelContainerUpdaterProvider
+public class RtUpcomingContainerUpdaterProvider
         implements EquivalenceUpdaterProvider<Container> {
 
-    private RtUpcomingTopLevelContainerUpdaterProvider() {
+    private RtUpcomingContainerUpdaterProvider() {
     }
 
-    public static RtUpcomingTopLevelContainerUpdaterProvider create() {
-        return new RtUpcomingTopLevelContainerUpdaterProvider();
+    public static RtUpcomingContainerUpdaterProvider create() {
+        return new RtUpcomingContainerUpdaterProvider();
     }
 
     @Override

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/RtUpcomingItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/RtUpcomingItemUpdaterProvider.java
@@ -4,6 +4,8 @@ import java.util.Set;
 
 import org.atlasapi.equiv.generators.BroadcastMatchingItemEquivalenceGenerator;
 import org.atlasapi.equiv.generators.EquivalenceGenerator;
+import org.atlasapi.equiv.generators.ExpandingTitleTransformer;
+import org.atlasapi.equiv.generators.TitleSearchGenerator;
 import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
 import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
 import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
@@ -55,12 +57,11 @@ public class RtUpcomingItemUpdaterProvider implements EquivalenceUpdaterProvider
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerators(
                         ImmutableSet.<EquivalenceGenerator<Item>>of(
-                                new BroadcastMatchingItemEquivalenceGenerator(
-                                        dependencies.getScheduleResolver(),
-                                        dependencies.getChannelResolver(),
+                                TitleSearchGenerator.create(
+                                        dependencies.getSearchResolver(),
+                                        Item.class,
                                         targetPublishers,
-                                        Duration.standardMinutes(5),
-                                        Predicates.alwaysTrue()
+                                        2.0
                                 )
                         )
                 )

--- a/src/main/java/org/atlasapi/equiv/update/updaters/types/ContainerEquivalenceUpdaterType.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/types/ContainerEquivalenceUpdaterType.java
@@ -5,8 +5,7 @@ import org.atlasapi.equiv.update.updaters.providers.container.BroadcastItemConta
 import org.atlasapi.equiv.update.updaters.providers.container.BtVodContainerUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.container.FacebookContainerUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.container.NopContainerUpdaterProvider;
-import org.atlasapi.equiv.update.updaters.providers.container
-        .RtUpcomingTopLevelContainerUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.container.RtUpcomingContainerUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.container.RteContainerUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.container.StandardSeriesUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.container
@@ -26,8 +25,8 @@ public enum ContainerEquivalenceUpdaterType {
     STANDARD_SERIES(
             StandardSeriesUpdaterProvider.create()
     ),
-    RT_UPCOMING_TOP_LEVEL_CONTAINER(
-            RtUpcomingTopLevelContainerUpdaterProvider.create()
+    RT_UPCOMING_CONTAINER(
+            RtUpcomingContainerUpdaterProvider.create()
     ),
     BROADCAST_ITEM_CONTAINER(
             BroadcastItemContainerUpdaterProvider.create()


### PR DESCRIPTION
The same updater provider is going to be used for top level containers and non top level containers for RTU, hence some renaming
TitleSearchGenerator is now used for Items as they have no broadcasts to generate from
