### PR TITLE
fix bug where null uri gets passed to images which then does not resolve

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/amazonunbox/AmazonUnboxContentExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/amazonunbox/AmazonUnboxContentExtractor.java
@@ -384,7 +384,7 @@ public class AmazonUnboxContentExtractor implements ContentExtractor<AmazonUnbox
     }
 
     private List<Image> generateImages(AmazonUnboxItem item) {
-        if (item.getLargeImageUrl() == null) {
+        if (Strings.isNullOrEmpty(item.getLargeImageUrl())) {
             return ImmutableList.of();
         }
         Image image = new Image(item.getLargeImageUrl());

--- a/src/main/java/org/atlasapi/remotesite/amazonunbox/AmazonUnboxContentExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/amazonunbox/AmazonUnboxContentExtractor.java
@@ -384,6 +384,9 @@ public class AmazonUnboxContentExtractor implements ContentExtractor<AmazonUnbox
     }
 
     private List<Image> generateImages(AmazonUnboxItem item) {
+        if (item.getLargeImageUrl() == null) {
+            return ImmutableList.of();
+        }
         Image image = new Image(item.getLargeImageUrl());
         image.setType(ImageType.PRIMARY);
         image.setWidth(320);

--- a/src/test/java/org/atlasapi/remotesite/amazonunbox/AmazonUnboxContentExtractorTest.java
+++ b/src/test/java/org/atlasapi/remotesite/amazonunbox/AmazonUnboxContentExtractorTest.java
@@ -374,6 +374,18 @@ public class AmazonUnboxContentExtractorTest {
         assertNull(series.getParent());
     }
 
+    @Test
+    public void testImageExtractionHandlesNullImageUris() {
+        AmazonUnboxItem amazonUnboxItem =
+                createAmazonUnboxItem("seasonAsin", ContentType.TVSEASON)
+                        .withLargeImageUrl(null)
+                        .build();
+
+        Series series = (Series) Iterables.getOnlyElement(extractor.extract(amazonUnboxItem));
+
+        assertEquals(0, series.getImages().size());
+    }
+
     /**
      * Creates a Builder object for an AmazonUnboxItem, defaulting enough fields to
      * ensure that content extraction will succeed. Any of these fields can be overridden,

--- a/src/test/java/org/atlasapi/remotesite/amazonunbox/AmazonUnboxContentExtractorTest.java
+++ b/src/test/java/org/atlasapi/remotesite/amazonunbox/AmazonUnboxContentExtractorTest.java
@@ -386,6 +386,18 @@ public class AmazonUnboxContentExtractorTest {
         assertEquals(0, series.getImages().size());
     }
 
+    @Test
+    public void testImageExtractionHandlesEmptyImageUris() {
+        AmazonUnboxItem amazonUnboxItem =
+                createAmazonUnboxItem("seasonAsin", ContentType.TVSEASON)
+                        .withLargeImageUrl("")
+                        .build();
+
+        Series series = (Series) Iterables.getOnlyElement(extractor.extract(amazonUnboxItem));
+
+        assertEquals(0, series.getImages().size());
+    }
+
     /**
      * Creates a Builder object for an AmazonUnboxItem, defaulting enough fields to
      * ensure that content extraction will succeed. Any of these fields can be overridden,


### PR DESCRIPTION
We found a series with an image in images with a null uri and it caused issues
This should prevent this from happening in the future