### PR TITLE
stop person from being written if they have no name

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/pa/people/PaPeopleProcessor.java
+++ b/src/main/java/org/atlasapi/remotesite/pa/people/PaPeopleProcessor.java
@@ -42,9 +42,8 @@ public class PaPeopleProcessor {
         Person person;
         if (!optionalPerson.isPresent()) {
             return;
-        } else {
-            person = optionalPerson.get();
         }
+        person = optionalPerson.get();
         Optional<Person> existing = personResolver.person(person.getCanonicalUri());
         if (!existing.isPresent()) {
             personWriter.createOrUpdatePerson(person);


### PR DESCRIPTION
PA are sending us people with no names, this is being set as null in the database and being thrown out by search, therefore not indexed, therefore not discoverable in search, therefore can't be equivalated.