### PR TITLE
Sanitise existing channel images

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/pa/channels/PaChannelDataHandler.java
+++ b/src/main/java/org/atlasapi/remotesite/pa/channels/PaChannelDataHandler.java
@@ -212,38 +212,47 @@ public class PaChannelDataHandler {
         }
     }
 
+    Iterable<TemporalField<Image>> updateImages(Channel newChannel, Channel existingChannel) {
+        if (!Iterables.isEmpty(newChannel.getAllImages())) {
+            if (!Iterables.isEmpty(existingChannel.getAllImages())) {
+                return updateImages(newChannel.getAllImages(), existingChannel.getAllImages());
+            } else {
+                return newChannel.getAllImages();
+            }
+        }
+
+        return existingChannel.getAllImages();
+    }
+
     // We need to update the existing channel images to avoid overwriting all existing images every
     // time we ingest PA channels. This should go away once we implement channel equivalence.
-    Iterable<TemporalField<Image>> updateImages(Channel newChannel, Channel existingChannel) {
+    private Iterable<TemporalField<Image>> updateImages(
+            Iterable<TemporalField<Image>> newImages,
+            Iterable<TemporalField<Image>> existingImages
+    ) {
+        Set<ImageTheme> newThemes = StreamSupport
+                .stream(newImages.spliterator(), false)
+                .map(image -> image.getValue().getTheme())
+                .collect(Collectors.toSet());
 
-        Map<ImageTheme, TemporalField<Image>> newImageMap = StreamSupport.stream(
-                newChannel.getAllImages().spliterator(),
-                false
-        )
-                .collect(MoreCollectors.toImmutableMap(
-                        temporalImage -> temporalImage.getValue().getTheme(),
-                        temporalImage -> temporalImage
-                ));
+        Set<ImageTheme> existingThemes = StreamSupport
+                .stream(existingImages.spliterator(), false)
+                .map(image -> image.getValue().getTheme())
+                .collect(Collectors.toSet());
 
-        Map<ImageTheme, TemporalField<Image>> existingImages =
-                StreamSupport.stream(existingChannel.getAllImages().spliterator(), false)
-                        .map(existingImage -> newImageMap.getOrDefault(
-                                existingImage.getValue().getTheme(),
-                                existingImage
-                        ))
-                        .collect(MoreCollectors.toImmutableMap(
-                                temporalImage -> temporalImage.getValue().getTheme(),
-                                temporalImage -> temporalImage
-                        ));
+        Set<ImageTheme> preservedThemes = Sets.difference(existingThemes, newThemes);
 
-        return ImmutableSet.<TemporalField<Image>>builder()
-                .addAll(existingImages.values())
-                .addAll(
-                        newImageMap.entrySet().stream()
-                                .filter(entry -> !existingImages.containsKey(entry.getKey()))
-                                .map(Entry::getValue)
-                                .collect(Collectors.toSet()))
-                .build();
+        if (preservedThemes.isEmpty()) {
+            return newImages;
+        }
+
+        Set<TemporalField<Image>> preservedImages = StreamSupport
+                .stream(existingImages.spliterator(), false)
+                .filter(image -> preservedThemes.contains(image.getValue().getTheme()))
+                .collect(Collectors.toSet());
+
+        return Sets.union(Sets.newHashSet(newImages), preservedImages);
+
     }
 
     private boolean isPaAlias(String alias) {

--- a/src/main/java/org/atlasapi/remotesite/pa/channels/PaChannelDataHandler.java
+++ b/src/main/java/org/atlasapi/remotesite/pa/channels/PaChannelDataHandler.java
@@ -167,14 +167,7 @@ public class PaChannelDataHandler {
         if (existing.hasValue()) {
             Channel existingChannel = existing.requireValue();
 
-            if (!Iterables.isEmpty(newChannel.getAllImages())) {
-                if (!Iterables.isEmpty(existingChannel.getAllImages())) {
-                    existingChannel.setImages(updateImages(newChannel, existingChannel));
-                } else {
-                    existingChannel.setImages(newChannel.getAllImages());
-                }
-            }
-
+            existingChannel.setImages(updateImages(newChannel, existingChannel));
             existingChannel.setTitles(newChannel.getAllTitles());
             existingChannel.setAdult(newChannel.getAdult());
             existingChannel.setStartDate(newChannel.getStartDate());

--- a/src/test/java/org/atlasapi/remotesite/pa/channels/PaChannelDataHandlerTest.java
+++ b/src/test/java/org/atlasapi/remotesite/pa/channels/PaChannelDataHandlerTest.java
@@ -1,5 +1,6 @@
 package org.atlasapi.remotesite.pa.channels;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 
 import com.google.common.collect.Sets;
@@ -11,16 +12,13 @@ import org.atlasapi.media.channel.ChannelWriter;
 import org.atlasapi.media.channel.TemporalField;
 import org.atlasapi.media.entity.Image;
 import org.atlasapi.media.entity.ImageTheme;
-import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Set;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -29,6 +27,7 @@ public class PaChannelDataHandlerTest {
 
     private Channel existingChannel;
     private Channel newChannel;
+    private TemporalField<Image> existingImage;
     private PaChannelDataHandler channelDataHandler;
     private LocalDate now;
 
@@ -52,14 +51,15 @@ public class PaChannelDataHandlerTest {
 
         now = LocalDate.now();
 
-        Image existingImage = Image.builder("existing uri").withTheme(ImageTheme.DARK_MONOCHROME).build();
-        existingChannel = Channel.builder().withImage(existingImage).build();
+        newChannel = Channel.builder().build();
+        existingChannel = Channel.builder().build();
+
+        existingImage = makeTemporalImage("existingUri", ImageTheme.DARK_MONOCHROME, null, null);
+        existingChannel.setImages(ImmutableSet.of(existingImage));
     }
 
     @Test
     public void dontUpdateImagesIfNewChannelDoesntHaveImages() {
-        newChannel = Channel.builder().build();
-
         existingChannel.setImages(channelDataHandler.updateImages(newChannel, existingChannel));
 
         assertTrue(Iterables.size(existingChannel.getAllImages()) == 1);
@@ -67,34 +67,100 @@ public class PaChannelDataHandlerTest {
 
     @Test
     public void updateExistingImageDetailsIfImagesThemeMatch() {
-        Image newImage = Image.builder("new uri").withTheme(ImageTheme.DARK_MONOCHROME).build();
-        newChannel = Channel.builder().withImage(newImage).build();
+        TemporalField<Image> newImage = makeTemporalImage("newUri", ImageTheme.DARK_MONOCHROME, null, null);
 
-        existingChannel.setImages(channelDataHandler.updateImages(newChannel, existingChannel));
-
-        assertTrue(Iterables.size(existingChannel.getAllImages()) == 1);
-        assertEquals(existingChannel.getAllImages().iterator().next().getValue().getCanonicalUri(), "new uri");
-    }
-
-    @Test
-    public void addNewImageIfItDoesntExist() {
-        Image newImage = Image.builder("new uri").withTheme(ImageTheme.LIGHT_MONOCHROME).build();
-        newChannel = Channel.builder().build();
-        newChannel.addImage(newImage, now.plusDays(1), now.plusDays(5));
+        newChannel.setImages(ImmutableSet.of(newImage));
 
         existingChannel.setImages(channelDataHandler.updateImages(newChannel, existingChannel));
 
         Set<TemporalField<Image>> images = Sets.newHashSet(existingChannel.getAllImages());
 
-        assertTrue(Iterables.size(existingChannel.getAllImages()) == 2);
+        assertThat(images.size(), is(1));
+        assertThat(Iterables.getOnlyElement(images), is(newImage));
+    }
 
-        images.forEach(image -> {
-            if (newImage.getCanonicalUri().equals(image.getValue().getCanonicalUri())) {
-                assertThat(image.getStartDate(), is(now.plusDays(1)));
-                assertThat(image.getEndDate(), is(now.plusDays(5)));
-            }
-        });
+    @Test
+    public void addNewImageIfItDoesntExist() {
+        TemporalField<Image> newImage = makeTemporalImage("newImage", ImageTheme.LIGHT_MONOCHROME, null, null);
 
+        newChannel.setImages(ImmutableSet.of(newImage));
+
+        existingChannel.setImages(channelDataHandler.updateImages(newChannel, existingChannel));
+
+        Set<TemporalField<Image>> images = Sets.newHashSet(existingChannel.getAllImages());
+
+        assertThat(images.size(), is(2));
+        assertTrue(images.contains(newImage));
+        assertTrue(images.contains(existingImage));
+    }
+
+    @Test
+    public void existingImageIsUpdatedWithEndDate() {
+        TemporalField<Image> existingGood = makeTemporalImage("existingGood", ImageTheme.LIGHT_OPAQUE, now.minusMonths(1), null);
+
+        TemporalField<Image> existingGoodUpdated = makeTemporalImage("existingGood", ImageTheme.LIGHT_OPAQUE, now.minusMonths(1), now.plusDays(2));
+        TemporalField<Image> futureGoodReplacement = makeTemporalImage("futureGoodReplacement", ImageTheme.LIGHT_OPAQUE, now.plusDays(2), now.plusMonths(1));
+
+        existingChannel.setImages(ImmutableSet.of(existingGood));
+        newChannel.setImages(ImmutableSet.of(existingGoodUpdated, futureGoodReplacement));
+
+        existingChannel.setImages(channelDataHandler.updateImages(newChannel, existingChannel));
+
+        Set<TemporalField<Image>> images = Sets.newHashSet(existingChannel.getAllImages());
+
+        assertThat(images.size(), is(2));
+        assertTrue(images.contains(existingGoodUpdated));
+        assertTrue(images.contains(futureGoodReplacement));
+    }
+
+    @Test
+    public void addsSameImageThemeIfDatesAreValid() {
+        TemporalField<Image> badImage1 = makeTemporalImage("badImage1", ImageTheme.LIGHT_OPAQUE, null, null);
+        TemporalField<Image> badImage2 = makeTemporalImage("badImage2", ImageTheme.LIGHT_OPAQUE, null, null);
+
+        TemporalField<Image> goodImage1 = makeTemporalImage("goodImage1", ImageTheme.LIGHT_OPAQUE, now.minusMonths(1), now.minusDays(2));
+        TemporalField<Image> goodImage2 = makeTemporalImage("goodImage2", ImageTheme.LIGHT_OPAQUE, now.minusDays(2), now.plusMonths(1));
+
+        existingChannel.setImages(ImmutableSet.of(badImage1, badImage2));
+        newChannel.setImages(ImmutableSet.of(goodImage1, goodImage2));
+
+        existingChannel.setImages(channelDataHandler.updateImages(newChannel, existingChannel));
+
+        Set<TemporalField<Image>> images = Sets.newHashSet(existingChannel.getAllImages());
+
+        assertThat(images.size(), is(2));
+        assertTrue(images.contains(goodImage1));
+        assertTrue(images.contains(goodImage2));
+    }
+
+    @Test
+    public void badImagesAreStrippedFromChannelImagesAndReplacedWithGood() {
+        TemporalField<Image> badPrimary1 = makeTemporalImage("primary1", ImageTheme.LIGHT_OPAQUE, null, null);
+        TemporalField<Image> badPrimary2 = makeTemporalImage("primary2", ImageTheme.LIGHT_OPAQUE, null, null);
+
+        TemporalField<Image> goodPrimary1 = makeTemporalImage("goodPrimary", ImageTheme.LIGHT_OPAQUE, now.minusDays(2), null);
+
+        existingChannel.setImages(ImmutableSet.of(badPrimary1, badPrimary2));
+        newChannel = Channel.builder().build();
+        newChannel.setImages(ImmutableSet.of(goodPrimary1));
+
+        existingChannel.setImages(channelDataHandler.updateImages(newChannel, existingChannel));
+
+        Set<TemporalField<Image>> images = Sets.newHashSet(existingChannel.getAllImages());
+
+        assertThat(images.size(), is(1));
+        assertThat(Iterables.getOnlyElement(images), is(goodPrimary1));
 
     }
+
+    private TemporalField<Image> makeTemporalImage(
+            String uri,
+            ImageTheme theme,
+            LocalDate start,
+            LocalDate end
+    ) {
+        Image image = Image.builder(uri).withTheme(theme).build();
+        return new TemporalField<>(image, start, end);
+    }
+
 }


### PR DESCRIPTION
Existing images that were ingested without dates persisted and caused issues
as there were duplicate themes for valid dates. This should clean those up
while preserving the logic.