### PR TITLE
Fix failing on first exception

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/bt/channels/AbstractBtChannelGroupSaver.java
+++ b/src/main/java/org/atlasapi/remotesite/bt/channels/AbstractBtChannelGroupSaver.java
@@ -101,7 +101,7 @@ public abstract class AbstractBtChannelGroupSaver {
             setCurrentChannelsToChannelGroup(channelGroup, currentChannels);
             channelGroupWriter.createOrUpdate(channelGroup);
             channelGroupUris.add(channelGroup.getCanonicalUri());
-        };
+        }
         return channelGroupUris.build();
     }
 
@@ -133,7 +133,6 @@ public abstract class AbstractBtChannelGroupSaver {
                         channelGroup.getId(),
                         e
                 );
-                throw new RuntimeException(e);
             }
         }
 


### PR DESCRIPTION
When the ingest run and found a channel it could not process, the whole
job would fail. This logs the exception and should continue to process.