### PR TITLE
Add an exact match check to equiv TitleSubset scorer.

### DIFF
--- a/src/main/java/org/atlasapi/equiv/scorers/TitleSubsetBroadcastItemScorer.java
+++ b/src/main/java/org/atlasapi/equiv/scorers/TitleSubsetBroadcastItemScorer.java
@@ -13,7 +13,6 @@ import org.atlasapi.media.entity.Item;
 import org.atlasapi.persistence.content.ContentResolver;
 
 import com.google.common.base.CharMatcher;
-import com.google.common.base.Function;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
@@ -29,7 +28,12 @@ import com.google.common.collect.Sets;
  * </p>
  * <p>
  * Common words are ignored. Words are trimmed of non-
- * {@link CharMatcher.JAVA_LETTER} characters.
+ * {@link CharMatcher#JAVA_LETTER} characters.
+ * </p>
+ * <p>
+ * Before performing the sub-set match, an exact (case-insensitive) comparison
+ * will be performed, to catch simple cases where titles are made up purely of
+ * common words and/or non-letter characters (e.g. "The 100").
  * </p>
  */
 public final class TitleSubsetBroadcastItemScorer extends BaseBroadcastItemScorer {
@@ -44,15 +48,10 @@ public final class TitleSubsetBroadcastItemScorer extends BaseBroadcastItemScore
             .omitEmptyStrings();
 
     private final Ordering<Collection<?>> collectionSize = Ordering.natural()
-            .onResultOf(new Function<Collection<?>, Integer>() {
-                @Override
-                public Integer apply(Collection<?> input) {
-                    return input.size();
-                }
-            });
+            .onResultOf(Collection::size);
     private final Set<String> commonWords = ImmutableSet.of(
-        "the", "in", "a", "and", "&", "of", "to", "show"
-    );
+        "the", "in", "a", "an","and", "of", "to", "show"
+    );  // don't bother with things like "&" as we only care about letter characters
 
     private final double threshold;
 
@@ -83,52 +82,62 @@ public final class TitleSubsetBroadcastItemScorer extends BaseBroadcastItemScore
 
     @Override
     protected boolean subjectAndCandidateMatch(Item subject, Item candidate) {
-        return subsetOfShorterTitleContainedInLonger(subject, candidate);
+        return titlesMatch(subject, candidate);
     }
 
     @Override
     protected boolean subjectContainerAndCandidateMatch(Container subjectContainer, Item candidate) {
-        return subsetOfShorterTitleContainedInLonger(subjectContainer, candidate);
+        return titlesMatch(subjectContainer, candidate);
     }
 
     @Override
     protected boolean subjectAndCandidateContainerMatch(Item subject, Container candidateContainer) {
-        return subsetOfShorterTitleContainedInLonger(subject, candidateContainer);
+        return titlesMatch(subject, candidateContainer);
     }
 
-    private boolean subsetOfShorterTitleContainedInLonger(Content subject, Content candidate) {
+    private boolean titlesMatch(Content subject, Content candidate) {
         if (titleMissing(subject) || titleMissing(candidate)) {
             return false;
         }
-        String sanitizedSubjectTitle = sanitize(subject.getTitle());
-        String sanitizedCandidateTitle = sanitize(candidate.getTitle());
-        Set<String> subjectWords = filterCommon(titleWords(sanitizedSubjectTitle));
-        Set<String> candidateWords = filterCommon(titleWords(sanitizedCandidateTitle));
+        String subjectTitle = sanitize(subject.getTitle());
+        String candidateTitle = sanitize(candidate.getTitle());
+        return titlesEqual(subjectTitle, candidateTitle)
+                || subsetOfShorterInLonger(subjectTitle, candidateTitle);
+    }
+
+    private boolean titleMissing(Content subject) {
+        return Strings.isNullOrEmpty(subject.getTitle());
+    }
+
+    private String sanitize(String title) {
+        return titleTransformer.expand(title).toLowerCase();
+    }
+
+    private boolean titlesEqual(String subjectTitle, String candidateTitle) {
+        return false && subjectTitle.equals(candidateTitle);
+    }
+
+    private boolean subsetOfShorterInLonger(String subjectTitle, String candidateTitle) {
+        Set<String> subjectWords = filterCommon(titleWords(subjectTitle));
+        Set<String> candidateWords = filterCommon(titleWords(candidateTitle));
         Set<String> shorter = collectionSize.min(subjectWords, candidateWords);
         Set<String> longer = collectionSize.max(candidateWords, subjectWords);
         return percentOfShorterInLonger(shorter, longer) >= threshold;
     }
 
-    private String sanitize(String title) {
-        return titleTransformer.expand(title)
-                .replaceAll("[^\\d\\w\\s]", "").toLowerCase();
+    private ImmutableSet<String> titleWords(String title) {
+        return ImmutableSet.copyOf(splitter.split(
+                title.replaceAll("[^\\d\\w\\s]", "")
+        ));
     }
 
     private Set<String> filterCommon(Set<String> words) {
         return Sets.difference(words, commonWords);
     }
 
-    private ImmutableSet<String> titleWords(String title) {
-        return ImmutableSet.copyOf(splitter.split(title));
-    }
-
     private double percentOfShorterInLonger(Set<String> shorter, Set<String> longer) {
         int contained = Sets.intersection(shorter, longer).size();
         return (contained * 1.0) / shorter.size();
-    }
-
-    private boolean titleMissing(Content subject) {
-        return Strings.isNullOrEmpty(subject.getTitle());
     }
 
 }

--- a/src/main/java/org/atlasapi/equiv/scorers/TitleSubsetBroadcastItemScorer.java
+++ b/src/main/java/org/atlasapi/equiv/scorers/TitleSubsetBroadcastItemScorer.java
@@ -114,7 +114,7 @@ public final class TitleSubsetBroadcastItemScorer extends BaseBroadcastItemScore
     }
 
     private boolean titlesEqual(String subjectTitle, String candidateTitle) {
-        return false && subjectTitle.equals(candidateTitle);
+        return subjectTitle.equals(candidateTitle);
     }
 
     private boolean subsetOfShorterInLonger(String subjectTitle, String candidateTitle) {

--- a/src/test/java/org/atlasapi/equiv/scorers/TitleSubsetBroadcastItemScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/scorers/TitleSubsetBroadcastItemScorerTest.java
@@ -24,19 +24,28 @@ public class TitleSubsetBroadcastItemScorerTest {
         = new TitleSubsetBroadcastItemScorer(resolver, Score.nullScore(), 100);
     
     @Test
-    public void testMatches() {
+    public void testCommonWordsMatches() {
         assertEquals(Score.ONE, score(
-            itemWithTitle("The Ren & Stimpy Show"), 
-            itemWithTitle("Ren and Stimpy!")
+                itemWithTitle("The Ren & Stimpy Show"),
+                itemWithTitle("Ren and Stimpy!")
         ));
         assertEquals(Score.ONE, score(
-            itemWithTitle("New: Uncle"), 
-            itemWithTitle("Uncle")
+                itemWithTitle("New: Uncle"),
+                itemWithTitle("Uncle")
         ));
+    }
+
+    @Test
+    public void testOtherMatches() {
+        // TODO: MBST-18584 this shouldn't match...
         assertEquals(Score.ONE, score(
-            itemWithTitle("Doctor Who?"), 
-            itemWithTitle("Doctor Who Confidential")
+                itemWithTitle("Doctor Who?"),
+                itemWithTitle("Doctor Who Confidential")
         ));
+    }
+
+    @Test
+    public void testPunctuationMatches() {
         assertEquals(Score.ONE, score(
                 itemWithTitle("Power Rangers: R.P.M."),
                 itemWithTitle("Power Rangers RPM")
@@ -45,9 +54,17 @@ public class TitleSubsetBroadcastItemScorerTest {
                 itemWithTitle("Power - Rangers: R.P.M.!!"),
                 itemWithTitle("Power Rangers RPM")
         ));
+    }
+
+    @Test
+    public void testOnlyCommonOrIgnored() {
         assertEquals(Score.ONE, score(
                 itemWithTitle("The 100"),
                 itemWithTitle("the 100")
+        ));
+        assertEquals(Score.ONE, score(
+                itemWithTitle("The BIG Show"),
+                itemWithTitle("the big show")
         ));
     }
     

--- a/src/test/java/org/atlasapi/equiv/scorers/TitleSubsetBroadcastItemScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/scorers/TitleSubsetBroadcastItemScorerTest.java
@@ -45,6 +45,10 @@ public class TitleSubsetBroadcastItemScorerTest {
                 itemWithTitle("Power - Rangers: R.P.M.!!"),
                 itemWithTitle("Power Rangers RPM")
         ));
+        assertEquals(Score.ONE, score(
+                itemWithTitle("The 100"),
+                itemWithTitle("the 100")
+        ));
     }
     
     @Test


### PR DESCRIPTION
If there is a name consisting of purely common words, or stripped
characters then titles won't match. In this case if there's an exact
match it would make sense to return a positive score.
This scorer also originally replaced an exact match scorer, so it
simply makes it a complete replacement/improvement of the old scorer.