### PR TITLE
Made BARB equiv bidirectional as mentioned in ENG-246

### DIFF
--- a/src/main/java/org/atlasapi/equiv/update/updaters/configuration/UpdaterConfigurationRegistry.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/configuration/UpdaterConfigurationRegistry.java
@@ -788,7 +788,7 @@ public class UpdaterConfigurationRegistry {
                 .withSource(FIVE)
                 .withItemEquivalenceUpdater(
                         BARB_ITEM,
-                        ImmutableSet.of(BBC_NITRO, ITV_CPS, BARB_TRANSMISSIONS, UKTV, C4_PMLSD)
+                        ImmutableSet.of(BBC_NITRO, ITV_CPS, UKTV, C4_PMLSD)
                 )
                 .withTopLevelContainerEquivalenceUpdater(
                         STANDARD_TOP_LEVEL_CONTAINER,
@@ -807,7 +807,15 @@ public class UpdaterConfigurationRegistry {
                 .withItemEquivalenceUpdater(
                         BARB_ITEM,
                         ImmutableSet.of(
-                                BBC_NITRO, ITV_CPS, UKTV, C4_PMLSD, C5_DATA_SUBMISSION, BARB_MASTER
+                                BBC_NITRO,
+                                ITV_CPS,
+                                UKTV,
+                                C4_PMLSD,
+                                C5_DATA_SUBMISSION,
+                                BARB_MASTER,
+                                BARB_TRANSMISSIONS,
+                                BARB_X_MASTER,
+                                BARB_CENSUS
                         )
                 )
                 .withTopLevelContainerEquivalenceUpdater(
@@ -829,11 +837,11 @@ public class UpdaterConfigurationRegistry {
                         ImmutableSet.of(
                                 BBC_NITRO,
                                 ITV_CPS,
-                                BARB_MASTER,
                                 UKTV,
                                 C4_PMLSD,
                                 C5_DATA_SUBMISSION,
-                                BARB_TRANSMISSIONS
+                                BARB_TRANSMISSIONS,
+                                BARB_MASTER
                         )
                 )
                 .withTopLevelContainerEquivalenceUpdater(
@@ -852,7 +860,7 @@ public class UpdaterConfigurationRegistry {
                 .withSource(ITV_CPS)
                 .withItemEquivalenceUpdater(
                         BARB_ITEM,
-                        ImmutableSet.of(PA, BBC_NITRO, UKTV)
+                        ImmutableSet.of(PA, BBC_NITRO, UKTV, BARB_TRANSMISSIONS, BARB_MASTER)
                 )
                 .withTopLevelContainerEquivalenceUpdater(
                         STANDARD_TOP_LEVEL_CONTAINER,
@@ -870,7 +878,7 @@ public class UpdaterConfigurationRegistry {
                 .withSource(BBC_NITRO)
                 .withItemEquivalenceUpdater(
                         STANDARD_ITEM,
-                        ImmutableSet.of(PA, UKTV)
+                        ImmutableSet.of(PA, UKTV, BARB_TRANSMISSIONS, BARB_MASTER)
                 )
                 .withTopLevelContainerEquivalenceUpdater(
                         STANDARD_TOP_LEVEL_CONTAINER,
@@ -888,7 +896,7 @@ public class UpdaterConfigurationRegistry {
                 .withSource(C4_PMLSD)
                 .withItemEquivalenceUpdater(
                         BARB_ITEM,
-                        ImmutableSet.of(PA, RADIO_TIMES)
+                        ImmutableSet.of(PA, RADIO_TIMES, BARB_TRANSMISSIONS, BARB_MASTER)
                 )
                 .withTopLevelContainerEquivalenceUpdater(
                         STANDARD_TOP_LEVEL_CONTAINER,
@@ -906,7 +914,7 @@ public class UpdaterConfigurationRegistry {
                 .withSource(UKTV)
                 .withItemEquivalenceUpdater(
                         BARB_ITEM,
-                        ImmutableSet.of(PA, RADIO_TIMES)
+                        ImmutableSet.of(PA, RADIO_TIMES, BARB_TRANSMISSIONS, BARB_MASTER)
                 )
                 .withTopLevelContainerEquivalenceUpdater(
                         STANDARD_TOP_LEVEL_CONTAINER,
@@ -924,7 +932,7 @@ public class UpdaterConfigurationRegistry {
                 .withSource(C5_DATA_SUBMISSION)
                 .withItemEquivalenceUpdater(
                         BARB_ITEM,
-                        ImmutableSet.of(PA, RADIO_TIMES)
+                        ImmutableSet.of(PA, RADIO_TIMES, BARB_TRANSMISSIONS, BARB_MASTER)
                 )
                 .withTopLevelContainerEquivalenceUpdater(
                         STANDARD_TOP_LEVEL_CONTAINER,

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/TxlogsItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/TxlogsItemUpdaterProvider.java
@@ -102,12 +102,15 @@ public class TxlogsItemUpdaterProvider implements EquivalenceUpdaterProvider<Ite
                         ))
                 )
                 .withExtractor(
-                        //If we equiv on bcid (scoring 10) then we don't want to equiv on broadcast time
-                        //This is due to an issue where some CMS and Txlog broadcasts have become incorrect
-                        //and we had ended up with txlogs equived on bcid to one piece of CMS content but to
-                        //another piece of CMS content (generally belonging to the same brand) on broadcast time.
-                        //Since BARB equivalence is primarily driven by bcid equiv this should not prove problematic
-                        //if we end up excluding some legitimate broadcast equiv since it will at least be equived on bcid
+                        // If we equiv on bcid (scoring 10) then we don't want to equiv on broadcast time
+                        // This is due to an issue where some CMS and Txlog broadcasts have become incorrect
+                        // and we had ended up with txlogs equived on bcid to one piece of CMS content but to
+                        // another piece of CMS content (generally belonging to the same brand) on broadcast time.
+                        // Since BARB equivalence is primarily driven by bcid equiv this should not prove problematic
+                        // if we end up excluding some legitimate broadcast equiv since it will at least be equived on bcid
+                        //
+                        // N.B. extractors extract individually by publisher so if the highest threshold for
+                        // one source is 10, we can still extract other publishers whose highest threshold was 4
                         new AllOverOrEqHighestNonEmptyThresholdExtractor<>(ImmutableSet.of(10D, 4D))
                 )
                 .withHandler(


### PR DESCRIPTION
When/if equiv writing is updated to properly cope with
unidirectional equiv then these changes can be
undone.