### PR TITLE
Different equiv for different target publishers

### DIFF
--- a/src/main/java/org/atlasapi/equiv/generators/AliasResolvingEquivalenceGenerator.java
+++ b/src/main/java/org/atlasapi/equiv/generators/AliasResolvingEquivalenceGenerator.java
@@ -1,22 +1,16 @@
 package org.atlasapi.equiv.generators;
 
-import java.math.BigInteger;
-
+import com.google.common.collect.Iterables;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates.Builder;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.persistence.content.ContentResolver;
 import org.atlasapi.persistence.content.ResolvedContent;
-
-import com.metabroadcast.common.ids.NumberToShortStringCodec;
-import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
-
-import com.google.common.collect.Iterables;
 
 public class AliasResolvingEquivalenceGenerator<T extends Content> implements EquivalenceGenerator<T> {
 
@@ -36,7 +30,7 @@ public class AliasResolvingEquivalenceGenerator<T extends Content> implements Eq
     public ScoredCandidates<T> generate(
             T content,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         Builder<T> equivalents = DefaultScoredCandidates.fromSource("Alias");
         desc.startStage("Resolving aliases:");
@@ -63,7 +57,7 @@ public class AliasResolvingEquivalenceGenerator<T extends Content> implements Eq
        }
        desc.appendText("Missed %s", resolved.getUnresolved().size());
 
-       equivToTelescopeResults.addGeneratorResult(generatorComponent);
+       equivToTelescopeResult.addGeneratorResult(generatorComponent);
 
        return equivalents.build();
     }

--- a/src/main/java/org/atlasapi/equiv/generators/BarbAliasEquivalenceGeneratorAndScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/BarbAliasEquivalenceGeneratorAndScorer.java
@@ -11,7 +11,7 @@ import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Alias;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Publisher;
@@ -84,13 +84,13 @@ public class BarbAliasEquivalenceGeneratorAndScorer<T extends Content> implement
     public ScoredCandidates<T> generate(
             T subject,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         DefaultScoredCandidates.Builder<T> equivalents =
                 DefaultScoredCandidates.fromSource("Barb Alias");
 
         if (!(subject.getAliases().isEmpty())) {
-            equivalents = findByCommonAlias(subject, equivalents, desc, equivToTelescopeResults);
+            equivalents = findByCommonAlias(subject, equivalents, desc, equivToTelescopeResult);
         }
 
         return equivalents.build();
@@ -101,7 +101,7 @@ public class BarbAliasEquivalenceGeneratorAndScorer<T extends Content> implement
             T subject,
             DefaultScoredCandidates.Builder<T> equivalents,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
 
         desc.startStage("Resolving Barb Aliases:");
@@ -152,7 +152,7 @@ public class BarbAliasEquivalenceGeneratorAndScorer<T extends Content> implement
                     }
                 });
 
-        equivToTelescopeResults.addGeneratorResult(generatorComponent);
+        equivToTelescopeResult.addGeneratorResult(generatorComponent);
 
         return equivalents;
     }

--- a/src/main/java/org/atlasapi/equiv/generators/BroadcastMatchingItemEquivalenceGeneratorAndScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/BroadcastMatchingItemEquivalenceGeneratorAndScorer.java
@@ -1,7 +1,13 @@
 package org.atlasapi.equiv.generators;
 
-import java.util.Set;
-
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Maps.EntryTransformer;
+import com.google.common.collect.Sets;
+import com.metabroadcast.common.base.Maybe;
+import com.metabroadcast.common.time.DateTimeZones;
 import org.atlasapi.equiv.generators.metadata.EquivalenceGeneratorMetadata;
 import org.atlasapi.equiv.generators.metadata.SourceLimitedEquivalenceGeneratorMetadata;
 import org.atlasapi.equiv.results.description.ResultDescription;
@@ -10,7 +16,7 @@ import org.atlasapi.equiv.results.scores.DefaultScoredCandidates.Builder;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.channel.Channel;
 import org.atlasapi.media.channel.ChannelResolver;
 import org.atlasapi.media.entity.Broadcast;
@@ -20,18 +26,10 @@ import org.atlasapi.media.entity.Schedule;
 import org.atlasapi.media.entity.Schedule.ScheduleChannel;
 import org.atlasapi.media.entity.Version;
 import org.atlasapi.persistence.content.ScheduleResolver;
-
-import com.metabroadcast.common.base.Maybe;
-import com.metabroadcast.common.time.DateTimeZones;
-
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Maps.EntryTransformer;
-import com.google.common.collect.Sets;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
+
+import java.util.Set;
 
 public class BroadcastMatchingItemEquivalenceGeneratorAndScorer implements EquivalenceGenerator<Item>{
 
@@ -105,7 +103,7 @@ public class BroadcastMatchingItemEquivalenceGeneratorAndScorer implements Equiv
     public ScoredCandidates<Item> generate(
             Item content,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
 
         Builder<Item> scores = DefaultScoredCandidates.fromSource("broadcast");
@@ -139,7 +137,7 @@ public class BroadcastMatchingItemEquivalenceGeneratorAndScorer implements Equiv
             }
         }
 
-        equivToTelescopeResults.addGeneratorResult(generatorComponent);
+        equivToTelescopeResult.addGeneratorResult(generatorComponent);
 
         desc.appendText("Processed %s of %s broadcasts", processedBroadcasts, totalBroadcasts);
 

--- a/src/main/java/org/atlasapi/equiv/generators/ContainerCandidatesContainerEquivalenceGenerator.java
+++ b/src/main/java/org/atlasapi/equiv/generators/ContainerCandidatesContainerEquivalenceGenerator.java
@@ -1,10 +1,10 @@
 package org.atlasapi.equiv.generators;
 
-import java.util.List;
-import java.util.Objects;
-
-import javax.annotation.Nullable;
-
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.metabroadcast.common.collect.OptionalMap;
 import org.atlasapi.equiv.ContentRef;
 import org.atlasapi.equiv.EquivalenceSummary;
 import org.atlasapi.equiv.EquivalenceSummaryStore;
@@ -14,7 +14,7 @@ import org.atlasapi.equiv.results.scores.DefaultScoredCandidates.Builder;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Brand;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Identified;
@@ -24,11 +24,9 @@ import org.atlasapi.media.entity.SeriesRef;
 import org.atlasapi.persistence.content.ContentResolver;
 import org.atlasapi.persistence.content.ResolvedContent;
 
-import com.google.common.base.Function;
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.metabroadcast.common.collect.OptionalMap;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Generates equivalences for an non-top-level Container based on the children of the equivalences
@@ -60,7 +58,7 @@ public class ContainerCandidatesContainerEquivalenceGenerator
     public ScoredCandidates<Container> generate(
             Container subject,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         Builder<Container> result = DefaultScoredCandidates.fromSource("Container");
         EquivToTelescopeComponent generatorComponent = EquivToTelescopeComponent.create();
@@ -90,7 +88,7 @@ public class ContainerCandidatesContainerEquivalenceGenerator
             }
         }
 
-        equivToTelescopeResults.addGeneratorResult(generatorComponent);
+        equivToTelescopeResult.addGeneratorResult(generatorComponent);
 
         return result.build();
     }

--- a/src/main/java/org/atlasapi/equiv/generators/ContainerCandidatesItemEquivalenceGenerator.java
+++ b/src/main/java/org/atlasapi/equiv/generators/ContainerCandidatesItemEquivalenceGenerator.java
@@ -1,10 +1,11 @@
 package org.atlasapi.equiv.generators;
 
-import java.util.List;
-import java.util.Objects;
-
-import javax.annotation.Nullable;
-
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.metabroadcast.common.collect.OptionalMap;
 import org.atlasapi.equiv.EquivalenceSummary;
 import org.atlasapi.equiv.EquivalenceSummaryStore;
 import org.atlasapi.equiv.results.description.ResultDescription;
@@ -13,7 +14,7 @@ import org.atlasapi.equiv.results.scores.DefaultScoredCandidates.Builder;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.ChildRef;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Identified;
@@ -22,12 +23,9 @@ import org.atlasapi.media.entity.ParentRef;
 import org.atlasapi.persistence.content.ContentResolver;
 import org.atlasapi.persistence.content.ResolvedContent;
 
-import com.google.common.base.Function;
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.metabroadcast.common.collect.OptionalMap;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Generates equivalences for an Item based on the children of the equivalence
@@ -58,7 +56,7 @@ public class ContainerCandidatesItemEquivalenceGenerator implements EquivalenceG
     public ScoredCandidates<Item> generate(
             Item subject,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         Builder<Item> result = DefaultScoredCandidates.fromSource("Container");
 
@@ -87,7 +85,7 @@ public class ContainerCandidatesItemEquivalenceGenerator implements EquivalenceG
             }
         }
 
-        equivToTelescopeResults.addGeneratorResult(generatorComponent);
+        equivToTelescopeResult.addGeneratorResult(generatorComponent);
 
         return result.build();
     }

--- a/src/main/java/org/atlasapi/equiv/generators/ContainerChildEquivalenceGenerator.java
+++ b/src/main/java/org/atlasapi/equiv/generators/ContainerChildEquivalenceGenerator.java
@@ -1,5 +1,13 @@
 package org.atlasapi.equiv.generators;
 
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.base.Predicates;
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Multiset;
+import com.metabroadcast.common.base.Maybe;
+import com.metabroadcast.common.collect.OptionalMap;
 import org.atlasapi.equiv.ContentRef;
 import org.atlasapi.equiv.EquivalenceSummary;
 import org.atlasapi.equiv.EquivalenceSummaryStore;
@@ -9,21 +17,12 @@ import org.atlasapi.equiv.results.scores.DefaultScoredCandidates.Builder;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.ChildRef;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Identified;
 import org.atlasapi.persistence.content.ContentResolver;
 import org.atlasapi.persistence.content.ResolvedContent;
-
-import com.google.common.base.Function;
-import com.google.common.base.Optional;
-import com.google.common.base.Predicates;
-import com.google.common.collect.HashMultiset;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Multiset;
-import com.metabroadcast.common.base.Maybe;
-import com.metabroadcast.common.collect.OptionalMap;
 
 public class ContainerChildEquivalenceGenerator implements EquivalenceGenerator<Container> {
     
@@ -51,7 +50,7 @@ public class ContainerChildEquivalenceGenerator implements EquivalenceGenerator<
     public ScoredCandidates<Container> generate(
             Container content,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
 
         EquivToTelescopeComponent generatorComponent = EquivToTelescopeComponent.create();
@@ -70,7 +69,7 @@ public class ContainerChildEquivalenceGenerator implements EquivalenceGenerator<
                 parents,
                 childSummaries.size(),
                 desc,
-                equivToTelescopeResults,
+                equivToTelescopeResult,
                 generatorComponent
         );
     }
@@ -79,7 +78,7 @@ public class ContainerChildEquivalenceGenerator implements EquivalenceGenerator<
             Multiset<String> parents,
             int children,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults,
+            EquivToTelescopeResult equivToTelescopeResult,
             EquivToTelescopeComponent generatorComponent
     ) {
         Builder<Container> candidates = DefaultScoredCandidates.fromSource(NAME);
@@ -118,7 +117,7 @@ public class ContainerChildEquivalenceGenerator implements EquivalenceGenerator<
             }
         }
 
-        equivToTelescopeResults.addGeneratorResult(generatorComponent);
+        equivToTelescopeResult.addGeneratorResult(generatorComponent);
         
         return candidates.build();
     }

--- a/src/main/java/org/atlasapi/equiv/generators/ContentTitleScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/ContentTitleScorer.java
@@ -1,17 +1,15 @@
 package org.atlasapi.equiv.generators;
 
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates.Builder;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
 import org.atlasapi.media.entity.Content;
-
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.base.Function;
 
 public final class ContentTitleScorer<T extends Content> {
     

--- a/src/main/java/org/atlasapi/equiv/generators/EquivalenceGenerator.java
+++ b/src/main/java/org/atlasapi/equiv/generators/EquivalenceGenerator.java
@@ -4,14 +4,14 @@ import org.atlasapi.equiv.generators.metadata.EquivalenceGeneratorMetadata;
 import org.atlasapi.equiv.generators.metadata.GenericEquivalenceGeneratorMetadata;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 
 public interface EquivalenceGenerator<T> {
 
     ScoredCandidates<T> generate(
             T subject,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     );
 
     default EquivalenceGeneratorMetadata getMetadata() {

--- a/src/main/java/org/atlasapi/equiv/generators/EquivalenceGenerators.java
+++ b/src/main/java/org/atlasapi/equiv/generators/EquivalenceGenerators.java
@@ -1,20 +1,17 @@
 package org.atlasapi.equiv.generators;
 
-import java.util.List;
-import java.util.Set;
-
-import org.atlasapi.equiv.results.description.ResultDescription;
-import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
-import org.atlasapi.media.entity.Content;
-
-import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
-import com.metabroadcast.common.stream.MoreCollectors;
-
-import com.google.api.client.util.Lists;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
+import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
+import com.metabroadcast.common.stream.MoreCollectors;
+import org.atlasapi.equiv.results.description.ResultDescription;
+import org.atlasapi.equiv.results.scores.ScoredCandidates;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
+import org.atlasapi.media.entity.Content;
+
+import java.util.List;
+import java.util.Set;
 
 public class EquivalenceGenerators<T extends Content> {
 
@@ -45,7 +42,7 @@ public class EquivalenceGenerators<T extends Content> {
     public List<ScoredCandidates<T>> generate(
             T content,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         desc.startStage("Generating equivalences");
         Builder<ScoredCandidates<T>> generatedScores = ImmutableList.builder();
@@ -68,7 +65,7 @@ public class EquivalenceGenerators<T extends Content> {
         for (EquivalenceGenerator<T> generator : generators) {
             try {
                 desc.startStage(generator.toString());
-                generatedScores.add(generator.generate(content, desc, equivToTelescopeResults));
+                generatedScores.add(generator.generate(content, desc, equivToTelescopeResult));
                 desc.finishStage();
             } catch (Exception e) {
                 throw new RuntimeException(String.format("Exception running %s for %s", generator, content), e);

--- a/src/main/java/org/atlasapi/equiv/generators/ExactTitleGenerator.java
+++ b/src/main/java/org/atlasapi/equiv/generators/ExactTitleGenerator.java
@@ -14,7 +14,7 @@ import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Described;
 import org.atlasapi.media.entity.Publisher;
@@ -63,7 +63,7 @@ public class ExactTitleGenerator<T extends Content> implements EquivalenceGenera
     public ScoredCandidates<T> generate(
             T content,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent generatorComponent = EquivToTelescopeComponent.create();
         generatorComponent.setComponentName("Exact Title Generator");

--- a/src/main/java/org/atlasapi/equiv/generators/FilmEquivalenceGenerator.java
+++ b/src/main/java/org/atlasapi/equiv/generators/FilmEquivalenceGenerator.java
@@ -1,10 +1,13 @@
 package org.atlasapi.equiv.generators;
 
-import java.util.List;
-import java.util.Set;
-import java.util.regex.Pattern;
-
+import com.google.common.base.Objects;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.metabroadcast.applications.client.model.internal.Application;
+import com.metabroadcast.common.base.Maybe;
+import com.metabroadcast.common.query.Selection;
 import org.atlasapi.equiv.generators.metadata.EquivalenceGeneratorMetadata;
 import org.atlasapi.equiv.generators.metadata.SourceLimitedEquivalenceGeneratorMetadata;
 import org.atlasapi.equiv.results.description.ResultDescription;
@@ -13,7 +16,7 @@ import org.atlasapi.equiv.results.scores.DefaultScoredCandidates.Builder;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Film;
 import org.atlasapi.media.entity.Identified;
 import org.atlasapi.media.entity.Item;
@@ -21,14 +24,9 @@ import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.persistence.content.SearchResolver;
 import org.atlasapi.search.model.SearchQuery;
 
-import com.metabroadcast.common.base.Maybe;
-import com.metabroadcast.common.query.Selection;
-
-import com.google.common.base.Objects;
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
 
 import static com.google.common.collect.Iterables.filter;
 
@@ -85,7 +83,7 @@ public class FilmEquivalenceGenerator implements EquivalenceGenerator<Item> {
     public ScoredCandidates<Item> generate(
             Item item,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         Builder<Item> scores = DefaultScoredCandidates.fromSource("Film");
 
@@ -100,13 +98,13 @@ public class FilmEquivalenceGenerator implements EquivalenceGenerator<Item> {
         
         if (!acceptNullYears && film.getYear() == null ) {
             desc.appendText("Can't generate: null year");
-            equivToTelescopeResults.addGeneratorResult(generatorComponent);
+            equivToTelescopeResult.addGeneratorResult(generatorComponent);
             return scores.build();
         }
         
         if (Strings.isNullOrEmpty(film.getTitle())) {
             desc.appendText("Can't generate: title '%s'", film.getTitle()).finishStage();
-            equivToTelescopeResults.addGeneratorResult(generatorComponent);
+            equivToTelescopeResult.addGeneratorResult(generatorComponent);
             return scores.build();
         } else {
             desc.appendText("Using year %s, title %s", film.getYear(), film.getTitle());
@@ -178,7 +176,7 @@ public class FilmEquivalenceGenerator implements EquivalenceGenerator<Item> {
             }
         }
 
-        equivToTelescopeResults.addGeneratorResult(generatorComponent);
+        equivToTelescopeResult.addGeneratorResult(generatorComponent);
         return scores.build();
     }
 

--- a/src/main/java/org/atlasapi/equiv/generators/RadioTimesFilmEquivalenceGenerator.java
+++ b/src/main/java/org/atlasapi/equiv/generators/RadioTimesFilmEquivalenceGenerator.java
@@ -1,28 +1,24 @@
 package org.atlasapi.equiv.generators;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import javax.annotation.Nullable;
-
+import com.google.common.collect.ImmutableSet;
+import com.metabroadcast.common.base.Maybe;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates.Builder;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Film;
 import org.atlasapi.media.entity.Identified;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.persistence.content.ContentResolver;
 import org.atlasapi.persistence.content.ResolvedContent;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableSet;
-import com.metabroadcast.common.base.Maybe;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class RadioTimesFilmEquivalenceGenerator implements EquivalenceGenerator<Item> {
 
@@ -39,7 +35,7 @@ public class RadioTimesFilmEquivalenceGenerator implements EquivalenceGenerator<
     public ScoredCandidates<Item> generate(
             Item content,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         checkArgument(content instanceof Film, "Content not Film:" + content.getCanonicalUri());
 

--- a/src/main/java/org/atlasapi/equiv/generators/ScalingEquivalenceGenerator.java
+++ b/src/main/java/org/atlasapi/equiv/generators/ScalingEquivalenceGenerator.java
@@ -1,12 +1,11 @@
 package org.atlasapi.equiv.generators;
 
+import com.google.common.base.Function;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScaledScoredEquivalents;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Content;
-
-import com.google.common.base.Function;
 
 public class ScalingEquivalenceGenerator<T extends Content> implements EquivalenceGenerator<T> {
 
@@ -49,12 +48,12 @@ public class ScalingEquivalenceGenerator<T extends Content> implements Equivalen
     public ScoredCandidates<T> generate(
             T content,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         return ScaledScoredEquivalents.<T>scale(delegate.generate(
                 content,
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ), scalingFunction);
     }
 

--- a/src/main/java/org/atlasapi/equiv/generators/TitleSearchGenerator.java
+++ b/src/main/java/org/atlasapi/equiv/generators/TitleSearchGenerator.java
@@ -17,7 +17,7 @@ import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Described;
 import org.atlasapi.media.entity.Publisher;
@@ -120,7 +120,7 @@ public class TitleSearchGenerator<T extends Content> implements EquivalenceGener
     public ScoredCandidates<T> generate(
             T content,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent generatorComponent = EquivToTelescopeComponent.create();
         generatorComponent.setComponentName("Title Search Generator");

--- a/src/main/java/org/atlasapi/equiv/handlers/DelegatingEquivalenceResultHandler.java
+++ b/src/main/java/org/atlasapi/equiv/handlers/DelegatingEquivalenceResultHandler.java
@@ -1,6 +1,6 @@
 package org.atlasapi.equiv.handlers;
 
-import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.equiv.results.EquivalenceResults;
 import org.atlasapi.media.entity.Content;
 
 public class DelegatingEquivalenceResultHandler<T extends Content>
@@ -13,11 +13,11 @@ public class DelegatingEquivalenceResultHandler<T extends Content>
     }
     
     @Override
-    public boolean handle(EquivalenceResult<T> result) {
+    public boolean handle(EquivalenceResults<T> results) {
         boolean handledWithStateChange = false;
         
         for (EquivalenceResultHandler<T> delegate  : delegates) {
-            handledWithStateChange |= delegate.handle(result);
+            handledWithStateChange |= delegate.handle(results);
         }
 
         return handledWithStateChange;

--- a/src/main/java/org/atlasapi/equiv/handlers/EpisodeFilteringEquivalenceResultHandler.java
+++ b/src/main/java/org/atlasapi/equiv/handlers/EpisodeFilteringEquivalenceResultHandler.java
@@ -90,7 +90,7 @@ public class EpisodeFilteringEquivalenceResultHandler implements EquivalenceResu
                                 result.rawScores(),
                                 result.combinedEquivalences(),
                                 filter(result.strongEquivalences(), equivalents, desc),
-                                (ReadableDescription) desc
+                                result.description()
                         )
                 )
                 .collect(MoreCollectors.toImmutableList());

--- a/src/main/java/org/atlasapi/equiv/handlers/EquivalenceResultHandler.java
+++ b/src/main/java/org/atlasapi/equiv/handlers/EquivalenceResultHandler.java
@@ -1,15 +1,15 @@
 package org.atlasapi.equiv.handlers;
 
-import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.equiv.results.EquivalenceResults;
 
 public interface EquivalenceResultHandler<T> {
 
     /**
-     * Handle the equivalence result
-     * @param result equivalence result
+     * Handle the equivalence results
+     * @param results equivalence results
      * @return false if the handler decided that the result has result in no change to the state
      * of the system and should therefore be ignored, true otherwise
      */
-    boolean handle(EquivalenceResult<T> result);
+    boolean handle(EquivalenceResults<T> results);
     
 }

--- a/src/main/java/org/atlasapi/equiv/handlers/LookupWritingEquivalenceHandler.java
+++ b/src/main/java/org/atlasapi/equiv/handlers/LookupWritingEquivalenceHandler.java
@@ -65,18 +65,20 @@ public class LookupWritingEquivalenceHandler<T extends Content>
     public boolean handle(EquivalenceResults<T> results) {
         
         // abort writing if seens as equiv and not equiv to anything
+        Set<T> strongEquivalences = results.strongEquivalences();
+
         if(seenAsEquiv.asMap().containsKey(results.subject().getCanonicalUri())
-                && results.strongEquivalences().isEmpty()) {
+                && strongEquivalences.isEmpty()) {
             return false;
         }
         
-        for (T equiv : results.strongEquivalences()) {
+        for (T equiv : strongEquivalences) {
             seenAsEquiv.getUnchecked(equiv.getCanonicalUri());
         }
 
         Optional<Set<LookupEntry>> writtenLookups = writer.writeLookup(
                 ContentRef.valueOf(results.subject()),
-                Iterables.transform(results.strongEquivalences(), ContentRef.FROM_CONTENT),
+                Iterables.transform(strongEquivalences, ContentRef.FROM_CONTENT),
                 publishers
         );
 

--- a/src/main/java/org/atlasapi/equiv/handlers/NopEquivalenceResultHandler.java
+++ b/src/main/java/org/atlasapi/equiv/handlers/NopEquivalenceResultHandler.java
@@ -1,6 +1,6 @@
 package org.atlasapi.equiv.handlers;
 
-import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.equiv.results.EquivalenceResults;
 import org.atlasapi.media.entity.Content;
 
 public class NopEquivalenceResultHandler<T extends Content> implements EquivalenceResultHandler<T> {
@@ -9,7 +9,7 @@ public class NopEquivalenceResultHandler<T extends Content> implements Equivalen
     }
 
     @Override
-    public boolean handle(EquivalenceResult<T> result) {
+    public boolean handle(EquivalenceResults<T> results) {
         return false;
     }
 }

--- a/src/main/java/org/atlasapi/equiv/handlers/NopEquivalenceResultHandler.java
+++ b/src/main/java/org/atlasapi/equiv/handlers/NopEquivalenceResultHandler.java
@@ -1,0 +1,15 @@
+package org.atlasapi.equiv.handlers;
+
+import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.media.entity.Content;
+
+public class NopEquivalenceResultHandler<T extends Content> implements EquivalenceResultHandler<T> {
+
+    public NopEquivalenceResultHandler() {
+    }
+
+    @Override
+    public boolean handle(EquivalenceResult<T> result) {
+        return false;
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/handlers/ResultWritingEquivalenceHandler.java
+++ b/src/main/java/org/atlasapi/equiv/handlers/ResultWritingEquivalenceHandler.java
@@ -1,6 +1,6 @@
 package org.atlasapi.equiv.handlers;
 
-import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.equiv.results.EquivalenceResults;
 import org.atlasapi.equiv.results.persistence.EquivalenceResultStore;
 import org.atlasapi.media.entity.Content;
 
@@ -14,8 +14,8 @@ public class ResultWritingEquivalenceHandler<T extends Content>
     }
     
     @Override
-    public boolean handle(EquivalenceResult<T> result) {
-        store.store(result);
+    public boolean handle(EquivalenceResults<T> results) {
+        store.store(results);
         return false;
     }
 }

--- a/src/main/java/org/atlasapi/equiv/messengers/EquivalenceResultMessenger.java
+++ b/src/main/java/org/atlasapi/equiv/messengers/EquivalenceResultMessenger.java
@@ -1,8 +1,8 @@
 package org.atlasapi.equiv.messengers;
 
-import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.equiv.results.EquivalenceResults;
 
 public interface EquivalenceResultMessenger<T> {
 
-    void sendMessage(EquivalenceResult<T> result);
+    void sendMessage(EquivalenceResults<T> results);
 }

--- a/src/main/java/org/atlasapi/equiv/messengers/NopEquivalenceResultMessenger.java
+++ b/src/main/java/org/atlasapi/equiv/messengers/NopEquivalenceResultMessenger.java
@@ -1,6 +1,6 @@
 package org.atlasapi.equiv.messengers;
 
-import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.equiv.results.EquivalenceResults;
 import org.atlasapi.media.entity.Content;
 
 public class NopEquivalenceResultMessenger<T extends Content> implements EquivalenceResultMessenger<T> {
@@ -9,6 +9,6 @@ public class NopEquivalenceResultMessenger<T extends Content> implements Equival
     }
 
     @Override
-    public void sendMessage(EquivalenceResult<T> result) {
+    public void sendMessage(EquivalenceResults<T> results) {
     }
 }

--- a/src/main/java/org/atlasapi/equiv/messengers/NopEquivalenceResultMessenger.java
+++ b/src/main/java/org/atlasapi/equiv/messengers/NopEquivalenceResultMessenger.java
@@ -1,0 +1,14 @@
+package org.atlasapi.equiv.messengers;
+
+import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.media.entity.Content;
+
+public class NopEquivalenceResultMessenger<T extends Content> implements EquivalenceResultMessenger<T> {
+
+    public NopEquivalenceResultMessenger() {
+    }
+
+    @Override
+    public void sendMessage(EquivalenceResult<T> result) {
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/messengers/QueueingEquivalenceResultMessenger.java
+++ b/src/main/java/org/atlasapi/equiv/messengers/QueueingEquivalenceResultMessenger.java
@@ -1,20 +1,17 @@
 package org.atlasapi.equiv.messengers;
 
-import org.atlasapi.equiv.results.EquivalenceResult;
-import org.atlasapi.equiv.results.scores.ScoredCandidate;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import com.metabroadcast.common.queue.MessageSender;
+import com.metabroadcast.common.stream.MoreCollectors;
+import com.metabroadcast.common.time.SystemClock;
+import com.metabroadcast.common.time.Timestamper;
+import org.atlasapi.equiv.results.EquivalenceResults;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.messaging.ContentEquivalenceAssertionMessenger;
 import org.atlasapi.messaging.v3.ContentEquivalenceAssertionMessage;
 import org.atlasapi.persistence.lookup.entry.LookupEntryStore;
-
-import com.metabroadcast.common.queue.MessageSender;
-import com.metabroadcast.common.stream.MoreCollectors;
-import com.metabroadcast.common.time.SystemClock;
-import com.metabroadcast.common.time.Timestamper;
-
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableSet;
 
 public class QueueingEquivalenceResultMessenger<T extends Content>
         implements EquivalenceResultMessenger<T> {
@@ -68,13 +65,10 @@ public class QueueingEquivalenceResultMessenger<T extends Content>
     }
 
     @Override
-    public void sendMessage(EquivalenceResult<T> result) {
+    public void sendMessage(EquivalenceResults<T> results) {
         messenger.sendMessage(
-                result.subject(),
-                result.strongEquivalences()
-                        .values()
-                        .stream()
-                        .map(ScoredCandidate::candidate)
+                results.subject(),
+                results.strongEquivalences().stream()
                         .collect(MoreCollectors.toImmutableList()),
                 sources.stream()
                         .map(Publisher::key)

--- a/src/main/java/org/atlasapi/equiv/results/DefaultEquivalenceResultBuilder.java
+++ b/src/main/java/org/atlasapi/equiv/results/DefaultEquivalenceResultBuilder.java
@@ -1,22 +1,5 @@
 package org.atlasapi.equiv.results;
 
-import java.util.List;
-import java.util.Set;
-
-import org.atlasapi.equiv.results.combining.ScoreCombiner;
-import org.atlasapi.equiv.results.description.ReadableDescription;
-import org.atlasapi.equiv.results.description.ResultDescription;
-import org.atlasapi.equiv.results.extractors.EquivalenceExtractor;
-import org.atlasapi.equiv.results.extractors.MultipleCandidateExtractor;
-import org.atlasapi.equiv.results.filters.EquivalenceFilter;
-import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
-import org.atlasapi.equiv.results.scores.ScoredCandidate;
-import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
-import org.atlasapi.media.entity.Content;
-import org.atlasapi.media.entity.Publisher;
-
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSortedSet;
@@ -24,6 +7,20 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.SortedSetMultimap;
 import com.google.common.collect.TreeMultimap;
+import org.atlasapi.equiv.results.combining.ScoreCombiner;
+import org.atlasapi.equiv.results.description.ReadableDescription;
+import org.atlasapi.equiv.results.description.ResultDescription;
+import org.atlasapi.equiv.results.extractors.EquivalenceExtractor;
+import org.atlasapi.equiv.results.filters.EquivalenceFilter;
+import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
+import org.atlasapi.equiv.results.scores.ScoredCandidate;
+import org.atlasapi.equiv.results.scores.ScoredCandidates;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
+import org.atlasapi.media.entity.Content;
+import org.atlasapi.media.entity.Publisher;
+
+import java.util.List;
+import java.util.Set;
 
 public class DefaultEquivalenceResultBuilder<T extends Content>
         implements EquivalenceResultBuilder<T> {
@@ -56,20 +53,20 @@ public class DefaultEquivalenceResultBuilder<T extends Content>
             T target,
             List<ScoredCandidates<T>> equivalents,
             ReadableDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
-        ScoredCandidates<T> combined = combine(equivalents, desc, equivToTelescopeResults);
+        ScoredCandidates<T> combined = combine(equivalents, desc, equivToTelescopeResult);
         List<ScoredCandidate<T>> filteredCandidates = filter(
                 target,
                 desc,
                 combined,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         Multimap<Publisher, ScoredCandidate<T>> extractedScores = extract(
                 target,
                 filteredCandidates,
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         return new EquivalenceResult<T>(target, equivalents, combined, extractedScores, desc);
     }
@@ -77,7 +74,7 @@ public class DefaultEquivalenceResultBuilder<T extends Content>
     private ScoredCandidates<T> combine(
             List<ScoredCandidates<T>> equivalents,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         desc.startStage("Combining scores");
         ScoredCandidates<T> combination;
@@ -94,7 +91,7 @@ public class DefaultEquivalenceResultBuilder<T extends Content>
             T target,
             ReadableDescription desc,
             ScoredCandidates<T> combined,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         desc.startStage("Filtering candidates");
         List<ScoredCandidate<T>> filteredCandidates = ImmutableList.copyOf(
@@ -102,7 +99,7 @@ public class DefaultEquivalenceResultBuilder<T extends Content>
                     combined.orderedCandidates(Ordering.usingToString()),
                     target,
                     desc,
-                    equivToTelescopeResults
+                    equivToTelescopeResult
             )
         );
         desc.finishStage();
@@ -113,7 +110,7 @@ public class DefaultEquivalenceResultBuilder<T extends Content>
             T target,
             List<ScoredCandidate<T>> filteredCandidates,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         desc.startStage("Extracting strong equivalents");
         SortedSetMultimap<Publisher, ScoredCandidate<T>> publisherBins =
@@ -133,7 +130,7 @@ public class DefaultEquivalenceResultBuilder<T extends Content>
                         copyOfSorted.asList().reverse(),
                         target,
                         desc,
-                        equivToTelescopeResults
+                        equivToTelescopeResult
                 );
                 if (!extracted.isEmpty()) {
                     builder.putAll(publisher, extracted);

--- a/src/main/java/org/atlasapi/equiv/results/EquivalenceResult.java
+++ b/src/main/java/org/atlasapi/equiv/results/EquivalenceResult.java
@@ -1,20 +1,17 @@
 package org.atlasapi.equiv.results;
 
-import java.util.List;
-import java.util.Map;
-
+import com.google.common.base.Function;
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
 import org.atlasapi.equiv.results.description.ReadableDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Publisher;
 
-import com.google.common.base.Function;
-import com.google.common.base.Objects;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.Multimap;
+import java.util.List;
 
 public class EquivalenceResult<T> {
     

--- a/src/main/java/org/atlasapi/equiv/results/EquivalenceResultBuilder.java
+++ b/src/main/java/org/atlasapi/equiv/results/EquivalenceResultBuilder.java
@@ -1,10 +1,10 @@
 package org.atlasapi.equiv.results;
 
-import java.util.List;
-
 import org.atlasapi.equiv.results.description.ReadableDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
+
+import java.util.List;
 
 public interface EquivalenceResultBuilder<T> {
 
@@ -12,7 +12,7 @@ public interface EquivalenceResultBuilder<T> {
             T target,
             List<ScoredCandidates<T>> equivalents,
             ReadableDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     );
 
 }

--- a/src/main/java/org/atlasapi/equiv/results/EquivalenceResults.java
+++ b/src/main/java/org/atlasapi/equiv/results/EquivalenceResults.java
@@ -1,0 +1,71 @@
+package org.atlasapi.equiv.results;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Multimap;
+import com.metabroadcast.common.stream.MoreCollectors;
+import org.atlasapi.equiv.results.description.ReadableDescription;
+import org.atlasapi.equiv.results.scores.ScoredCandidate;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+public class EquivalenceResults<T> {
+
+    private final T subject;
+    private final List<EquivalenceResult<T>> results;
+    private final ReadableDescription desc;
+
+    public EquivalenceResults(T subject, Iterable<EquivalenceResult<T>> results, ReadableDescription desc) {
+        this.subject = subject;
+        this.results = ImmutableList.copyOf(results);
+        this.desc = desc;
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(getClass())
+            .addValue(subject)
+            .add("results", results)
+            .toString();
+    }
+    
+    @Override
+    public boolean equals(Object that) {
+        if(this == that) {
+            return true;
+        }
+        if(that instanceof EquivalenceResults) {
+            EquivalenceResults<?> other = (EquivalenceResults<?>) that;
+            return Objects.equal(subject, other.subject) && Objects.equal(results, other.results);
+        }
+        return false;
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(subject, results);
+    }
+
+    public T subject() {
+        return subject;
+    }
+
+    public List<EquivalenceResult<T>> getResults() {
+        return results;
+    }
+
+    public ReadableDescription description() {
+        return desc;
+    }
+
+    public Set<T> strongEquivalences() {
+        return results.stream()
+                .map(EquivalenceResult::strongEquivalences)
+                .map(Multimap::values)
+                .flatMap(Collection::stream)
+                .map(ScoredCandidate::candidate)
+                .collect(MoreCollectors.toImmutableSet());
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/results/extractors/AllOverOrEqHighestNonEmptyThresholdExtractor.java
+++ b/src/main/java/org/atlasapi/equiv/results/extractors/AllOverOrEqHighestNonEmptyThresholdExtractor.java
@@ -6,7 +6,7 @@ import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Content;
 
 import java.util.Collection;
@@ -35,7 +35,7 @@ public class AllOverOrEqHighestNonEmptyThresholdExtractor<T extends Content> imp
             List<ScoredCandidate<T>> candidates,
             T target,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent extractorComponent = EquivToTelescopeComponent.create();
         extractorComponent.setComponentName("All over >= " + thresholds.toString());
@@ -65,7 +65,7 @@ public class AllOverOrEqHighestNonEmptyThresholdExtractor<T extends Content> imp
             }
         }
 
-        equivToTelescopeResults.addExtractorResult(extractorComponent);
+        equivToTelescopeResult.addExtractorResult(extractorComponent);
         return allowedCandidatesBuilder.build();
     }
 

--- a/src/main/java/org/atlasapi/equiv/results/extractors/AllOverOrEqThresholdExtractor.java
+++ b/src/main/java/org/atlasapi/equiv/results/extractors/AllOverOrEqThresholdExtractor.java
@@ -1,15 +1,14 @@
 package org.atlasapi.equiv.results.extractors;
 
-import java.util.List;
-import java.util.Set;
-
+import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Content;
 
-import com.google.common.collect.ImmutableSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * This extractor will select all candidates over or at the given threshold.
@@ -31,7 +30,7 @@ public class AllOverOrEqThresholdExtractor<T extends Content> implements Equival
             List<ScoredCandidate<T>> candidates,
             T target,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent extractorComponent = EquivToTelescopeComponent.create();
         extractorComponent.setComponentName("All over >= " + threshold);
@@ -53,7 +52,7 @@ public class AllOverOrEqThresholdExtractor<T extends Content> implements Equival
             }
         }
 
-        equivToTelescopeResults.addExtractorResult(extractorComponent);
+        equivToTelescopeResult.addExtractorResult(extractorComponent);
         return allowedCandidatesBuilder.build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/results/extractors/AllThatTieAtTopExtractor.java
+++ b/src/main/java/org/atlasapi/equiv/results/extractors/AllThatTieAtTopExtractor.java
@@ -1,15 +1,14 @@
 package org.atlasapi.equiv.results.extractors;
 
-import java.util.List;
-import java.util.Set;
-
+import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Content;
 
-import com.google.common.collect.ImmutableSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * This extractor will select all candidates that tie at the top score, over or equal to the
@@ -32,7 +31,7 @@ public class AllThatTieAtTopExtractor<T extends Content> implements EquivalenceE
             List<ScoredCandidate<T>> candidates,
             T target,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent extractorComponent = EquivToTelescopeComponent.create();
         extractorComponent.setComponentName("All that tie at the top and >= " + threshold);
@@ -66,7 +65,7 @@ public class AllThatTieAtTopExtractor<T extends Content> implements EquivalenceE
                     );
                 }
             }
-            equivToTelescopeResults.addExtractorResult(extractorComponent);
+            equivToTelescopeResult.addExtractorResult(extractorComponent);
             return allowedCandidates;
         } else {
             return ImmutableSet.of();

--- a/src/main/java/org/atlasapi/equiv/results/extractors/AllWithTheSameHighscoreAndPublisherExtractor.java
+++ b/src/main/java/org/atlasapi/equiv/results/extractors/AllWithTheSameHighscoreAndPublisherExtractor.java
@@ -1,15 +1,14 @@
 package org.atlasapi.equiv.results.extractors;
 
-import java.util.List;
-import java.util.Set;
-
+import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Content;
 
-import com.google.common.collect.ImmutableSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * This extractor will select all candidates at the best score from the publisher of the target
@@ -32,7 +31,7 @@ public class AllWithTheSameHighscoreAndPublisherExtractor<T extends Content> imp
             List<ScoredCandidate<T>> candidates,
             T target,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent extractorComponent = EquivToTelescopeComponent.create();
         extractorComponent.setComponentName("All at the top from the content's publisher and >= "
@@ -71,7 +70,7 @@ public class AllWithTheSameHighscoreAndPublisherExtractor<T extends Content> imp
             }
         }
 
-        equivToTelescopeResults.addExtractorResult(extractorComponent);
+        equivToTelescopeResult.addExtractorResult(extractorComponent);
         return allowedCandidatesBuilder.build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/results/extractors/ContinueUntilOneWorksExtractor.java
+++ b/src/main/java/org/atlasapi/equiv/results/extractors/ContinueUntilOneWorksExtractor.java
@@ -1,15 +1,14 @@
 package org.atlasapi.equiv.results.extractors;
 
-import java.util.List;
-import java.util.Set;
-
+import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Content;
 
-import com.google.common.collect.ImmutableSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * This extractor will attempt the delegates one by one, until one of them provides at least one
@@ -34,7 +33,7 @@ public class ContinueUntilOneWorksExtractor<T extends Content> implements Equiva
             List<ScoredCandidate<T>> candidates,
             T target,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         if (candidates.isEmpty()) {
             return ImmutableSet.of();
@@ -48,16 +47,16 @@ public class ContinueUntilOneWorksExtractor<T extends Content> implements Equiva
                     candidates,
                     target,
                     desc,
-                    equivToTelescopeResults
+                    equivToTelescopeResult
             );
             if(!extracted.isEmpty()){
-                equivToTelescopeResults.addExtractorResult(extractorComponent);
+                equivToTelescopeResult.addExtractorResult(extractorComponent);
                 return extracted;
             }
         }
 
         //we wont be adding any results for presentation, we expect the underlying extractors to do that.
-        equivToTelescopeResults.addExtractorResult(extractorComponent);
+        equivToTelescopeResult.addExtractorResult(extractorComponent);
 
         return ImmutableSet.of();
     }

--- a/src/main/java/org/atlasapi/equiv/results/extractors/EquivalenceExtractor.java
+++ b/src/main/java/org/atlasapi/equiv/results/extractors/EquivalenceExtractor.java
@@ -1,13 +1,11 @@
 package org.atlasapi.equiv.results.extractors;
 
-import java.util.List;
-import java.util.Set;
-
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 
-import com.google.common.base.Optional;
+import java.util.List;
+import java.util.Set;
 
 
 public interface EquivalenceExtractor<T> {
@@ -23,7 +21,7 @@ public interface EquivalenceExtractor<T> {
             List<ScoredCandidate<T>> candidates,
             T subject,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     );
     
 }

--- a/src/main/java/org/atlasapi/equiv/results/extractors/ExcludePublisherThenExtractExtractor.java
+++ b/src/main/java/org/atlasapi/equiv/results/extractors/ExcludePublisherThenExtractExtractor.java
@@ -1,19 +1,17 @@
 package org.atlasapi.equiv.results.extractors;
 
-import java.util.List;
-import java.util.Set;
-
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.metabroadcast.common.stream.MoreCollectors;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Publisher;
 
-import com.metabroadcast.common.stream.MoreCollectors;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * This extractor will filter OUT all canidates from the given list of publishers,
@@ -43,7 +41,7 @@ public class ExcludePublisherThenExtractExtractor<T extends Content> implements 
             List<ScoredCandidate<T>> candidates,
             T target,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         if (candidates.isEmpty()) {
             return ImmutableSet.of();
@@ -53,7 +51,7 @@ public class ExcludePublisherThenExtractExtractor<T extends Content> implements 
         extractorComponent.setComponentName("Exclude results from " + publishers + ", then get the results from the extractor.");
 
         //we wont be adding any results for presentation, we expect the underlying extractors to do that.
-        equivToTelescopeResults.addExtractorResult(extractorComponent);
+        equivToTelescopeResult.addExtractorResult(extractorComponent);
 
         //remove the results, then get the results of the extractor extractor.
         ImmutableList<ScoredCandidate<T>> reducedCandidates
@@ -61,7 +59,7 @@ public class ExcludePublisherThenExtractExtractor<T extends Content> implements 
                 .filter(c -> !publishers.contains(c.candidate().getPublisher()))
                 .collect(MoreCollectors.toImmutableList());
         Set<ScoredCandidate<T>> results
-                = extractor.extract(reducedCandidates, target, desc, equivToTelescopeResults);
+                = extractor.extract(reducedCandidates, target, desc, equivToTelescopeResult);
 
         return results;
     }

--- a/src/main/java/org/atlasapi/equiv/results/extractors/MultipleCandidateExtractor.java
+++ b/src/main/java/org/atlasapi/equiv/results/extractors/MultipleCandidateExtractor.java
@@ -1,25 +1,21 @@
 package org.atlasapi.equiv.results.extractors;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import org.atlasapi.equiv.results.DefaultEquivalenceResultBuilder;
+import com.google.common.collect.ImmutableSet;
+import com.metabroadcast.common.stream.MoreCollectors;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Brand;
 import org.atlasapi.media.entity.Broadcast;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Series;
-
-import com.metabroadcast.common.stream.MoreCollectors;
-
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableSet;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * This extractor attempts to get multiple candidates for the same publisher. It will only do this
@@ -50,7 +46,7 @@ public class MultipleCandidateExtractor<T extends Content> implements Equivalenc
             List<ScoredCandidate<T>> candidates,
             T target,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent extractorComponent = EquivToTelescopeComponent.create();
         extractorComponent.setComponentName("Multiple Candidate Extractor");
@@ -93,7 +89,7 @@ public class MultipleCandidateExtractor<T extends Content> implements Equivalenc
                 }
         );
 
-        equivToTelescopeResults.addExtractorResult(extractorComponent);
+        equivToTelescopeResult.addExtractorResult(extractorComponent);
 
         if (allowedCandidates.size() > 1) {
             return allowedCandidates;

--- a/src/main/java/org/atlasapi/equiv/results/extractors/MusicEquivalenceExtractor.java
+++ b/src/main/java/org/atlasapi/equiv/results/extractors/MusicEquivalenceExtractor.java
@@ -1,17 +1,16 @@
 package org.atlasapi.equiv.results.extractors;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Item;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 public class MusicEquivalenceExtractor implements EquivalenceExtractor<Item> {
 
@@ -23,7 +22,7 @@ public class MusicEquivalenceExtractor implements EquivalenceExtractor<Item> {
             List<ScoredCandidate<Item>> candidates,
             Item subject,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent extractorComponent = EquivToTelescopeComponent.create();
         extractorComponent.setComponentName("Music Equivalence Extractor");

--- a/src/main/java/org/atlasapi/equiv/results/extractors/NothingEquivalenceExtractor.java
+++ b/src/main/java/org/atlasapi/equiv/results/extractors/NothingEquivalenceExtractor.java
@@ -1,15 +1,13 @@
 package org.atlasapi.equiv.results.extractors;
 
-import java.util.List;
-import java.util.Set;
-
+import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Content;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableSet;
+import java.util.List;
+import java.util.Set;
 
 public class NothingEquivalenceExtractor<T extends Content> implements EquivalenceExtractor<T> {
 
@@ -18,7 +16,7 @@ public class NothingEquivalenceExtractor<T extends Content> implements Equivalen
             List<ScoredCandidate<T>> equivalents,
             T sujbect,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         return ImmutableSet.of();
     }

--- a/src/main/java/org/atlasapi/equiv/results/extractors/PercentThresholdAboveNextBestMatchEquivalenceExtractor.java
+++ b/src/main/java/org/atlasapi/equiv/results/extractors/PercentThresholdAboveNextBestMatchEquivalenceExtractor.java
@@ -97,6 +97,8 @@ public class PercentThresholdAboveNextBestMatchEquivalenceExtractor<T>
         
         desc.appendText("%s not extracted. Strongest score of %s doesn't beat next best from %s of %s.", strongest.candidate(), strongest.score(), 
                     nextBest.candidate(), nextBest.score());
+
+        desc.finishStage();
         
         return ImmutableSet.of();
     }

--- a/src/main/java/org/atlasapi/equiv/results/extractors/PercentThresholdAboveNextBestMatchEquivalenceExtractor.java
+++ b/src/main/java/org/atlasapi/equiv/results/extractors/PercentThresholdAboveNextBestMatchEquivalenceExtractor.java
@@ -1,16 +1,14 @@
 package org.atlasapi.equiv.results.extractors;
 
-import java.util.List;
-import java.util.Set;
-
+import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Content;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Selects the candidate with the highest score, so long as its score
@@ -38,7 +36,7 @@ public class PercentThresholdAboveNextBestMatchEquivalenceExtractor<T>
             List<ScoredCandidate<T>> candidates,
             T subject,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         desc.startStage(NAME);
 
@@ -59,7 +57,7 @@ public class PercentThresholdAboveNextBestMatchEquivalenceExtractor<T>
                         String.valueOf(candidates.get(0).score().asDouble())
                 );
             }
-            equivToTelescopeResults.addExtractorResult(extractorComponent);
+            equivToTelescopeResult.addExtractorResult(extractorComponent);
             desc.appendText("%s extracted. Only candidate.", candidates.get(0));
             return ImmutableSet.of(candidates.get(0));
         }
@@ -78,7 +76,7 @@ public class PercentThresholdAboveNextBestMatchEquivalenceExtractor<T>
                     ((Content) strongest.candidate()).getId(),
                     String.valueOf(strongest.score().asDouble())
             );
-            equivToTelescopeResults.addExtractorResult(extractorComponent);
+            equivToTelescopeResult.addExtractorResult(extractorComponent);
             return ImmutableSet.of(strongest);
         }
         
@@ -91,7 +89,7 @@ public class PercentThresholdAboveNextBestMatchEquivalenceExtractor<T>
                         String.valueOf(strongest.score().asDouble())
                 );
             }
-            equivToTelescopeResults.addExtractorResult(extractorComponent);
+            equivToTelescopeResult.addExtractorResult(extractorComponent);
             return ImmutableSet.of(strongest);
         }
         

--- a/src/main/java/org/atlasapi/equiv/results/extractors/PercentThresholdEquivalenceExtractor.java
+++ b/src/main/java/org/atlasapi/equiv/results/extractors/PercentThresholdEquivalenceExtractor.java
@@ -1,17 +1,15 @@
 package org.atlasapi.equiv.results.extractors;
 
-import java.util.List;
-import java.util.Set;
-
+import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Content;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Selects the candidate with the highest score given its score is above a given percentage threshold of the total of all equivalents' scores
@@ -35,7 +33,7 @@ public class PercentThresholdEquivalenceExtractor<T> implements EquivalenceExtra
             List<ScoredCandidate<T>> candidates,
             T subject,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent extractorCompoenent = EquivToTelescopeComponent.create();
         extractorCompoenent.setComponentName("Percent Threshold Equivalence Extractor");
@@ -58,7 +56,7 @@ public class PercentThresholdEquivalenceExtractor<T> implements EquivalenceExtra
                         String.valueOf(strongest.score().asDouble())
                 );
             }
-            equivToTelescopeResults.addExtractorResult(extractorCompoenent);
+            equivToTelescopeResult.addExtractorResult(extractorCompoenent);
             return ImmutableSet.of(strongest);
         }
         

--- a/src/main/java/org/atlasapi/equiv/results/extractors/RemoveAndCombineExtractor.java
+++ b/src/main/java/org/atlasapi/equiv/results/extractors/RemoveAndCombineExtractor.java
@@ -1,19 +1,17 @@
 package org.atlasapi.equiv.results.extractors;
 
-import java.util.List;
-import java.util.Set;
-
-import org.atlasapi.equiv.results.description.ResultDescription;
-import org.atlasapi.equiv.results.scores.ScoredCandidate;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
-import org.atlasapi.media.entity.Content;
-
-import com.metabroadcast.common.stream.MoreCollectors;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import com.metabroadcast.common.stream.MoreCollectors;
+import org.atlasapi.equiv.results.description.ResultDescription;
+import org.atlasapi.equiv.results.scores.ScoredCandidate;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
+import org.atlasapi.media.entity.Content;
+
+import java.util.List;
+import java.util.Set;
 
 /**
  * This extractor will select all candidates from the first extractor, then remove them from the
@@ -39,7 +37,7 @@ public class RemoveAndCombineExtractor<T extends Content> implements Equivalence
             List<ScoredCandidate<T>> candidates,
             T target,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         if (candidates.isEmpty()) {
             return ImmutableSet.of();
@@ -49,10 +47,10 @@ public class RemoveAndCombineExtractor<T extends Content> implements Equivalence
         extractorComponent.setComponentName("Get the results from first extractor, then remove them from the set, then get the results from second.");
 
         //we wont be adding any results for presentation, we expect the underlying extractors to do that.
-        equivToTelescopeResults.addExtractorResult(extractorComponent);
+        equivToTelescopeResult.addExtractorResult(extractorComponent);
 
         Set<ScoredCandidate<T>> firstResults
-                = first.extract(candidates, target, desc, equivToTelescopeResults);
+                = first.extract(candidates, target, desc, equivToTelescopeResult);
 
         //remove the results, then get the results of the second extractor.
         ImmutableList<ScoredCandidate<T>> reducedCandidates
@@ -60,7 +58,7 @@ public class RemoveAndCombineExtractor<T extends Content> implements Equivalence
                 .filter(c -> !firstResults.contains(c))
                 .collect(MoreCollectors.toImmutableList());
         Set<ScoredCandidate<T>> secondResults
-                = second.extract(reducedCandidates, target, desc, equivToTelescopeResults);
+                = second.extract(reducedCandidates, target, desc, equivToTelescopeResult);
 
         return Sets.union(firstResults, secondResults);
     }

--- a/src/main/java/org/atlasapi/equiv/results/extractors/TopEquivalenceExtractor.java
+++ b/src/main/java/org/atlasapi/equiv/results/extractors/TopEquivalenceExtractor.java
@@ -1,16 +1,14 @@
 package org.atlasapi.equiv.results.extractors;
 
-import java.util.List;
-import java.util.Set;
-
+import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Content;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Always selects a single candidate with the highest score
@@ -26,7 +24,7 @@ public class TopEquivalenceExtractor<T extends Content> implements EquivalenceEx
             List<ScoredCandidate<T>> equivalents,
             T target,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent extractorComponent = EquivToTelescopeComponent.create();
         extractorComponent.setComponentName("Top Equivalence Extractor");
@@ -42,7 +40,7 @@ public class TopEquivalenceExtractor<T extends Content> implements EquivalenceEx
             );
         }
 
-        equivToTelescopeResults.addExtractorResult(extractorComponent);
+        equivToTelescopeResult.addExtractorResult(extractorComponent);
 
         return ImmutableSet.of(equivalents.get(0));
         

--- a/src/main/java/org/atlasapi/equiv/results/filters/AbstractEquivalenceFilter.java
+++ b/src/main/java/org/atlasapi/equiv/results/filters/AbstractEquivalenceFilter.java
@@ -1,14 +1,12 @@
 package org.atlasapi.equiv.results.filters;
 
-import java.util.List;
-
-import org.atlasapi.equiv.results.description.ResultDescription;
-import org.atlasapi.equiv.results.scores.ScoredCandidate;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
-import org.atlasapi.media.entity.Equiv;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
+import org.atlasapi.equiv.results.description.ResultDescription;
+import org.atlasapi.equiv.results.scores.ScoredCandidate;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
+
+import java.util.List;
 
 public abstract class AbstractEquivalenceFilter<T> implements EquivalenceFilter<T> {
 
@@ -17,12 +15,12 @@ public abstract class AbstractEquivalenceFilter<T> implements EquivalenceFilter<
             Iterable<ScoredCandidate<T>> candidates,
             final T subject,
             final ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         desc.startStage(toString());
         Builder<ScoredCandidate<T>> results = ImmutableList.builder();
         for (ScoredCandidate<T> candidate : candidates) {
-            if (doFilter(candidate, subject, desc, equivToTelescopeResults)) {
+            if (doFilter(candidate, subject, desc, equivToTelescopeResult)) {
                 results.add(candidate);
             }
         }
@@ -34,7 +32,7 @@ public abstract class AbstractEquivalenceFilter<T> implements EquivalenceFilter<
             ScoredCandidate<T> input,
             T subject,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     );
 
     @Override

--- a/src/main/java/org/atlasapi/equiv/results/filters/AlwaysTrueFilter.java
+++ b/src/main/java/org/atlasapi/equiv/results/filters/AlwaysTrueFilter.java
@@ -3,8 +3,7 @@ package org.atlasapi.equiv.results.filters;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
-import org.atlasapi.media.entity.Content;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Identified;
 
 public class AlwaysTrueFilter<T> extends AbstractEquivalenceFilter<T> {
@@ -24,7 +23,7 @@ public class AlwaysTrueFilter<T> extends AbstractEquivalenceFilter<T> {
             ScoredCandidate<T> input,
             T subject,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent filterComponent = EquivToTelescopeComponent.create();
         filterComponent.setComponentName("Always True Filter");
@@ -35,7 +34,7 @@ public class AlwaysTrueFilter<T> extends AbstractEquivalenceFilter<T> {
                     "Always True"
             );
         }
-        equivToTelescopeResults.addFilterResult(filterComponent);
+        equivToTelescopeResult.addFilterResult(filterComponent);
         return true;
     }
 

--- a/src/main/java/org/atlasapi/equiv/results/filters/ConjunctiveFilter.java
+++ b/src/main/java/org/atlasapi/equiv/results/filters/ConjunctiveFilter.java
@@ -1,13 +1,11 @@
 package org.atlasapi.equiv.results.filters;
 
-import java.util.List;
-
+import com.google.common.collect.ImmutableList;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 
-import com.google.common.collect.ImmutableList;
+import java.util.List;
 
 public class ConjunctiveFilter<T> implements EquivalenceFilter<T> {
 
@@ -26,12 +24,12 @@ public class ConjunctiveFilter<T> implements EquivalenceFilter<T> {
             Iterable<ScoredCandidate<T>> candidates,
             T subject,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         desc.startStage(toString());
         Iterable<ScoredCandidate<T>> result = candidates;
         for (EquivalenceFilter<T> filter : filters) {
-            result = filter.apply(result, subject, desc, equivToTelescopeResults);
+            result = filter.apply(result, subject, desc, equivToTelescopeResult);
         }
         desc.finishStage();
         return ImmutableList.copyOf(result);

--- a/src/main/java/org/atlasapi/equiv/results/filters/ContainerHierarchyFilter.java
+++ b/src/main/java/org/atlasapi/equiv/results/filters/ContainerHierarchyFilter.java
@@ -3,7 +3,7 @@ package org.atlasapi.equiv.results.filters;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Brand;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Series;
@@ -19,7 +19,7 @@ public class ContainerHierarchyFilter extends AbstractEquivalenceFilter<Containe
             ScoredCandidate<Container> input,
             Container subject,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent filterComponent = EquivToTelescopeComponent.create();
         filterComponent.setComponentName("Container Hierarchy Filter");
@@ -34,7 +34,7 @@ public class ContainerHierarchyFilter extends AbstractEquivalenceFilter<Containe
                 );
             }
         }
-        equivToTelescopeResults.addFilterResult(filterComponent);
+        equivToTelescopeResult.addFilterResult(filterComponent);
 
         return retain;
     }

--- a/src/main/java/org/atlasapi/equiv/results/filters/DummyContainerFilter.java
+++ b/src/main/java/org/atlasapi/equiv/results/filters/DummyContainerFilter.java
@@ -3,7 +3,7 @@ package org.atlasapi.equiv.results.filters;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Content;
 
@@ -14,7 +14,7 @@ public class DummyContainerFilter<T extends Content> extends AbstractEquivalence
             ScoredCandidate<T> input,
             T subject,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent filterComponent = EquivToTelescopeComponent.create();
         filterComponent.setComponentName("Dummy Container Filter");
@@ -24,7 +24,7 @@ public class DummyContainerFilter<T extends Content> extends AbstractEquivalence
                     input.candidate().getId(),
                     "Went through, not a container."
             );
-            equivToTelescopeResults.addFilterResult(filterComponent);
+            equivToTelescopeResult.addFilterResult(filterComponent);
             return true;
         }
 
@@ -53,7 +53,7 @@ public class DummyContainerFilter<T extends Content> extends AbstractEquivalence
             );
         }
 
-        equivToTelescopeResults.addFilterResult(filterComponent);
+        equivToTelescopeResult.addFilterResult(filterComponent);
 
         return retain;
     }

--- a/src/main/java/org/atlasapi/equiv/results/filters/EquivalenceFilter.java
+++ b/src/main/java/org/atlasapi/equiv/results/filters/EquivalenceFilter.java
@@ -1,10 +1,10 @@
 package org.atlasapi.equiv.results.filters;
 
-import java.util.List;
-
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
+
+import java.util.List;
 
 public interface EquivalenceFilter<T> {
     
@@ -12,7 +12,7 @@ public interface EquivalenceFilter<T> {
             Iterable<ScoredCandidate<T>> candidates,
             T subject,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     );
     
 }

--- a/src/main/java/org/atlasapi/equiv/results/filters/ExclusionListFilter.java
+++ b/src/main/java/org/atlasapi/equiv/results/filters/ExclusionListFilter.java
@@ -1,18 +1,16 @@
 package org.atlasapi.equiv.results.filters;
 
-import java.util.Set;
-
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
+import com.metabroadcast.common.stream.MoreCollectors;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Identified;
 
-import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
-import com.metabroadcast.common.stream.MoreCollectors;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
+import java.util.Set;
 
 
 public class ExclusionListFilter<T extends Identified> extends AbstractEquivalenceFilter<T> {
@@ -39,7 +37,7 @@ public class ExclusionListFilter<T extends Identified> extends AbstractEquivalen
             ScoredCandidate<T> candidate,
             T subject,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent filterComponent = EquivToTelescopeComponent.create();
         filterComponent.setComponentName("Exclusion List Filter");
@@ -60,7 +58,7 @@ public class ExclusionListFilter<T extends Identified> extends AbstractEquivalen
             );
         }
 
-        equivToTelescopeResults.addFilterResult(filterComponent);
+        equivToTelescopeResult.addFilterResult(filterComponent);
 
         return result;
     }

--- a/src/main/java/org/atlasapi/equiv/results/filters/FilmAndEpisodeFilter.java
+++ b/src/main/java/org/atlasapi/equiv/results/filters/FilmAndEpisodeFilter.java
@@ -3,7 +3,7 @@ package org.atlasapi.equiv.results.filters;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Episode;
 import org.atlasapi.media.entity.Film;
@@ -16,7 +16,7 @@ public class FilmAndEpisodeFilter<T extends Content> extends AbstractEquivalence
             ScoredCandidate<T> input,
             T subject,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent filterComponent = EquivToTelescopeComponent.create();
         filterComponent.setComponentName("Film and Episode Filter");
@@ -31,11 +31,11 @@ public class FilmAndEpisodeFilter<T extends Content> extends AbstractEquivalence
                     input.candidate().getId(),
                     "Removed since its content type does not match"
             );
-            equivToTelescopeResults.addFilterResult(filterComponent);
+            equivToTelescopeResult.addFilterResult(filterComponent);
             return false;
         }
 
-        equivToTelescopeResults.addFilterResult(filterComponent);
+        equivToTelescopeResult.addFilterResult(filterComponent);
         return true;
 
     }

--- a/src/main/java/org/atlasapi/equiv/results/filters/FilmYearFilter.java
+++ b/src/main/java/org/atlasapi/equiv/results/filters/FilmYearFilter.java
@@ -3,7 +3,7 @@ package org.atlasapi.equiv.results.filters;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Film;
 
@@ -17,7 +17,7 @@ public class FilmYearFilter<T extends Content> extends AbstractEquivalenceFilter
             ScoredCandidate<T> input,
             T subject,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent filterComponent = EquivToTelescopeComponent.create();
         filterComponent.setComponentName("Film Year Filter");
@@ -27,7 +27,7 @@ public class FilmYearFilter<T extends Content> extends AbstractEquivalenceFilter
                     input.candidate().getId(),
                     "Went through, not a film."
             );
-            equivToTelescopeResults.addFilterResult(filterComponent);
+            equivToTelescopeResult.addFilterResult(filterComponent);
             return true;
         }
 
@@ -42,7 +42,7 @@ public class FilmYearFilter<T extends Content> extends AbstractEquivalenceFilter
                     input.candidate().getId(),
                     "Went through, subject or candidate film year is null; not applying film year filter."
             );
-            equivToTelescopeResults.addFilterResult(filterComponent);
+            equivToTelescopeResult.addFilterResult(filterComponent);
             return true;
         }
 
@@ -72,7 +72,7 @@ public class FilmYearFilter<T extends Content> extends AbstractEquivalenceFilter
             );
         }
 
-        equivToTelescopeResults.addFilterResult(filterComponent);
+        equivToTelescopeResult.addFilterResult(filterComponent);
 
         return shouldRetain;
     }

--- a/src/main/java/org/atlasapi/equiv/results/filters/MediaTypeFilter.java
+++ b/src/main/java/org/atlasapi/equiv/results/filters/MediaTypeFilter.java
@@ -1,13 +1,12 @@
 package org.atlasapi.equiv.results.filters;
 
+import com.google.common.base.Objects;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.MediaType;
-
-import com.google.common.base.Objects;
 
 
 public class MediaTypeFilter<T extends Content> extends AbstractEquivalenceFilter<T> {
@@ -17,7 +16,7 @@ public class MediaTypeFilter<T extends Content> extends AbstractEquivalenceFilte
             ScoredCandidate<T> input,
             T subject,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent filterComponent = EquivToTelescopeComponent.create();
         filterComponent.setComponentName("Media Type Filter");
@@ -44,7 +43,7 @@ public class MediaTypeFilter<T extends Content> extends AbstractEquivalenceFilte
             );
         }
 
-        equivToTelescopeResults.addFilterResult(filterComponent);
+        equivToTelescopeResult.addFilterResult(filterComponent);
 
         return result;
     }

--- a/src/main/java/org/atlasapi/equiv/results/filters/MinimumScoreFilter.java
+++ b/src/main/java/org/atlasapi/equiv/results/filters/MinimumScoreFilter.java
@@ -3,7 +3,7 @@ package org.atlasapi.equiv.results.filters;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Content;
 
 public class MinimumScoreFilter<T extends Content>  extends AbstractEquivalenceFilter<T> {
@@ -18,7 +18,7 @@ public class MinimumScoreFilter<T extends Content>  extends AbstractEquivalenceF
             ScoredCandidate<T> candidate,
             T subject,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent filterComponent = EquivToTelescopeComponent.create();
         filterComponent.setComponentName("Minimum Score Filter "+minimum);
@@ -42,7 +42,7 @@ public class MinimumScoreFilter<T extends Content>  extends AbstractEquivalenceF
         }
 
 
-        equivToTelescopeResults.addFilterResult(filterComponent);
+        equivToTelescopeResult.addFilterResult(filterComponent);
 
         return result;
     }

--- a/src/main/java/org/atlasapi/equiv/results/filters/PublisherFilter.java
+++ b/src/main/java/org/atlasapi/equiv/results/filters/PublisherFilter.java
@@ -1,17 +1,16 @@
 package org.atlasapi.equiv.results.filters;
 
-import java.util.Map;
-import java.util.Set;
-
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Publisher;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
+import java.util.Map;
+import java.util.Set;
 
 public class PublisherFilter<T extends Content> extends AbstractEquivalenceFilter<T> {
 
@@ -25,7 +24,7 @@ public class PublisherFilter<T extends Content> extends AbstractEquivalenceFilte
             ScoredCandidate<T> candidate,
             T subject,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent filterComponent = EquivToTelescopeComponent.create();
         filterComponent.setComponentName("Publisher Filter");
@@ -35,7 +34,7 @@ public class PublisherFilter<T extends Content> extends AbstractEquivalenceFilte
                     candidate.candidate().getId(),
                     "Removing because target and source have the same publisher."
             );
-            equivToTelescopeResults.addFilterResult(filterComponent);
+            equivToTelescopeResult.addFilterResult(filterComponent);
             return false;
         }
         Set<Publisher> unacceptable = unacceptablePublishers.get(subject.getPublisher());
@@ -44,7 +43,7 @@ public class PublisherFilter<T extends Content> extends AbstractEquivalenceFilte
                     candidate.candidate().getId(),
                     "Went through."
             );
-            equivToTelescopeResults.addFilterResult(filterComponent);
+            equivToTelescopeResult.addFilterResult(filterComponent);
             return true;
         }
 
@@ -70,7 +69,7 @@ public class PublisherFilter<T extends Content> extends AbstractEquivalenceFilte
             );
         }
 
-        equivToTelescopeResults.addFilterResult(filterComponent);
+        equivToTelescopeResult.addFilterResult(filterComponent);
 
         return passes;
     }

--- a/src/main/java/org/atlasapi/equiv/results/filters/SpecializationFilter.java
+++ b/src/main/java/org/atlasapi/equiv/results/filters/SpecializationFilter.java
@@ -1,13 +1,12 @@
 package org.atlasapi.equiv.results.filters;
 
+import com.google.common.base.Objects;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Specialization;
-
-import com.google.common.base.Objects;
 
 public class SpecializationFilter<T extends Content> extends AbstractEquivalenceFilter<T> {
 
@@ -16,7 +15,7 @@ public class SpecializationFilter<T extends Content> extends AbstractEquivalence
             ScoredCandidate<T> candidate,
             T subject,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent filterComponent = EquivToTelescopeComponent.create();
         filterComponent.setComponentName("Specialization Filter");
@@ -43,7 +42,7 @@ public class SpecializationFilter<T extends Content> extends AbstractEquivalence
             );
         }
 
-        equivToTelescopeResults.addFilterResult(filterComponent);
+        equivToTelescopeResult.addFilterResult(filterComponent);
 
         return result;
     }

--- a/src/main/java/org/atlasapi/equiv/results/filters/UnpublishedContentFilter.java
+++ b/src/main/java/org/atlasapi/equiv/results/filters/UnpublishedContentFilter.java
@@ -3,10 +3,8 @@ package org.atlasapi.equiv.results.filters;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Content;
-import org.atlasapi.media.entity.Equiv;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,7 +17,7 @@ public class UnpublishedContentFilter<T extends Content> extends AbstractEquival
             ScoredCandidate<T> candidate,
             T subject,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent filterCompoenent = EquivToTelescopeComponent.create();
         filterCompoenent.setComponentName("Unpublished Content Filter");
@@ -46,7 +44,7 @@ public class UnpublishedContentFilter<T extends Content> extends AbstractEquival
             );
         }
 
-        equivToTelescopeResults.addFilterResult(filterCompoenent);
+        equivToTelescopeResult.addFilterResult(filterCompoenent);
 
         return isActivelyPublished;
     }

--- a/src/main/java/org/atlasapi/equiv/results/persistence/EquivalenceResultStore.java
+++ b/src/main/java/org/atlasapi/equiv/results/persistence/EquivalenceResultStore.java
@@ -1,15 +1,15 @@
 package org.atlasapi.equiv.results.persistence;
 
-import java.util.List;
-
-import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.equiv.results.EquivalenceResults;
 import org.atlasapi.media.entity.Content;
+
+import java.util.List;
 
 public interface EquivalenceResultStore {
 
-    <T extends Content> StoredEquivalenceResult store(EquivalenceResult<T> result);
+    <T extends Content> StoredEquivalenceResults store(EquivalenceResults<T> results);
     
-    StoredEquivalenceResult forId(String canonicalUri);
+    StoredEquivalenceResults forId(String canonicalUri);
     
-    List<StoredEquivalenceResult> forIds(Iterable<String> canonicalUris);
+    List<StoredEquivalenceResults> forIds(Iterable<String> canonicalUris);
 }

--- a/src/main/java/org/atlasapi/equiv/results/persistence/EquivalenceResultsTranslator.java
+++ b/src/main/java/org/atlasapi/equiv/results/persistence/EquivalenceResultsTranslator.java
@@ -1,0 +1,173 @@
+package org.atlasapi.equiv.results.persistence;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Ordering;
+import com.google.common.collect.Table;
+import com.metabroadcast.common.base.Maybe;
+import com.metabroadcast.common.persistence.translator.TranslatorUtils;
+import com.metabroadcast.common.time.DateTimeZones;
+import com.mongodb.BasicDBList;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.equiv.results.EquivalenceResults;
+import org.atlasapi.equiv.results.scores.Score;
+import org.atlasapi.equiv.results.scores.ScoredCandidate;
+import org.atlasapi.equiv.results.scores.ScoredCandidates;
+import org.atlasapi.media.entity.Content;
+import org.atlasapi.media.entity.Publisher;
+import org.joda.time.DateTime;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableSet.copyOf;
+import static com.google.common.collect.Iterables.transform;
+import static com.metabroadcast.common.persistence.mongo.MongoConstants.ID;
+import static org.atlasapi.media.entity.Identified.TO_URI;
+
+public class EquivalenceResultsTranslator {
+
+    private static final String TIMESTAMP = "timestamp";
+    private static final String TITLE = "title";
+    private static final String EQUIVS = "equivs";
+    private static final String STRONG = "strong";
+    private static final String RESULTS = "results";
+
+    private static final String COMBINED = "combined";
+    private static final String PUBLISHER = "publisher";
+    private static final String SCORES = "scores";
+    private static final String SOURCE = "source";
+    private static final String SCORE = "score";
+    public static final String DESC = "desc";
+
+
+    public <T extends Content> DBObject toDBObject(EquivalenceResults<T> results) {
+        DBObject dbo = new BasicDBObject();
+
+        final Ordering<Entry<T, Score>> equivalenceResultOrdering = Ordering.from(new Comparator<Entry<T, Score>>() {
+            @Override
+            public int compare(Entry<T, Score> o1, Entry<T, Score> o2) {
+                return o1.getKey().getPublisher().compareTo(o2.getKey().getPublisher());
+            }
+        }).compound(new Comparator<Entry<T, Score>>() {
+            @Override
+            public int compare(Entry<T, Score> o1, Entry<T, Score> o2) {
+                return Score.SCORE_ORDERING.reverse().compare(o1.getValue(), o2.getValue());
+            }
+        }).compound(new Comparator<Entry<T, Score>>() {
+            @Override
+            public int compare(Entry<T, Score> o1, Entry<T, Score> o2) {
+                return o1.getKey().getCanonicalUri().compareTo(o2.getKey().getCanonicalUri());
+            }
+        });
+
+        T target = results.subject();
+        TranslatorUtils.from(dbo, ID, target.getCanonicalUri());
+        TranslatorUtils.from(dbo, TITLE, target.getTitle());
+
+        BasicDBList resultList = new BasicDBList();
+
+        for(EquivalenceResult<T> result : results.getResults()) {
+            DBObject resultDbo = new BasicDBObject();
+
+            TranslatorUtils.fromSet(resultDbo, copyOf(transform(transform(result.strongEquivalences().values(), ScoredCandidate.<T>toCandidate()), TO_URI)), STRONG);
+
+            BasicDBList equivList = new BasicDBList();
+
+            for (Entry<T, Score> combinedEquiv : equivalenceResultOrdering.sortedCopy(result.combinedEquivalences().candidates().entrySet())) {
+                DBObject equivDbo = new BasicDBObject();
+
+                T content = combinedEquiv.getKey();
+
+                TranslatorUtils.from(equivDbo, ID, content.getCanonicalUri());
+                TranslatorUtils.from(equivDbo, TITLE, content.getTitle());
+                TranslatorUtils.from(equivDbo, PUBLISHER, content.getPublisher().key());
+                TranslatorUtils.from(equivDbo, COMBINED, combinedEquiv.getValue().isRealScore() ? combinedEquiv.getValue().asDouble() : null);
+
+                BasicDBList scoreList = new BasicDBList();
+                for (ScoredCandidates<T> source : result.rawScores()) {
+                    Score sourceScore = source.candidates().get(content);
+
+                    BasicDBObject scoreDbo = new BasicDBObject();
+                    scoreDbo.put(SOURCE, source.source());
+                    scoreDbo.put(SCORE, sourceScore != null && sourceScore.isRealScore() ? sourceScore.asDouble() : null);
+
+                    scoreList.add(scoreDbo);
+                }
+                TranslatorUtils.from(equivDbo, SCORES, scoreList);
+
+                equivList.add(equivDbo);
+            }
+            TranslatorUtils.from(resultDbo, EQUIVS, equivList);
+            resultDbo.put(DESC, result.description().parts());
+            resultList.add(resultDbo);
+        }
+        TranslatorUtils.from(dbo, RESULTS, resultList);
+
+        TranslatorUtils.fromDateTime(dbo, TIMESTAMP, new DateTime(DateTimeZones.UTC));
+
+        dbo.put(DESC, results.description().parts());
+
+        return dbo;
+    }
+
+    @Nullable
+    public StoredEquivalenceResults fromDBObject(DBObject dbo) {
+        if(dbo == null) {
+            return null;
+        }
+
+        if(!dbo.containsField(RESULTS)) { //New field may not exist e.g. objects created by old translator
+            return null;
+        }
+        
+        String targetId = TranslatorUtils.toString(dbo, ID);
+        String targetTitle = TranslatorUtils.toString(dbo, TITLE);
+
+
+        List<StoredEquivalenceResultTable> resultTables = new ArrayList<>();
+
+        for (DBObject resultDbo : TranslatorUtils.toDBObjectList(dbo, RESULTS)) {
+            Set<String> strongs = TranslatorUtils.toSet(resultDbo, STRONG);
+
+            ImmutableList.Builder<CombinedEquivalenceScore> totals = ImmutableList.builder();
+            Table<String, String, Double> results = HashBasedTable.create();
+
+            for (DBObject equivDbo : TranslatorUtils.toDBObjectList(resultDbo, EQUIVS)) {
+                String id = TranslatorUtils.toString(equivDbo, ID);
+                Double combined = equivDbo.containsField(COMBINED) ? TranslatorUtils.toDouble(equivDbo, COMBINED) : Double.NaN;
+                totals.add(
+                        new CombinedEquivalenceScore(id, TranslatorUtils.toString(equivDbo, TITLE), combined, strongs.contains(id), publisherName(equivDbo))
+                );
+                for (DBObject scoreDbo : TranslatorUtils.toDBObjectList(equivDbo, SCORES)) {
+                    Double score = TranslatorUtils.toDouble(scoreDbo, SCORE);
+                    results.put(id, TranslatorUtils.toString(scoreDbo, SOURCE), score == null ? Double.NaN : score);
+                }
+            }
+
+            resultTables.add(new StoredEquivalenceResultTable(results, totals.build(), (List<Object>)resultDbo.get(DESC)));
+        }
+        
+        @SuppressWarnings("unchecked") List<Object> description = (List<Object>)dbo.get(DESC);
+        return new StoredEquivalenceResults(
+                targetId,
+                targetTitle,
+                resultTables,
+                TranslatorUtils.toDateTime(dbo, TIMESTAMP),
+                description
+        );
+    }
+    
+    private String publisherName(DBObject equivDbo) {
+        Maybe<Publisher> restoredPublisher = Publisher.fromKey(TranslatorUtils.toString(equivDbo, PUBLISHER));
+        String publisher = restoredPublisher.hasValue() ? restoredPublisher.requireValue().title() : "Unknown Publisher";
+        return publisher;
+    }
+    
+}

--- a/src/main/java/org/atlasapi/equiv/results/persistence/EquivalenceResultsTranslator.java
+++ b/src/main/java/org/atlasapi/equiv/results/persistence/EquivalenceResultsTranslator.java
@@ -74,6 +74,7 @@ public class EquivalenceResultsTranslator {
         TranslatorUtils.from(dbo, ID, target.getCanonicalUri());
         TranslatorUtils.from(dbo, AID, target.getId());
         TranslatorUtils.from(dbo, TITLE, target.getTitle());
+        TranslatorUtils.from(dbo, PUBLISHER, target.getPublisher().title());
 
         BasicDBList resultList = new BasicDBList();
 
@@ -144,6 +145,7 @@ public class EquivalenceResultsTranslator {
         String targetId = TranslatorUtils.toString(dbo, ID);
         Long targetAid = TranslatorUtils.toLong(dbo, AID);
         String targetTitle = TranslatorUtils.toString(dbo, TITLE);
+        String targetPublisher = TranslatorUtils.toString(dbo, PUBLISHER);
 
 
         List<StoredEquivalenceResultTable> resultTables = new ArrayList<>();
@@ -176,6 +178,7 @@ public class EquivalenceResultsTranslator {
                 targetId,
                 codec.encode(BigInteger.valueOf(targetAid)),
                 targetTitle,
+                targetPublisher,
                 resultTables,
                 TranslatorUtils.toDateTime(dbo, TIMESTAMP),
                 description

--- a/src/main/java/org/atlasapi/equiv/results/persistence/FileEquivalenceResultStore.java
+++ b/src/main/java/org/atlasapi/equiv/results/persistence/FileEquivalenceResultStore.java
@@ -1,5 +1,13 @@
 package org.atlasapi.equiv.results.persistence;
 
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import org.atlasapi.equiv.results.EquivalenceResults;
+import org.atlasapi.media.entity.Content;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -9,15 +17,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.List;
 
-import org.atlasapi.equiv.results.EquivalenceResult;
-import org.atlasapi.media.entity.Content;
-
-import com.google.common.base.Function;
-import com.google.common.base.Optional;
-import com.google.common.base.Throwables;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-
 /**
  * Filesystem-based store for equivalence results. New files will be stored in a
  * hashed directory structure to avoid a single directory with too many files in it, but
@@ -25,7 +24,7 @@ import com.google.common.collect.Lists;
  */
 public class FileEquivalenceResultStore implements EquivalenceResultStore {
 
-    private StoredEquivalenceResultTranslator translator = new StoredEquivalenceResultTranslator();
+    private StoredEquivalenceResultsTranslator translator = new StoredEquivalenceResultsTranslator();
     private final File baseDirectory;
     
     public FileEquivalenceResultStore(File directory) {
@@ -39,14 +38,14 @@ public class FileEquivalenceResultStore implements EquivalenceResultStore {
     }
     
     @Override
-    public <T extends Content> StoredEquivalenceResult store(
-            EquivalenceResult<T> result) {
-        StoredEquivalenceResult storedEquivalenceResult = translator.toStoredEquivalenceResult(result);
+    public <T extends Content> StoredEquivalenceResults store(
+            EquivalenceResults<T> results) {
+        StoredEquivalenceResults storedEquivalenceResults = translator.toStoredEquivalenceResults(results);
         try {
-            String filename = filenameFor(result.subject().getCanonicalUri());
+            String filename = filenameFor(results.subject().getCanonicalUri());
             ObjectOutputStream os = new ObjectOutputStream(
                     new FileOutputStream(new File(directoryFor(filename), filename)));
-            os.writeObject(storedEquivalenceResult);
+            os.writeObject(storedEquivalenceResults);
             os.close();
         } catch (FileNotFoundException e) {
             Throwables.propagate(e);
@@ -54,30 +53,34 @@ public class FileEquivalenceResultStore implements EquivalenceResultStore {
             Throwables.propagate(e);
         }
         
-        return storedEquivalenceResult;
+        return storedEquivalenceResults;
     }
 
     @Override
-    public StoredEquivalenceResult forId(String canonicalUri) {
+    public StoredEquivalenceResults forId(String canonicalUri) {
         String filename = filenameFor(canonicalUri);
 
-        Optional<StoredEquivalenceResult> resultInHashedDirectory = resultFor(new File(directoryFor(filename), filename));
+        Optional<StoredEquivalenceResults> resultInHashedDirectory = resultFor(new File(directoryFor(filename), filename));
         if (resultInHashedDirectory.isPresent()) {
             return resultInHashedDirectory.get();
         }
 
-        Optional<StoredEquivalenceResult> resultInBaseDirectory = resultFor(new File(baseDirectory, filename));
+        Optional<StoredEquivalenceResults> resultInBaseDirectory = resultFor(new File(baseDirectory, filename));
         return resultInBaseDirectory.orNull();
     }
 
-    private Optional<StoredEquivalenceResult> resultFor(File file) {
+    private Optional<StoredEquivalenceResults> resultFor(File file) {
         if(!file.exists()) {
             return Optional.absent();
         }
 
-        try {
-            ObjectInputStream is = new ObjectInputStream(new FileInputStream(file));
-            return Optional.of((StoredEquivalenceResult) is.readObject());
+        try(ObjectInputStream is = new ObjectInputStream(new FileInputStream(file))) {
+            Object readObject = is.readObject();
+            try {
+                return Optional.of((StoredEquivalenceResults) readObject);
+            } catch (ClassCastException e) { //Stored object might be the old result object
+                return Optional.of(new StoredEquivalenceResults((StoredEquivalenceResult) readObject));
+            }
         } catch (IOException e) {
             Throwables.propagate(e);
         } catch (ClassNotFoundException e) {
@@ -87,11 +90,11 @@ public class FileEquivalenceResultStore implements EquivalenceResultStore {
     }
 
     @Override
-    public List<StoredEquivalenceResult> forIds(Iterable<String> canonicalUris) {
-        return Lists.newArrayList(Iterables.transform(canonicalUris, new Function<String, StoredEquivalenceResult>() {
+    public List<StoredEquivalenceResults> forIds(Iterable<String> canonicalUris) {
+        return Lists.newArrayList(Iterables.transform(canonicalUris, new Function<String, StoredEquivalenceResults>() {
 
             @Override
-            public StoredEquivalenceResult apply(String input) {
+            public StoredEquivalenceResults apply(String input) {
                 return forId(input);
             }
             

--- a/src/main/java/org/atlasapi/equiv/results/persistence/MongoEquivalenceResultStore.java
+++ b/src/main/java/org/atlasapi/equiv/results/persistence/MongoEquivalenceResultStore.java
@@ -1,51 +1,59 @@
 package org.atlasapi.equiv.results.persistence;
 
-import static com.metabroadcast.common.persistence.mongo.MongoBuilders.where;
-import static com.metabroadcast.common.persistence.mongo.MongoConstants.ID;
-
-import java.util.List;
-
-import org.atlasapi.equiv.results.EquivalenceResult;
-import org.atlasapi.media.entity.Content;
-
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.metabroadcast.common.persistence.mongo.DatabasedMongo;
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
+import org.atlasapi.equiv.results.EquivalenceResults;
+import org.atlasapi.media.entity.Content;
+
+import java.util.List;
+
+import static com.metabroadcast.common.persistence.mongo.MongoBuilders.where;
+import static com.metabroadcast.common.persistence.mongo.MongoConstants.ID;
 
 public class MongoEquivalenceResultStore implements EquivalenceResultStore {
 
     private DBCollection equivResults;
-    private EquivalenceResultTranslator translator;
+    private EquivalenceResultsTranslator translator = new EquivalenceResultsTranslator();
+    private EquivalenceResultTranslator oldTranslator = new EquivalenceResultTranslator();
 
     public MongoEquivalenceResultStore(DatabasedMongo mongo) {
         this.equivResults = mongo.collection("equivalence");
-        this.translator = new EquivalenceResultTranslator();
     }
     
     @Override
-    public <T extends Content> StoredEquivalenceResult store(EquivalenceResult<T> result) {
-        DBObject dbo = translator.toDBObject(result);
-        equivResults.update(where().fieldEquals(ID, result.subject().getCanonicalUri()).build(), dbo, true, false);
-        return translator.fromDBObject(dbo);
+    public <T extends Content> StoredEquivalenceResults store(EquivalenceResults<T> results) {
+        DBObject dbo = translator.toDBObject(results);
+        equivResults.update(where().fieldEquals(ID, results.subject().getCanonicalUri()).build(), dbo, true, false);
+        return fromDBObject(dbo);
     }
 
     @Override
-    public StoredEquivalenceResult forId(String canonicalUri) {
-        return translator.fromDBObject(equivResults.findOne(canonicalUri));
+    public StoredEquivalenceResults forId(String canonicalUri) {
+        return fromDBObject(equivResults.findOne(canonicalUri));
     }
 
     @Override
-    public List<StoredEquivalenceResult> forIds(Iterable<String> canonicalUris) {
-        return ImmutableList.copyOf(Iterables.transform(equivResults.find(where().idIn(canonicalUris).build()), new Function<DBObject, StoredEquivalenceResult>() {
+    public List<StoredEquivalenceResults> forIds(Iterable<String> canonicalUris) {
+        return ImmutableList.copyOf(Iterables.transform(equivResults.find(where().idIn(canonicalUris).build()), new Function<DBObject, StoredEquivalenceResults>() {
 
             @Override
-            public StoredEquivalenceResult apply(DBObject input) {
-                return translator.fromDBObject(input);
+            public StoredEquivalenceResults apply(DBObject input) {
+                return fromDBObject(input);
             }
         }));
+    }
+
+    private StoredEquivalenceResults fromDBObject(DBObject dbo) {
+        StoredEquivalenceResults results = translator.fromDBObject(dbo);
+        if (results == null) {
+            results = new StoredEquivalenceResults(oldTranslator.fromDBObject(dbo));
+        }
+        return results;
+
     }
 
 }

--- a/src/main/java/org/atlasapi/equiv/results/persistence/StoredEquivalenceResultTable.java
+++ b/src/main/java/org/atlasapi/equiv/results/persistence/StoredEquivalenceResultTable.java
@@ -1,0 +1,56 @@
+package org.atlasapi.equiv.results.persistence;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.Table;
+
+import java.io.Serializable;
+import java.util.List;
+
+public class StoredEquivalenceResultTable implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Table<String, String, Double> results;
+    private final List<CombinedEquivalenceScore> totals;
+    private final List<Object> desc;
+
+    public StoredEquivalenceResultTable(
+            Table<String, String, Double> results,
+            List<CombinedEquivalenceScore> totals,
+            List<Object> desc
+    ) {
+        this.results = results;
+        this.totals = totals;
+        this.desc = desc;
+    }
+
+    public Table<String, String, Double> sourceResults() {
+        return results;
+    }
+
+    public List<CombinedEquivalenceScore> combinedResults() {
+        return totals;
+    }
+
+    public List<Object> description() {
+        return desc;
+    }
+
+    @Override
+    public boolean equals(Object that) {
+        if(this == that) {
+            return true;
+        }
+        if(that instanceof StoredEquivalenceResultTable) {
+            StoredEquivalenceResultTable other = (StoredEquivalenceResultTable) that;
+            return results.equals(other.results) && totals.equals(other.totals);
+        }
+        return super.equals(that);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(results, totals);
+    }
+
+}

--- a/src/main/java/org/atlasapi/equiv/results/persistence/StoredEquivalenceResults.java
+++ b/src/main/java/org/atlasapi/equiv/results/persistence/StoredEquivalenceResults.java
@@ -13,6 +13,7 @@ public class StoredEquivalenceResults implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private final String id;
+    private final String aid;
     private final String title;
     private final List<StoredEquivalenceResultTable> resultTables;
     private final DateTime resultTime;
@@ -20,12 +21,14 @@ public class StoredEquivalenceResults implements Serializable {
 
     public StoredEquivalenceResults(
             String targetId,
+            String aid,
             String targetTitle,
             Collection<StoredEquivalenceResultTable> resultTables,
             DateTime resultTime,
             List<Object> desc
     ) {
         this.id = targetId;
+        this.aid = aid;
         this.title = targetTitle;
         this.resultTables = ImmutableList.copyOf(resultTables);
         this.resultTime = resultTime;
@@ -39,6 +42,7 @@ public class StoredEquivalenceResults implements Serializable {
     public StoredEquivalenceResults(StoredEquivalenceResult result) {
         this(
                 result.id(),
+                "",
                 result.title(),
                 ImmutableList.of(new StoredEquivalenceResultTable(result.sourceResults(), result.combinedResults(), result.description())),
                 result.resultTime(),
@@ -48,6 +52,10 @@ public class StoredEquivalenceResults implements Serializable {
 
     public String id() {
         return id;
+    }
+
+    public String getAid() {
+        return aid;
     }
 
     public String title() {

--- a/src/main/java/org/atlasapi/equiv/results/persistence/StoredEquivalenceResults.java
+++ b/src/main/java/org/atlasapi/equiv/results/persistence/StoredEquivalenceResults.java
@@ -15,6 +15,7 @@ public class StoredEquivalenceResults implements Serializable {
     private final String id;
     private final String aid;
     private final String title;
+    private final String publisher;
     private final List<StoredEquivalenceResultTable> resultTables;
     private final DateTime resultTime;
     private final List<Object> desc;
@@ -23,6 +24,7 @@ public class StoredEquivalenceResults implements Serializable {
             String targetId,
             String aid,
             String targetTitle,
+            String publisher,
             Collection<StoredEquivalenceResultTable> resultTables,
             DateTime resultTime,
             List<Object> desc
@@ -30,6 +32,7 @@ public class StoredEquivalenceResults implements Serializable {
         this.id = targetId;
         this.aid = aid;
         this.title = targetTitle;
+        this.publisher = publisher;
         this.resultTables = ImmutableList.copyOf(resultTables);
         this.resultTime = resultTime;
         this.desc = desc;
@@ -44,6 +47,7 @@ public class StoredEquivalenceResults implements Serializable {
                 result.id(),
                 "",
                 result.title(),
+                "",
                 ImmutableList.of(new StoredEquivalenceResultTable(result.sourceResults(), result.combinedResults(), result.description())),
                 result.resultTime(),
                 ImmutableList.of()
@@ -60,6 +64,10 @@ public class StoredEquivalenceResults implements Serializable {
 
     public String title() {
         return title;
+    }
+
+    public String getPublisher() {
+        return publisher;
     }
 
     public List<StoredEquivalenceResultTable> getResultTables() {

--- a/src/main/java/org/atlasapi/equiv/results/persistence/StoredEquivalenceResults.java
+++ b/src/main/java/org/atlasapi/equiv/results/persistence/StoredEquivalenceResults.java
@@ -1,0 +1,91 @@
+package org.atlasapi.equiv.results.persistence;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+import org.joda.time.DateTime;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.List;
+
+public class StoredEquivalenceResults implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String id;
+    private final String title;
+    private final List<StoredEquivalenceResultTable> resultTables;
+    private final DateTime resultTime;
+    private final List<Object> desc;
+
+    public StoredEquivalenceResults(
+            String targetId,
+            String targetTitle,
+            Collection<StoredEquivalenceResultTable> resultTables,
+            DateTime resultTime,
+            List<Object> desc
+    ) {
+        this.id = targetId;
+        this.title = targetTitle;
+        this.resultTables = ImmutableList.copyOf(resultTables);
+        this.resultTime = resultTime;
+        this.desc = desc;
+    }
+
+    /**
+     * Convert the original StoredEquivalenceResult object to the new class
+     * @param result
+     */
+    public StoredEquivalenceResults(StoredEquivalenceResult result) {
+        this(
+                result.id(),
+                result.title(),
+                ImmutableList.of(new StoredEquivalenceResultTable(result.sourceResults(), result.combinedResults(), result.description())),
+                result.resultTime(),
+                ImmutableList.of()
+        );
+    }
+
+    public String id() {
+        return id;
+    }
+
+    public String title() {
+        return title;
+    }
+
+    public List<StoredEquivalenceResultTable> getResultTables() {
+        return resultTables;
+    }
+
+    public DateTime resultTime() {
+        return resultTime;
+    }
+
+    public List<Object> description() {
+        return desc;
+    }
+    
+    @Override
+    public String toString() {
+        return String.format("Result for %s %s", title, id);
+    }
+    
+    @Override
+    public boolean equals(Object that) {
+        if(this == that) {
+            return true;
+        }
+        if(that instanceof StoredEquivalenceResults) {
+            StoredEquivalenceResults other = (StoredEquivalenceResults) that;
+            return id.equals(other.id) && title.equals(other.title) && resultTables.equals(other.resultTables) && resultTime.equals(other.resultTime);
+        }
+        return super.equals(that);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id, title, resultTables, resultTime);
+    }
+
+}

--- a/src/main/java/org/atlasapi/equiv/results/persistence/StoredEquivalenceResultsTranslator.java
+++ b/src/main/java/org/atlasapi/equiv/results/persistence/StoredEquivalenceResultsTranslator.java
@@ -4,6 +4,7 @@ import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.Table;
+import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
 import com.metabroadcast.common.time.DateTimeZones;
 import org.atlasapi.equiv.results.EquivalenceResult;
 import org.atlasapi.equiv.results.EquivalenceResults;
@@ -13,6 +14,7 @@ import org.atlasapi.equiv.results.scores.ScoredCandidates;
 import org.atlasapi.media.entity.Content;
 import org.joda.time.DateTime;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -24,6 +26,7 @@ import static com.google.common.collect.Iterables.transform;
 import static org.atlasapi.media.entity.Identified.TO_URI;
 
 public class StoredEquivalenceResultsTranslator {
+    private static final SubstitutionTableNumberCodec codec = SubstitutionTableNumberCodec.lowerCaseOnly();
 
     public <T extends Content> StoredEquivalenceResults toStoredEquivalenceResults(EquivalenceResults<T> results) {
 
@@ -63,7 +66,7 @@ public class StoredEquivalenceResultsTranslator {
 
                     Score sourceScore = source.candidates().get(content);
                     Double score = sourceScore != null && sourceScore.isRealScore() ? sourceScore.asDouble() : Double.NaN;
-                    resultTable.put(content.getCanonicalUri(), source.source(), score);
+                    resultTable.put(codec.encode(BigInteger.valueOf(content.getId())), source.source(), score);
                 }
 
             }
@@ -72,6 +75,7 @@ public class StoredEquivalenceResultsTranslator {
         
         return new StoredEquivalenceResults(
                 results.subject().getCanonicalUri(),
+                codec.encode(BigInteger.valueOf(results.subject().getId())),
                 results.subject().getTitle(),
                 resultTables,
                 new DateTime(DateTimeZones.UTC),

--- a/src/main/java/org/atlasapi/equiv/results/persistence/StoredEquivalenceResultsTranslator.java
+++ b/src/main/java/org/atlasapi/equiv/results/persistence/StoredEquivalenceResultsTranslator.java
@@ -1,0 +1,81 @@
+package org.atlasapi.equiv.results.persistence;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Ordering;
+import com.google.common.collect.Table;
+import com.metabroadcast.common.time.DateTimeZones;
+import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.equiv.results.EquivalenceResults;
+import org.atlasapi.equiv.results.scores.Score;
+import org.atlasapi.equiv.results.scores.ScoredCandidate;
+import org.atlasapi.equiv.results.scores.ScoredCandidates;
+import org.atlasapi.media.entity.Content;
+import org.joda.time.DateTime;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableSet.copyOf;
+import static com.google.common.collect.Iterables.transform;
+import static org.atlasapi.media.entity.Identified.TO_URI;
+
+public class StoredEquivalenceResultsTranslator {
+
+    public <T extends Content> StoredEquivalenceResults toStoredEquivalenceResults(EquivalenceResults<T> results) {
+
+        
+        final Ordering<Entry<T, Score>> equivalenceResultOrdering = Ordering.from(new Comparator<Entry<T, Score>>() {
+            @Override
+            public int compare(Entry<T, Score> o1, Entry<T, Score> o2) {
+                return o1.getKey().getPublisher().compareTo(o2.getKey().getPublisher());
+            }
+        }).compound(new Comparator<Entry<T, Score>>() {
+            @Override
+            public int compare(Entry<T, Score> o1, Entry<T, Score> o2) {
+                return Score.SCORE_ORDERING.reverse().compare(o1.getValue(), o2.getValue());
+            }
+        }).compound(new Comparator<Entry<T, Score>>() {
+            @Override
+            public int compare(Entry<T, Score> o1, Entry<T, Score> o2) {
+                return o1.getKey().getCanonicalUri().compareTo(o2.getKey().getCanonicalUri());
+            }
+        });
+
+        List<StoredEquivalenceResultTable> resultTables = new ArrayList<>();
+
+        for(EquivalenceResult<T> result : results.getResults()) {
+            ImmutableList.Builder<CombinedEquivalenceScore> totals = ImmutableList.builder();
+            Table<String, String, Double> resultTable = HashBasedTable.create();
+
+            Set<String> strongEquivalences = copyOf(transform(transform(result.strongEquivalences().values(), ScoredCandidate.<T>toCandidate()), TO_URI));
+
+            for (Entry<T, Score> combinedEquiv : equivalenceResultOrdering.sortedCopy(result.combinedEquivalences().candidates().entrySet())) {
+
+                T content = combinedEquiv.getKey();
+
+                Double combinedScore = combinedEquiv.getValue().isRealScore() ? combinedEquiv.getValue().asDouble() : Double.NaN;
+                totals.add(new CombinedEquivalenceScore(content.getCanonicalUri(), content.getTitle(), combinedScore, strongEquivalences.contains(content.getCanonicalUri()), content.getPublisher().title()));
+                for (ScoredCandidates<T> source : result.rawScores()) {
+
+                    Score sourceScore = source.candidates().get(content);
+                    Double score = sourceScore != null && sourceScore.isRealScore() ? sourceScore.asDouble() : Double.NaN;
+                    resultTable.put(content.getCanonicalUri(), source.source(), score);
+                }
+
+            }
+            resultTables.add(new StoredEquivalenceResultTable(resultTable, totals.build(), result.description().parts()));
+        }
+        
+        return new StoredEquivalenceResults(
+                results.subject().getCanonicalUri(),
+                results.subject().getTitle(),
+                resultTables,
+                new DateTime(DateTimeZones.UTC),
+                results.description().parts()
+        );
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/results/persistence/StoredEquivalenceResultsTranslator.java
+++ b/src/main/java/org/atlasapi/equiv/results/persistence/StoredEquivalenceResultsTranslator.java
@@ -81,6 +81,7 @@ public class StoredEquivalenceResultsTranslator {
                 results.subject().getCanonicalUri(),
                 codec.encode(BigInteger.valueOf(results.subject().getId())),
                 results.subject().getTitle(),
+                results.subject().getPublisher().title(),
                 resultTables,
                 new DateTime(DateTimeZones.UTC),
                 results.description().parts()

--- a/src/main/java/org/atlasapi/equiv/results/www/EquivalenceResultController.java
+++ b/src/main/java/org/atlasapi/equiv/results/www/EquivalenceResultController.java
@@ -1,17 +1,16 @@
 package org.atlasapi.equiv.results.www;
 
-import static com.metabroadcast.common.http.HttpStatusCode.NOT_FOUND;
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-
-import javax.servlet.http.HttpServletResponse;
-
+import com.google.api.client.util.Strings;
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.metabroadcast.common.base.Maybe;
 import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
+import com.metabroadcast.common.model.SimpleModel;
+import com.metabroadcast.common.model.SimpleModelList;
 import org.atlasapi.equiv.results.persistence.EquivalenceResultStore;
-import org.atlasapi.equiv.results.persistence.StoredEquivalenceResult;
+import org.atlasapi.equiv.results.persistence.StoredEquivalenceResults;
 import org.atlasapi.equiv.results.probe.EquivalenceProbeStore;
 import org.atlasapi.media.entity.ChildRef;
 import org.atlasapi.media.entity.Container;
@@ -23,14 +22,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import com.google.api.client.util.Strings;
-import com.google.common.base.Function;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.metabroadcast.common.base.Maybe;
-import com.metabroadcast.common.model.SimpleModel;
-import com.metabroadcast.common.model.SimpleModelList;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.metabroadcast.common.http.HttpStatusCode.NOT_FOUND;
 
 @Controller
 public class EquivalenceResultController {
@@ -66,14 +64,14 @@ public class EquivalenceResultController {
             uri = uriFor(id);
         }
         
-        StoredEquivalenceResult equivalenceResult = store.forId(uri);
+        StoredEquivalenceResults equivalenceResults = store.forId(uri);
 
-        if (equivalenceResult == null) {
+        if (equivalenceResults == null) {
             response.sendError(NOT_FOUND.code(), "No result for URI");
             return null;
         }
 
-        SimpleModel resultModel = resultModelBuilder.build(equivalenceResult, probeStore.probeFor(uri));
+        SimpleModel resultModel = resultModelBuilder.build(equivalenceResults, probeStore.probeFor(uri));
 
         model.put("result", resultModel);
 
@@ -99,14 +97,14 @@ public class EquivalenceResultController {
 
         if (ided.requireValue() instanceof Container) {
 
-            List<StoredEquivalenceResult> results = store.forIds(Iterables.transform(((Container) ided.requireValue()).getChildRefs(), new Function<ChildRef, String>() {
+            List<StoredEquivalenceResults> results = store.forIds(Iterables.transform(((Container) ided.requireValue()).getChildRefs(), new Function<ChildRef, String>() {
                 @Override
                 public String apply(ChildRef input) {
                     return input.getUri();
                 }
             }));
 
-            for (StoredEquivalenceResult result : results) {
+            for (StoredEquivalenceResults result : results) {
                 resultModelList.add(resultModelBuilder.build(result, probeStore.probeFor(uri)));
             }
 

--- a/src/main/java/org/atlasapi/equiv/results/www/RecentResultController.java
+++ b/src/main/java/org/atlasapi/equiv/results/www/RecentResultController.java
@@ -1,15 +1,14 @@
 package org.atlasapi.equiv.results.www;
 
-import java.util.List;
-import java.util.Map;
-
+import com.google.common.collect.Lists;
+import com.metabroadcast.common.model.SimpleModelList;
 import org.atlasapi.equiv.results.persistence.RecentEquivalenceResultStore;
-import org.atlasapi.equiv.results.persistence.StoredEquivalenceResult;
+import org.atlasapi.equiv.results.persistence.StoredEquivalenceResults;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import com.google.common.collect.Lists;
-import com.metabroadcast.common.model.SimpleModelList;
+import java.util.List;
+import java.util.Map;
 
 @Controller
 public class RecentResultController {
@@ -41,10 +40,10 @@ public class RecentResultController {
         return "equivalence.recentContainers";
     }
     
-    private List<Map<String, ?>> compileResults(List<StoredEquivalenceResult> latestResults) {
+    private List<Map<String, ?>> compileResults(List<StoredEquivalenceResults> latestResults) {
         SimpleModelList resultsList = new SimpleModelList();
         
-        for (StoredEquivalenceResult result : Lists.reverse(latestResults)) {
+        for (StoredEquivalenceResults result : Lists.reverse(latestResults)) {
             resultsList.add(resultModelBuilder.build(result, null));
         }
         

--- a/src/main/java/org/atlasapi/equiv/results/www/RestoredEquivalenceResultModelBuilder.java
+++ b/src/main/java/org/atlasapi/equiv/results/www/RestoredEquivalenceResultModelBuilder.java
@@ -24,10 +24,13 @@ public class RestoredEquivalenceResultModelBuilder {
         
         model.put("id", target.id());
         model.put("encodedId", UrlEncoded.encodeString(target.id()));
+        model.put("aid", target.getAid());
         model.put("title", target.title());
         model.put("time", target.resultTime().toDateTime(DateTimeZones.LONDON).toString("YYYY-MM-dd HH:mm:ss"));
         
         boolean hasStrong = false;
+
+        int equivalencesCount = 0;
 
         SimpleModelList resultTables = new SimpleModelList();
 
@@ -51,6 +54,7 @@ public class RestoredEquivalenceResultModelBuilder {
                 equivModel.put("scores", scores(equivalence.score(), resultTable.sourceResults().row(equivalence.id()), totals));
 
                 hasStrong |= equivalence.strong();
+                equivalencesCount++;
 
                 equivModel.put("expected", expected(equivalence, probe));
 
@@ -62,13 +66,15 @@ public class RestoredEquivalenceResultModelBuilder {
             resultTableModel.putStrings("sources", resultTable.sourceResults().columnKeySet());
 
             if (resultTable.description() != null) {
-                model.put("desc", modelDesc(resultTable.description()));
+                resultTableModel.put("desc", modelDesc(resultTable.description()));
             }
 
             resultTables.add(resultTableModel);
         }
 
         model.put("resultTables", resultTables);
+
+        model.put("equivalences", equivalencesCount);
 
         model.put("hasStrong", hasStrong);
 

--- a/src/main/java/org/atlasapi/equiv/results/www/RestoredEquivalenceResultModelBuilder.java
+++ b/src/main/java/org/atlasapi/equiv/results/www/RestoredEquivalenceResultModelBuilder.java
@@ -25,6 +25,7 @@ public class RestoredEquivalenceResultModelBuilder {
         model.put("id", target.id());
         model.put("encodedId", UrlEncoded.encodeString(target.id()));
         model.put("aid", target.getAid());
+        model.put("publisher", target.getPublisher());
         model.put("title", target.title());
         model.put("time", target.resultTime().toDateTime(DateTimeZones.LONDON).toString("YYYY-MM-dd HH:mm:ss"));
         

--- a/src/main/java/org/atlasapi/equiv/scorers/BarbTitleMatchingItemScorer.java
+++ b/src/main/java/org/atlasapi/equiv/scorers/BarbTitleMatchingItemScorer.java
@@ -1,19 +1,17 @@
 package org.atlasapi.equiv.scorers;
 
-import java.util.Optional;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import javax.annotation.Nullable;
-
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.metabroadcast.common.base.Maybe;
+import org.apache.commons.lang3.StringUtils;
 import org.atlasapi.equiv.generators.ExpandingTitleTransformer;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Identified;
 import org.atlasapi.media.entity.Item;
@@ -21,12 +19,11 @@ import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.media.entity.Series;
 import org.atlasapi.persistence.content.ContentResolver;
 
-import com.metabroadcast.common.base.Maybe;
-
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import org.apache.commons.lang3.StringUtils;
+import javax.annotation.Nullable;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static com.google.api.client.repackaged.com.google.common.base.Preconditions.checkNotNull;
 
@@ -103,7 +100,7 @@ public class BarbTitleMatchingItemScorer implements EquivalenceScorer<Item> {
             Item subject,
             Set<? extends Item> suggestions,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent scorerComponent = EquivToTelescopeComponent.create();
         scorerComponent.setComponentName("Barb Title Matching Item Scorer");
@@ -140,7 +137,7 @@ public class BarbTitleMatchingItemScorer implements EquivalenceScorer<Item> {
             }
         }
 
-        equivToTelescopeResults.addScorerResult(scorerComponent);
+        equivToTelescopeResult.addScorerResult(scorerComponent);
 
         return equivalents.build();
     }

--- a/src/main/java/org/atlasapi/equiv/scorers/BaseBroadcastItemScorer.java
+++ b/src/main/java/org/atlasapi/equiv/scorers/BaseBroadcastItemScorer.java
@@ -1,37 +1,29 @@
 package org.atlasapi.equiv.scorers;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.util.Set;
-import java.util.TreeSet;
-
-import javax.annotation.Nullable;
-
+import com.google.common.base.Optional;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.metabroadcast.common.base.Maybe;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
+import org.atlasapi.equiv.results.scores.DefaultScoredCandidates.Builder;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.results.scores.DefaultScoredCandidates.Builder;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
-import org.atlasapi.media.entity.Broadcast;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Identified;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.ParentRef;
-import org.atlasapi.media.entity.Version;
 import org.atlasapi.persistence.content.ContentResolver;
 import org.atlasapi.persistence.content.ResolvedContent;
 
-import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
+import java.util.Set;
+import java.util.TreeSet;
 
-import com.metabroadcast.common.base.Maybe;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * <p>Specialized {@link EquivalenceScorer} for "broadcast items", i.e. those that
@@ -185,7 +177,7 @@ public abstract class BaseBroadcastItemScorer implements EquivalenceScorer<Item>
             Item subject,
             Set<? extends Item> candidates,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent scorerComponent = EquivToTelescopeComponent.create();
         scorerComponent.setComponentName(getName());
@@ -206,7 +198,7 @@ public abstract class BaseBroadcastItemScorer implements EquivalenceScorer<Item>
             }
         }
 
-        equivToTelescopeResults.addScorerResult(scorerComponent);
+        equivToTelescopeResult.addScorerResult(scorerComponent);
 
         return equivalents.build();
     }

--- a/src/main/java/org/atlasapi/equiv/scorers/BroadcastAliasScorer.java
+++ b/src/main/java/org/atlasapi/equiv/scorers/BroadcastAliasScorer.java
@@ -8,7 +8,7 @@ import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Alias;
 import org.atlasapi.media.entity.Item;
 
@@ -31,7 +31,7 @@ public class BroadcastAliasScorer implements EquivalenceScorer<Item> {
             Item subject,
             Set<? extends Item> candidates,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent scorerComponent = EquivToTelescopeComponent.create();
         scorerComponent.setComponentName("Broadcast Alias Scorer");
@@ -48,7 +48,7 @@ public class BroadcastAliasScorer implements EquivalenceScorer<Item> {
             );
         }
 
-        equivToTelescopeResults.addScorerResult(scorerComponent);
+        equivToTelescopeResult.addScorerResult(scorerComponent);
 
         return equivalents.build();
     }

--- a/src/main/java/org/atlasapi/equiv/scorers/ContainerHierarchyMatchingScorer.java
+++ b/src/main/java/org/atlasapi/equiv/scorers/ContainerHierarchyMatchingScorer.java
@@ -1,22 +1,5 @@
 package org.atlasapi.equiv.scorers;
 
-import java.util.List;
-import java.util.Set;
-
-import org.atlasapi.equiv.results.description.ResultDescription;
-import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
-import org.atlasapi.equiv.results.scores.DefaultScoredCandidates.Builder;
-import org.atlasapi.equiv.results.scores.Score;
-import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
-import org.atlasapi.media.entity.Brand;
-import org.atlasapi.media.entity.Container;
-import org.atlasapi.media.entity.Identified;
-import org.atlasapi.media.entity.Series;
-import org.atlasapi.media.entity.SeriesRef;
-import org.atlasapi.persistence.content.ContentResolver;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
@@ -24,6 +7,22 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.PeekingIterator;
+import org.atlasapi.equiv.results.description.ResultDescription;
+import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
+import org.atlasapi.equiv.results.scores.DefaultScoredCandidates.Builder;
+import org.atlasapi.equiv.results.scores.Score;
+import org.atlasapi.equiv.results.scores.ScoredCandidates;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
+import org.atlasapi.media.entity.Brand;
+import org.atlasapi.media.entity.Container;
+import org.atlasapi.media.entity.Identified;
+import org.atlasapi.media.entity.Series;
+import org.atlasapi.media.entity.SeriesRef;
+import org.atlasapi.persistence.content.ContentResolver;
+
+import java.util.List;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -49,7 +48,7 @@ public class ContainerHierarchyMatchingScorer implements EquivalenceScorer<Conta
             Container subj,
             Set<? extends Container> candidates,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent scorerComponent = EquivToTelescopeComponent.create();
         scorerComponent.setComponentName("Container Hierarchy Matching Scorer");
@@ -117,7 +116,7 @@ public class ContainerHierarchyMatchingScorer implements EquivalenceScorer<Conta
             }
         }
 
-        equivToTelescopeResults.addScorerResult(scorerComponent);
+        equivToTelescopeResult.addScorerResult(scorerComponent);
         
         desc.finishStage();
         return results.build();

--- a/src/main/java/org/atlasapi/equiv/scorers/ContainerYearScorer.java
+++ b/src/main/java/org/atlasapi/equiv/scorers/ContainerYearScorer.java
@@ -5,7 +5,7 @@ import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Container;
 
 import java.util.Set;
@@ -27,7 +27,7 @@ public class ContainerYearScorer implements EquivalenceScorer<Container> {
             Container subject,
             Set<? extends Container> candidates,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent scorerComponent = EquivToTelescopeComponent.create();
         scorerComponent.setComponentName("Container Year Scorer");
@@ -43,7 +43,7 @@ public class ContainerYearScorer implements EquivalenceScorer<Container> {
             );
         }
 
-        equivToTelescopeResults.addScorerResult(scorerComponent);
+        equivToTelescopeResult.addScorerResult(scorerComponent);
 
         return scoredCandidates.build();
     }

--- a/src/main/java/org/atlasapi/equiv/scorers/ContentAliasScorer.java
+++ b/src/main/java/org/atlasapi/equiv/scorers/ContentAliasScorer.java
@@ -1,15 +1,14 @@
 package org.atlasapi.equiv.scorers;
 
 import com.google.common.collect.Sets;
-
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
-import org.atlasapi.media.entity.Item;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Alias;
+import org.atlasapi.media.entity.Item;
 
 import java.util.Set;
 
@@ -30,7 +29,7 @@ public class ContentAliasScorer implements EquivalenceScorer<Item> {
             Item subject,
             Set<? extends Item> candidates,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         DefaultScoredCandidates.Builder<Item> equivalents =
                 DefaultScoredCandidates.fromSource(NAME);
@@ -50,7 +49,7 @@ public class ContentAliasScorer implements EquivalenceScorer<Item> {
             }
         });
 
-        equivToTelescopeResults.addScorerResult(scorerComponent);
+        equivToTelescopeResult.addScorerResult(scorerComponent);
 
         return equivalents.build();
     }

--- a/src/main/java/org/atlasapi/equiv/scorers/CrewMemberScorer.java
+++ b/src/main/java/org/atlasapi/equiv/scorers/CrewMemberScorer.java
@@ -8,7 +8,7 @@ import org.atlasapi.equiv.results.scores.DefaultScoredCandidates.Builder;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.CrewMember;
 import org.atlasapi.media.entity.CrewMember.Role;
 import org.atlasapi.media.entity.Item;
@@ -44,7 +44,7 @@ public class CrewMemberScorer implements EquivalenceScorer<Item> {
             Item content,
             Set<? extends Item> candidates,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent scorerComponent = EquivToTelescopeComponent.create();
         scorerComponent.setComponentName("Crew Member Scorer");

--- a/src/main/java/org/atlasapi/equiv/scorers/DescriptionMatchingScorer.java
+++ b/src/main/java/org/atlasapi/equiv/scorers/DescriptionMatchingScorer.java
@@ -1,24 +1,22 @@
 package org.atlasapi.equiv.scorers;
 
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import org.atlasapi.equiv.results.description.ResultDescription;
+import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
+import org.atlasapi.equiv.results.scores.Score;
+import org.atlasapi.equiv.results.scores.ScoredCandidates;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
+import org.atlasapi.media.entity.Item;
+
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import org.atlasapi.equiv.results.description.ResultDescription;
-import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
-import org.atlasapi.equiv.results.scores.Score;
-import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
-import org.atlasapi.media.entity.Equiv;
-import org.atlasapi.media.entity.Item;
-
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 
 public class DescriptionMatchingScorer implements EquivalenceScorer<Item> {
 
@@ -46,7 +44,7 @@ public class DescriptionMatchingScorer implements EquivalenceScorer<Item> {
             Item subject,
             Set<? extends Item> candidates,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent scorerComponent = EquivToTelescopeComponent.create();
         scorerComponent.setComponentName("Description Matching Scorer");
@@ -66,7 +64,7 @@ public class DescriptionMatchingScorer implements EquivalenceScorer<Item> {
             }
         }
 
-        equivToTelescopeResults.addScorerResult(scorerComponent);
+        equivToTelescopeResult.addScorerResult(scorerComponent);
 
         return equivalents.build();
     }

--- a/src/main/java/org/atlasapi/equiv/scorers/DescriptionTitleMatchingScorer.java
+++ b/src/main/java/org/atlasapi/equiv/scorers/DescriptionTitleMatchingScorer.java
@@ -1,22 +1,20 @@
 package org.atlasapi.equiv.scorers;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.stream.Collectors;
-
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
-
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates.Builder;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Item;
 
-import com.google.common.base.Strings;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class DescriptionTitleMatchingScorer implements EquivalenceScorer<Item> {
 
@@ -45,7 +43,7 @@ public class DescriptionTitleMatchingScorer implements EquivalenceScorer<Item> {
             Item subject,
             Set<? extends Item> suggestions,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent scorerComponent = EquivToTelescopeComponent.create();
         scorerComponent.setComponentName("Description Title Matching Scorer");
@@ -64,7 +62,7 @@ public class DescriptionTitleMatchingScorer implements EquivalenceScorer<Item> {
             }
         }
 
-        equivToTelescopeResults.addScorerResult(scorerComponent);
+        equivToTelescopeResult.addScorerResult(scorerComponent);
 
         return equivalents.build();
     }

--- a/src/main/java/org/atlasapi/equiv/scorers/EquivalenceScorer.java
+++ b/src/main/java/org/atlasapi/equiv/scorers/EquivalenceScorer.java
@@ -1,10 +1,10 @@
 package org.atlasapi.equiv.scorers;
 
-import java.util.Set;
-
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
+
+import java.util.Set;
 
 public interface EquivalenceScorer<T> {
 
@@ -23,7 +23,7 @@ public interface EquivalenceScorer<T> {
             T subject,
             Set<? extends T> candidates,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     );
     
 }

--- a/src/main/java/org/atlasapi/equiv/scorers/EquivalenceScorers.java
+++ b/src/main/java/org/atlasapi/equiv/scorers/EquivalenceScorers.java
@@ -1,15 +1,14 @@
 package org.atlasapi.equiv.scorers;
 
-import java.util.List;
-import java.util.Set;
-
-import org.atlasapi.equiv.results.description.ResultDescription;
-import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
-
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
+import org.atlasapi.equiv.results.description.ResultDescription;
+import org.atlasapi.equiv.results.scores.ScoredCandidates;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
+
+import java.util.List;
+import java.util.Set;
 
 public class EquivalenceScorers<T> {
     
@@ -27,7 +26,7 @@ public class EquivalenceScorers<T> {
             T content,
             Set<? extends T> candidates,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         desc.startStage("Scoring equivalences");
         Builder<ScoredCandidates<T>> scoredScores = ImmutableList.builder();
@@ -35,7 +34,7 @@ public class EquivalenceScorers<T> {
         for (EquivalenceScorer<T> scorer : scorers) {
             try {
                 desc.startStage(scorer.toString());
-                scoredScores.add(scorer.score(content, candidates, desc, equivToTelescopeResults));
+                scoredScores.add(scorer.score(content, candidates, desc, equivToTelescopeResult));
                 desc.finishStage();
             } catch (Exception e) {
                 throw new RuntimeException(String.format("%s - %s", scorer, content), e);

--- a/src/main/java/org/atlasapi/equiv/scorers/ItemYearScorer.java
+++ b/src/main/java/org/atlasapi/equiv/scorers/ItemYearScorer.java
@@ -5,7 +5,7 @@ import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Item;
 
 import java.util.Set;
@@ -27,7 +27,7 @@ public class ItemYearScorer implements EquivalenceScorer<Item> {
             org.atlasapi.media.entity.Item subject,
             Set<? extends org.atlasapi.media.entity.Item> candidates,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent scorerComponent = EquivToTelescopeComponent.create();
         scorerComponent.setComponentName("Item Year Scorer");
@@ -43,7 +43,7 @@ public class ItemYearScorer implements EquivalenceScorer<Item> {
             );
         }
 
-        equivToTelescopeResults.addScorerResult(scorerComponent);
+        equivToTelescopeResult.addScorerResult(scorerComponent);
 
         return scoredCandidates.build();
     }

--- a/src/main/java/org/atlasapi/equiv/scorers/ScalingEquivalenceScorer.java
+++ b/src/main/java/org/atlasapi/equiv/scorers/ScalingEquivalenceScorer.java
@@ -1,14 +1,13 @@
 package org.atlasapi.equiv.scorers;
 
-import java.util.Set;
-
+import com.google.common.base.Function;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScaledScoredEquivalents;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Content;
 
-import com.google.common.base.Function;
+import java.util.Set;
 
 public class ScalingEquivalenceScorer<T extends Content> implements EquivalenceScorer<T> {
 
@@ -43,13 +42,13 @@ public class ScalingEquivalenceScorer<T extends Content> implements EquivalenceS
             T content,
             Set<? extends T> suggestions,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         return ScaledScoredEquivalents.<T>scale(delegate.score(
                 content,
                 suggestions,
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ), scalingFunction);
     }
  

--- a/src/main/java/org/atlasapi/equiv/scorers/SequenceContainerScorer.java
+++ b/src/main/java/org/atlasapi/equiv/scorers/SequenceContainerScorer.java
@@ -1,18 +1,17 @@
 package org.atlasapi.equiv.scorers;
 
-import java.util.Set;
-
+import com.google.common.collect.Iterables;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
-import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates.Builder;
+import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Series;
 
-import com.google.common.collect.Iterables;
+import java.util.Set;
 
 
 public class SequenceContainerScorer implements EquivalenceScorer<Container> {
@@ -22,7 +21,7 @@ public class SequenceContainerScorer implements EquivalenceScorer<Container> {
             Container subject,
             Set<? extends Container> candidates,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent scorerComponent = EquivToTelescopeComponent.create();
         scorerComponent.setComponentName("Sequence Container Scorer");

--- a/src/main/java/org/atlasapi/equiv/scorers/SequenceItemScorer.java
+++ b/src/main/java/org/atlasapi/equiv/scorers/SequenceItemScorer.java
@@ -1,21 +1,20 @@
 package org.atlasapi.equiv.scorers;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.util.Set;
-
+import com.google.common.base.Objects;
+import com.google.common.collect.Iterables;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
+import org.atlasapi.equiv.results.scores.DefaultScoredCandidates.Builder;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.results.scores.DefaultScoredCandidates.Builder;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Episode;
 import org.atlasapi.media.entity.Item;
 
-import com.google.common.base.Objects;
-import com.google.common.collect.Iterables;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class SequenceItemScorer implements EquivalenceScorer<Item> {
 
@@ -32,7 +31,7 @@ public class SequenceItemScorer implements EquivalenceScorer<Item> {
             Item subject,
             Set<? extends Item> candidates,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent scorerComponent = EquivToTelescopeComponent.create();
         scorerComponent.setComponentName("Sequence Item Scorer");
@@ -71,7 +70,7 @@ public class SequenceItemScorer implements EquivalenceScorer<Item> {
             }
         }
 
-        equivToTelescopeResults.addScorerResult(scorerComponent);
+        equivToTelescopeResult.addScorerResult(scorerComponent);
 
         return equivalents.build();
     }

--- a/src/main/java/org/atlasapi/equiv/scorers/SeriesSequenceItemScorer.java
+++ b/src/main/java/org/atlasapi/equiv/scorers/SeriesSequenceItemScorer.java
@@ -1,19 +1,17 @@
 package org.atlasapi.equiv.scorers;
 
-import java.util.Set;
-
+import com.google.common.base.Objects;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
+import org.atlasapi.equiv.results.scores.DefaultScoredCandidates.Builder;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.results.scores.DefaultScoredCandidates.Builder;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Episode;
-import org.atlasapi.media.entity.Equiv;
 import org.atlasapi.media.entity.Item;
 
-import com.google.common.base.Objects;
+import java.util.Set;
 
 public class SeriesSequenceItemScorer implements EquivalenceScorer<Item> {
 
@@ -24,7 +22,7 @@ public class SeriesSequenceItemScorer implements EquivalenceScorer<Item> {
             Item subject,
             Set<? extends Item> candidates,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent scorerComponent = EquivToTelescopeComponent.create();
         scorerComponent.setComponentName("Series Sequence Item Scorer");

--- a/src/main/java/org/atlasapi/equiv/scorers/TitleMatchingContainerScorer.java
+++ b/src/main/java/org/atlasapi/equiv/scorers/TitleMatchingContainerScorer.java
@@ -1,15 +1,14 @@
 package org.atlasapi.equiv.scorers;
 
-import java.util.Set;
-
+import com.google.common.base.Functions;
 import org.atlasapi.equiv.generators.ContentTitleScorer;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Container;
 
-import com.google.common.base.Functions;
+import java.util.Set;
 
 public class TitleMatchingContainerScorer implements EquivalenceScorer<Container> {
 
@@ -26,7 +25,7 @@ public class TitleMatchingContainerScorer implements EquivalenceScorer<Container
             Container subject,
             Set<? extends Container> candidates,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent scorerComponent = EquivToTelescopeComponent.create();
         scorerComponent.setComponentName("Title Matching Container Scorer");

--- a/src/main/java/org/atlasapi/equiv/scorers/TitleMatchingItemScorer.java
+++ b/src/main/java/org/atlasapi/equiv/scorers/TitleMatchingItemScorer.java
@@ -1,11 +1,9 @@
 package org.atlasapi.equiv.scorers;
 
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-
+import org.apache.commons.lang3.StringUtils;
 import org.atlasapi.equiv.generators.ExpandingTitleTransformer;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
@@ -13,12 +11,12 @@ import org.atlasapi.equiv.results.scores.DefaultScoredCandidates.Builder;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Item;
 
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
-import org.apache.commons.lang3.StringUtils;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class TitleMatchingItemScorer implements EquivalenceScorer<Item> {
     
@@ -76,7 +74,7 @@ public class TitleMatchingItemScorer implements EquivalenceScorer<Item> {
             Item subject,
             Set<? extends Item> suggestions,
             ResultDescription desc,
-            EquivToTelescopeResults equivToTelescopeResults
+            EquivToTelescopeResult equivToTelescopeResult
     ) {
         EquivToTelescopeComponent scorerComponent = EquivToTelescopeComponent.create();
         scorerComponent.setComponentName("Title Matching Item Scorer");
@@ -98,7 +96,7 @@ public class TitleMatchingItemScorer implements EquivalenceScorer<Item> {
             }
         }
 
-        equivToTelescopeResults.addScorerResult(scorerComponent);
+        equivToTelescopeResult.addScorerResult(scorerComponent);
     
         return equivalents.build();
     }

--- a/src/main/java/org/atlasapi/equiv/update/ContentEquivalenceResultUpdater.java
+++ b/src/main/java/org/atlasapi/equiv/update/ContentEquivalenceResultUpdater.java
@@ -17,6 +17,7 @@ import org.atlasapi.equiv.results.scores.ScoredEquivalentsMerger;
 import org.atlasapi.equiv.scorers.EquivalenceScorer;
 import org.atlasapi.equiv.scorers.EquivalenceScorers;
 import org.atlasapi.equiv.update.metadata.ContentEquivalenceResultProviderMetadata;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
 import org.atlasapi.equiv.update.metadata.EquivalenceUpdaterMetadata;
 import org.atlasapi.media.entity.Content;
@@ -75,10 +76,15 @@ public class ContentEquivalenceResultUpdater<T extends Content> implements Equiv
     ) {
         ReadableDescription desc = new DefaultDescription();
 
+        EquivToTelescopeResult resultForTelescope = EquivToTelescopeResult.create(
+                String.valueOf(content.getId()),
+                content.getPublisher().toString()
+        );
+
         List<ScoredCandidates<T>> generatedScores = generators.generate(
                 content,
                 desc,
-                resultsForTelescope
+                resultForTelescope
         );
 
         Set<T> candidates = ImmutableSet.copyOf(extractCandidates(generatedScores));
@@ -87,7 +93,7 @@ public class ContentEquivalenceResultUpdater<T extends Content> implements Equiv
                 content,
                 candidates,
                 desc,
-                resultsForTelescope
+                resultForTelescope
         );
         
         List<ScoredCandidates<T>> mergedScores = merger.merge(
@@ -99,8 +105,11 @@ public class ContentEquivalenceResultUpdater<T extends Content> implements Equiv
                 content,
                 mergedScores,
                 desc,
-                resultsForTelescope
+                resultForTelescope
         );
+
+        resultsForTelescope.addResult(resultForTelescope);
+
         return result;
     }
 

--- a/src/main/java/org/atlasapi/equiv/update/ContentEquivalenceResultUpdater.java
+++ b/src/main/java/org/atlasapi/equiv/update/ContentEquivalenceResultUpdater.java
@@ -8,7 +8,6 @@ import org.atlasapi.equiv.generators.EquivalenceGenerators;
 import org.atlasapi.equiv.results.DefaultEquivalenceResultBuilder;
 import org.atlasapi.equiv.results.EquivalenceResult;
 import org.atlasapi.equiv.results.combining.ScoreCombiner;
-import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.description.ReadableDescription;
 import org.atlasapi.equiv.results.extractors.EquivalenceExtractor;
 import org.atlasapi.equiv.results.filters.EquivalenceFilter;
@@ -70,9 +69,11 @@ public class ContentEquivalenceResultUpdater<T extends Content> implements Equiv
     }
 
     @Override
-    public EquivalenceResult<T> provideEquivalenceResult(T content, OwlTelescopeReporter telescope) {
-        ReadableDescription desc = new DefaultDescription();
-
+    public EquivalenceResult<T> provideEquivalenceResult(
+            T content,
+            OwlTelescopeReporter telescope,
+            ReadableDescription desc
+    ) {
         EquivToTelescopeResults resultsForTelescope = EquivToTelescopeResults.create(
                 String.valueOf(content.getId()),
                 content.getPublisher().toString()

--- a/src/main/java/org/atlasapi/equiv/update/ContentEquivalenceResultUpdater.java
+++ b/src/main/java/org/atlasapi/equiv/update/ContentEquivalenceResultUpdater.java
@@ -20,7 +20,6 @@ import org.atlasapi.equiv.update.metadata.ContentEquivalenceResultProviderMetada
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
 import org.atlasapi.equiv.update.metadata.EquivalenceUpdaterMetadata;
 import org.atlasapi.media.entity.Content;
-import org.atlasapi.reporting.telescope.OwlTelescopeReporter;
 
 import java.util.List;
 import java.util.Set;
@@ -72,13 +71,9 @@ public class ContentEquivalenceResultUpdater<T extends Content> implements Equiv
     @Override
     public EquivalenceResult<T> provideEquivalenceResult(
             T content,
-            OwlTelescopeReporter telescope
+            EquivToTelescopeResults resultsForTelescope
     ) {
         ReadableDescription desc = new DefaultDescription();
-        EquivToTelescopeResults resultsForTelescope = EquivToTelescopeResults.create(
-                String.valueOf(content.getId()),
-                content.getPublisher().toString()
-        );
 
         List<ScoredCandidates<T>> generatedScores = generators.generate(
                 content,

--- a/src/main/java/org/atlasapi/equiv/update/ContentEquivalenceResultUpdater.java
+++ b/src/main/java/org/atlasapi/equiv/update/ContentEquivalenceResultUpdater.java
@@ -1,0 +1,250 @@
+package org.atlasapi.equiv.update;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.metabroadcast.common.stream.MoreCollectors;
+import org.atlasapi.equiv.generators.EquivalenceGenerator;
+import org.atlasapi.equiv.generators.EquivalenceGenerators;
+import org.atlasapi.equiv.results.DefaultEquivalenceResultBuilder;
+import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.equiv.results.combining.ScoreCombiner;
+import org.atlasapi.equiv.results.description.DefaultDescription;
+import org.atlasapi.equiv.results.description.ReadableDescription;
+import org.atlasapi.equiv.results.extractors.EquivalenceExtractor;
+import org.atlasapi.equiv.results.filters.EquivalenceFilter;
+import org.atlasapi.equiv.results.scores.ScoredCandidates;
+import org.atlasapi.equiv.results.scores.ScoredEquivalentsMerger;
+import org.atlasapi.equiv.scorers.EquivalenceScorer;
+import org.atlasapi.equiv.scorers.EquivalenceScorers;
+import org.atlasapi.equiv.update.metadata.ContentEquivalenceResultProviderMetadata;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivalenceUpdaterMetadata;
+import org.atlasapi.media.entity.Content;
+import org.atlasapi.reporting.telescope.OwlTelescopeReporter;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.StreamSupport;
+
+public class ContentEquivalenceResultUpdater<T extends Content> implements EquivalenceResultUpdater<T> {
+
+    private final ScoredEquivalentsMerger merger;
+
+    private final EquivalenceGenerators<T> generators;
+    private final EquivalenceScorers<T> scorers;
+    private final DefaultEquivalenceResultBuilder<T> resultBuilder;
+
+    private final EquivalenceUpdaterMetadata metadata;
+
+    private ContentEquivalenceResultUpdater(Builder<T> builder) {
+        ImmutableSet<EquivalenceGenerator<T>> builtGenerators = builder.generators.build();
+        ImmutableSet<EquivalenceScorer<T>> builtScorers = builder.scorers.build();
+        ImmutableList<EquivalenceExtractor<T>> builtExtractors = builder.extractors.build();
+
+        this.merger = new ScoredEquivalentsMerger();
+        this.generators = EquivalenceGenerators.create(
+                builtGenerators,
+                builder.excludedUris,
+                builder.excludedIds
+        );
+        this.scorers = EquivalenceScorers.from(builtScorers);
+        this.resultBuilder = new DefaultEquivalenceResultBuilder<>(
+                builder.combiner,
+                builder.filter,
+                builtExtractors
+        );
+
+        this.metadata = ContentEquivalenceResultProviderMetadata.builder()
+                .withGenerators(builtGenerators)
+                .withScorers(builtScorers)
+                .withCombiner(builder.combiner)
+                .withFilter(builder.filter)
+                .withExtractors(builtExtractors)
+                .withExcludedUris(builder.excludedUris)
+                .withExcludedIds(builder.excludedIds)
+                .build();
+    }
+
+    public static <T extends Content> ExcludedUrisStep<T> builder() {
+        return new Builder<>();
+    }
+
+    @Override
+    public EquivalenceResult<T> provideEquivalenceResult(T content, OwlTelescopeReporter telescope) {
+        ReadableDescription desc = new DefaultDescription();
+
+        EquivToTelescopeResults resultsForTelescope = EquivToTelescopeResults.create(
+                String.valueOf(content.getId()),
+                content.getPublisher().toString()
+        );
+
+        List<ScoredCandidates<T>> generatedScores = generators.generate(
+                content,
+                desc,
+                resultsForTelescope
+        );
+
+        Set<T> candidates = ImmutableSet.copyOf(extractCandidates(generatedScores));
+        
+        List<ScoredCandidates<T>> scoredScores = scorers.score(
+                content,
+                candidates,
+                desc,
+                resultsForTelescope
+        );
+        
+        List<ScoredCandidates<T>> mergedScores = merger.merge(
+                generatedScores,
+                scoredScores
+        );
+        
+        EquivalenceResult<T> result = resultBuilder.resultFor(
+                content,
+                mergedScores,
+                desc,
+                resultsForTelescope
+        );
+        return result;
+    }
+
+    @Override
+    public EquivalenceUpdaterMetadata getMetadata() {
+        return metadata;
+    }
+
+    private Iterable<T> extractCandidates(Iterable<ScoredCandidates<T>> generatedScores) {
+
+        return StreamSupport.stream(generatedScores.spliterator(), false)
+                .map(input -> input.candidates().keySet())
+                .flatMap(Set::stream)
+                .collect(MoreCollectors.toImmutableSet());
+    }
+
+    public interface ExcludedUrisStep<T extends Content> {
+
+        ExcludedIdsStep<T> withExcludedUris(Set<String> excludedUris);
+    }
+
+    public interface ExcludedIdsStep<T extends Content> {
+
+        GeneratorStep<T> withExcludedIds(Set<String> excludedIds);
+    }
+
+    public interface GeneratorStep<T extends Content> {
+
+        ScorerStep<T> withGenerator(EquivalenceGenerator<T> generator);
+
+        ScorerStep<T> withGenerators(Iterable<? extends EquivalenceGenerator<T>> generators);
+    }
+
+    public interface ScorerStep<T extends Content> {
+
+        CombinerStep<T> withScorer(EquivalenceScorer<T> scorer);
+
+        CombinerStep<T> withScorers(Iterable<? extends EquivalenceScorer<T>> scorers);
+    }
+
+    public interface CombinerStep<T extends Content> {
+
+        FilterStep<T> withCombiner(ScoreCombiner<T> combiner);
+    }
+
+    public interface FilterStep<T extends Content> {
+
+        ExtractorStep<T> withFilter(EquivalenceFilter<T> filter);
+    }
+
+    public interface ExtractorStep<T extends Content> {
+
+        BuildStep<T> withExtractor(EquivalenceExtractor<T> extractor);
+
+        BuildStep<T> withExtractors(List<EquivalenceExtractor<T>> extractors);
+    }
+
+    public interface BuildStep<T extends Content> {
+
+        ContentEquivalenceResultUpdater<T> build();
+    }
+
+    public static class Builder<T extends Content> implements ExcludedUrisStep<T>,
+            ExcludedIdsStep<T>, GeneratorStep<T>, ScorerStep<T>, CombinerStep<T>, FilterStep<T>,
+            ExtractorStep<T>, BuildStep<T> {
+
+        private ImmutableSet.Builder<EquivalenceGenerator<T>> generators = ImmutableSet.builder();
+        private ImmutableSet.Builder<EquivalenceScorer<T>> scorers = ImmutableSet.builder();
+        private ScoreCombiner<T> combiner;
+        private EquivalenceFilter<T> filter;
+        private ImmutableList.Builder<EquivalenceExtractor<T>> extractors = ImmutableList.builder();
+        private Set<String> excludedUris;
+        private Set<String> excludedIds;
+
+        private Builder() {
+        }
+
+        @Override
+        public ExcludedIdsStep<T> withExcludedUris(Set<String> excludedUris) {
+            this.excludedUris = excludedUris;
+            return this;
+        }
+
+        @Override
+        public GeneratorStep<T> withExcludedIds(Set<String> excludedIds) {
+            this.excludedIds = excludedIds;
+            return this;
+        }
+
+        @Override
+        public ScorerStep<T> withGenerator(EquivalenceGenerator<T> generator) {
+            generators.add(generator);
+            return this;
+        }
+
+        @Override
+        public ScorerStep<T> withGenerators(
+                Iterable<? extends EquivalenceGenerator<T>> generators
+        ) {
+            this.generators.addAll(generators);
+            return this;
+        }
+
+        @Override
+        public CombinerStep<T> withScorer(EquivalenceScorer<T> scorer) {
+            this.scorers.add(scorer);
+            return this;
+        }
+
+        @Override
+        public CombinerStep<T> withScorers(Iterable<? extends EquivalenceScorer<T>> scorers) {
+            this.scorers.addAll(scorers);
+            return this;
+        }
+
+        @Override
+        public FilterStep<T> withCombiner(ScoreCombiner<T> combiner) {
+            this.combiner = combiner;
+            return this;
+        }
+
+        @Override
+        public ExtractorStep<T> withFilter(EquivalenceFilter<T> filter) {
+            this.filter = filter;
+            return this;
+        }
+
+        @Override
+        public BuildStep<T> withExtractor(EquivalenceExtractor<T> extractor) {
+            this.extractors.add(extractor);
+            return this;
+        }
+
+        @Override
+        public BuildStep<T> withExtractors(List<EquivalenceExtractor<T>> extractors) {
+            this.extractors.addAll(extractors);
+            return this;
+        }
+
+        public ContentEquivalenceResultUpdater<T> build() {
+            return new ContentEquivalenceResultUpdater<>(this);
+        }
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/ContentEquivalenceResultUpdater.java
+++ b/src/main/java/org/atlasapi/equiv/update/ContentEquivalenceResultUpdater.java
@@ -8,6 +8,7 @@ import org.atlasapi.equiv.generators.EquivalenceGenerators;
 import org.atlasapi.equiv.results.DefaultEquivalenceResultBuilder;
 import org.atlasapi.equiv.results.EquivalenceResult;
 import org.atlasapi.equiv.results.combining.ScoreCombiner;
+import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.description.ReadableDescription;
 import org.atlasapi.equiv.results.extractors.EquivalenceExtractor;
 import org.atlasapi.equiv.results.filters.EquivalenceFilter;
@@ -71,9 +72,9 @@ public class ContentEquivalenceResultUpdater<T extends Content> implements Equiv
     @Override
     public EquivalenceResult<T> provideEquivalenceResult(
             T content,
-            OwlTelescopeReporter telescope,
-            ReadableDescription desc
+            OwlTelescopeReporter telescope
     ) {
+        ReadableDescription desc = new DefaultDescription();
         EquivToTelescopeResults resultsForTelescope = EquivToTelescopeResults.create(
                 String.valueOf(content.getId()),
                 content.getPublisher().toString()

--- a/src/main/java/org/atlasapi/equiv/update/ContentEquivalenceUpdater.java
+++ b/src/main/java/org/atlasapi/equiv/update/ContentEquivalenceUpdater.java
@@ -55,7 +55,7 @@ public class ContentEquivalenceUpdater<T extends Content> implements Equivalence
         ImmutableList.Builder<EquivalenceResult<T>> resultsBuilder = ImmutableList.builder();
 
         for(EquivalenceResultUpdater<T> equivalenceResultUpdater : equivalenceResultUpdaters) {
-            resultsBuilder.add(equivalenceResultUpdater.provideEquivalenceResult(content, telescope));
+            resultsBuilder.add(equivalenceResultUpdater.provideEquivalenceResult(content, resultsForTelescope));
         }
 
         EquivalenceResults<T> results = new EquivalenceResults<>(content, resultsBuilder.build(), desc);

--- a/src/main/java/org/atlasapi/equiv/update/ContentEquivalenceUpdater.java
+++ b/src/main/java/org/atlasapi/equiv/update/ContentEquivalenceUpdater.java
@@ -1,24 +1,17 @@
 package org.atlasapi.equiv.update;
 
-import java.util.List;
-import java.util.Set;
-import java.util.stream.StreamSupport;
-
-import org.atlasapi.equiv.generators.EquivalenceGenerator;
-import org.atlasapi.equiv.generators.EquivalenceGenerators;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.Multimap;
 import org.atlasapi.equiv.handlers.EquivalenceResultHandler;
 import org.atlasapi.equiv.messengers.EquivalenceResultMessenger;
-import org.atlasapi.equiv.results.DefaultEquivalenceResultBuilder;
 import org.atlasapi.equiv.results.EquivalenceResult;
-import org.atlasapi.equiv.results.combining.ScoreCombiner;
 import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.description.ReadableDescription;
-import org.atlasapi.equiv.results.extractors.EquivalenceExtractor;
-import org.atlasapi.equiv.results.filters.EquivalenceFilter;
+import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
+import org.atlasapi.equiv.results.scores.Score;
+import org.atlasapi.equiv.results.scores.ScoredCandidate;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.results.scores.ScoredEquivalentsMerger;
-import org.atlasapi.equiv.scorers.EquivalenceScorer;
-import org.atlasapi.equiv.scorers.EquivalenceScorers;
 import org.atlasapi.equiv.update.metadata.ContentEquivalenceUpdaterMetadata;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
 import org.atlasapi.equiv.update.metadata.EquivalenceUpdaterMetadata;
@@ -26,60 +19,33 @@ import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.reporting.telescope.OwlTelescopeReporter;
 
-import com.metabroadcast.common.stream.MoreCollectors;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.gson.Gson;
-import com.google.gson.JsonElement;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class ContentEquivalenceUpdater<T extends Content> implements EquivalenceUpdater<T> {
 
-    private final ScoredEquivalentsMerger merger;
-
-    private final EquivalenceGenerators<T> generators;
-    private final EquivalenceScorers<T> scorers;
-    private final DefaultEquivalenceResultBuilder<T> resultBuilder;
+    private final Set<EquivalenceResultUpdater<T>> equivalenceResultUpdaters;
     private final EquivalenceResultHandler<T> handler;
     private final EquivalenceResultMessenger<T> messenger;
 
     private final EquivalenceUpdaterMetadata metadata;
 
     private ContentEquivalenceUpdater(Builder<T> builder) {
-        ImmutableSet<EquivalenceGenerator<T>> builtGenerators = builder.generators.build();
-        ImmutableSet<EquivalenceScorer<T>> builtScorers = builder.scorers.build();
-        ImmutableList<EquivalenceExtractor<T>> builtExtractors = builder.extractors.build();
-
-        this.merger = new ScoredEquivalentsMerger();
-        this.generators = EquivalenceGenerators.create(
-                builtGenerators,
-                builder.excludedUris,
-                builder.excludedIds
-        );
-        this.scorers = EquivalenceScorers.from(builtScorers);
-        this.resultBuilder = new DefaultEquivalenceResultBuilder<>(
-                builder.combiner,
-                builder.filter,
-                builtExtractors
-        );
+       this.equivalenceResultUpdaters = ImmutableSet.copyOf(builder.equivalenceResultUpdaters);
         this.handler = checkNotNull(builder.handler);
         this.messenger = checkNotNull(builder.messenger);
-
         this.metadata = ContentEquivalenceUpdaterMetadata.builder()
-                .withGenerators(builtGenerators)
-                .withScorers(builtScorers)
-                .withCombiner(builder.combiner)
-                .withFilter(builder.filter)
-                .withExtractors(builtExtractors)
+                .withEquivalenceResultUpdaters(this.equivalenceResultUpdaters)
                 .withHandler(handler)
-                .withExcludedUris(builder.excludedUris)
-                .withExcludedIds(builder.excludedIds)
                 .build();
     }
 
-    public static <T extends Content> ExcludedUrisStep<T> builder() {
+    public static <T extends Content> EquivalenceResultUpdatersStep<T> builder() {
         return new Builder<>();
     }
 
@@ -92,31 +58,24 @@ public class ContentEquivalenceUpdater<T extends Content> implements Equivalence
                 content.getPublisher().toString()
         );
 
-        List<ScoredCandidates<T>> generatedScores = generators.generate(
-                content,
-                desc,
-                resultsForTelescope
-        );
+        List<ScoredCandidates<T>> rawScores = new ArrayList<>();
+        Map<T, Score> combinedScores = new HashMap<>();
+        Multimap<Publisher, ScoredCandidate<T>> strongEquivalences = LinkedListMultimap.create();
 
-        Set<T> candidates = ImmutableSet.copyOf(extractCandidates(generatedScores));
-        
-        List<ScoredCandidates<T>> scoredScores = scorers.score(
+        for(EquivalenceResultUpdater<T> equivalenceResultUpdater : equivalenceResultUpdaters) {
+            EquivalenceResult<T> result = equivalenceResultUpdater.provideEquivalenceResult(content, telescope);
+            rawScores.addAll(result.rawScores());
+            combinedScores.putAll(result.combinedEquivalences().candidates());
+            strongEquivalences.putAll(result.strongEquivalences());
+            desc.appendText(result.description().toString());
+        }
+
+        EquivalenceResult<T> result = new EquivalenceResult<>(
                 content,
-                candidates,
-                desc,
-                resultsForTelescope
-        );
-        
-        List<ScoredCandidates<T>> mergedScores = merger.merge(
-                generatedScores,
-                scoredScores
-        );
-        
-        EquivalenceResult<T> result = resultBuilder.resultFor(
-                content,
-                mergedScores,
-                desc,
-                resultsForTelescope
+                rawScores,
+                DefaultScoredCandidates.fromMappedEquivs("ContentEquivalenceUpdater", combinedScores),
+                strongEquivalences,
+                desc
         );
 
         boolean handledWithStateChange = handler.handle(result);
@@ -140,53 +99,8 @@ public class ContentEquivalenceUpdater<T extends Content> implements Equivalence
         return metadata;
     }
 
-    private Iterable<T> extractCandidates(Iterable<ScoredCandidates<T>> generatedScores) {
-
-        return StreamSupport.stream(generatedScores.spliterator(), false)
-                .map(input -> input.candidates().keySet())
-                .flatMap(Set::stream)
-                .collect(MoreCollectors.toImmutableSet());
-    }
-
-    public interface ExcludedUrisStep<T extends Content> {
-
-        ExcludedIdsStep<T> withExcludedUris(Set<String> excludedUris);
-    }
-
-    public interface ExcludedIdsStep<T extends Content> {
-
-        GeneratorStep<T> withExcludedIds(Set<String> excludedIds);
-    }
-
-    public interface GeneratorStep<T extends Content> {
-
-        ScorerStep<T> withGenerator(EquivalenceGenerator<T> generator);
-
-        ScorerStep<T> withGenerators(Iterable<? extends EquivalenceGenerator<T>> generators);
-    }
-
-    public interface ScorerStep<T extends Content> {
-
-        CombinerStep<T> withScorer(EquivalenceScorer<T> scorer);
-
-        CombinerStep<T> withScorers(Iterable<? extends EquivalenceScorer<T>> scorers);
-    }
-
-    public interface CombinerStep<T extends Content> {
-
-        FilterStep<T> withCombiner(ScoreCombiner<T> combiner);
-    }
-
-    public interface FilterStep<T extends Content> {
-
-        ExtractorStep<T> withFilter(EquivalenceFilter<T> filter);
-    }
-
-    public interface ExtractorStep<T extends Content> {
-
-        HandlerStep<T> withExtractor(EquivalenceExtractor<T> extractor);
-
-        HandlerStep<T> withExtractors(List<EquivalenceExtractor<T>> extractors);
+    public interface  EquivalenceResultUpdatersStep<T extends Content> {
+        HandlerStep<T> withEquivalenceResultUpdaters(Set<EquivalenceResultUpdater<T>> equivalenceResultUpdaters);
     }
 
     public interface HandlerStep<T extends Content> {
@@ -204,82 +118,21 @@ public class ContentEquivalenceUpdater<T extends Content> implements Equivalence
         ContentEquivalenceUpdater<T> build();
     }
 
-    public static class Builder<T extends Content> implements ExcludedUrisStep<T>,
-            ExcludedIdsStep<T>, GeneratorStep<T>, ScorerStep<T>, CombinerStep<T>, FilterStep<T>,
-            ExtractorStep<T>, HandlerStep<T>, MessengerStep<T>, BuildStep<T> {
+    public static class Builder<T extends Content> implements EquivalenceResultUpdatersStep<T>, HandlerStep<T>,
+            MessengerStep<T>, BuildStep<T> {
 
-        private ImmutableSet.Builder<EquivalenceGenerator<T>> generators = ImmutableSet.builder();
-        private ImmutableSet.Builder<EquivalenceScorer<T>> scorers = ImmutableSet.builder();
-        private ScoreCombiner<T> combiner;
-        private EquivalenceFilter<T> filter;
-        private ImmutableList.Builder<EquivalenceExtractor<T>> extractors = ImmutableList.builder();
+        private Set<EquivalenceResultUpdater<T>> equivalenceResultUpdaters;
         private EquivalenceResultHandler<T> handler;
         private EquivalenceResultMessenger<T> messenger;
-        private Set<String> excludedUris;
-        private Set<String> excludedIds;
 
         private Builder() {
         }
 
         @Override
-        public ExcludedIdsStep<T> withExcludedUris(Set<String> excludedUris) {
-            this.excludedUris = excludedUris;
-            return this;
-        }
-
-        @Override
-        public GeneratorStep<T> withExcludedIds(Set<String> excludedIds) {
-            this.excludedIds = excludedIds;
-            return this;
-        }
-
-        @Override
-        public ScorerStep<T> withGenerator(EquivalenceGenerator<T> generator) {
-            generators.add(generator);
-            return this;
-        }
-
-        @Override
-        public ScorerStep<T> withGenerators(
-                Iterable<? extends EquivalenceGenerator<T>> generators
+        public HandlerStep<T> withEquivalenceResultUpdaters(
+                Set<EquivalenceResultUpdater<T>> equivalenceResultUpdaters
         ) {
-            this.generators.addAll(generators);
-            return this;
-        }
-
-        @Override
-        public CombinerStep<T> withScorer(EquivalenceScorer<T> scorer) {
-            this.scorers.add(scorer);
-            return this;
-        }
-
-        @Override
-        public CombinerStep<T> withScorers(Iterable<? extends EquivalenceScorer<T>> scorers) {
-            this.scorers.addAll(scorers);
-            return this;
-        }
-
-        @Override
-        public FilterStep<T> withCombiner(ScoreCombiner<T> combiner) {
-            this.combiner = combiner;
-            return this;
-        }
-
-        @Override
-        public ExtractorStep<T> withFilter(EquivalenceFilter<T> filter) {
-            this.filter = filter;
-            return this;
-        }
-
-        @Override
-        public HandlerStep<T> withExtractor(EquivalenceExtractor<T> extractor) {
-            this.extractors.add(extractor);
-            return this;
-        }
-
-        @Override
-        public HandlerStep<T> withExtractors(List<EquivalenceExtractor<T>> extractors) {
-            this.extractors.addAll(extractors);
+            this.equivalenceResultUpdaters = equivalenceResultUpdaters;
             return this;
         }
 

--- a/src/main/java/org/atlasapi/equiv/update/ContentEquivalenceUpdater.java
+++ b/src/main/java/org/atlasapi/equiv/update/ContentEquivalenceUpdater.java
@@ -63,7 +63,7 @@ public class ContentEquivalenceUpdater<T extends Content> implements Equivalence
         Multimap<Publisher, ScoredCandidate<T>> strongEquivalences = LinkedListMultimap.create();
 
         for(EquivalenceResultUpdater<T> equivalenceResultUpdater : equivalenceResultUpdaters) {
-            EquivalenceResult<T> result = equivalenceResultUpdater.provideEquivalenceResult(content, telescope);
+            EquivalenceResult<T> result = equivalenceResultUpdater.provideEquivalenceResult(content, telescope, desc);
             rawScores.addAll(result.rawScores());
             result.combinedEquivalences().candidates().forEach(
                     (key, value) -> combinedScores.merge( //this value likely won't be used - we'll keep the largest one just in case
@@ -83,7 +83,6 @@ public class ContentEquivalenceUpdater<T extends Content> implements Equivalence
                     )
             );
             strongEquivalences.putAll(result.strongEquivalences());
-            desc.appendText(result.description().toString());
         }
 
         EquivalenceResult<T> result = new EquivalenceResult<>(

--- a/src/main/java/org/atlasapi/equiv/update/EquivalenceResultUpdater.java
+++ b/src/main/java/org/atlasapi/equiv/update/EquivalenceResultUpdater.java
@@ -1,13 +1,14 @@
 package org.atlasapi.equiv.update;
 
 import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.equiv.results.description.ReadableDescription;
 import org.atlasapi.equiv.update.metadata.EquivalenceUpdaterMetadata;
 import org.atlasapi.reporting.telescope.OwlTelescopeReporter;
 
 
 public interface EquivalenceResultUpdater<T> {
 
-    EquivalenceResult<T> provideEquivalenceResult(T subject, OwlTelescopeReporter telescope);
+    EquivalenceResult<T> provideEquivalenceResult(T subject, OwlTelescopeReporter telescope, ReadableDescription desc);
 
     EquivalenceUpdaterMetadata getMetadata();
 }

--- a/src/main/java/org/atlasapi/equiv/update/EquivalenceResultUpdater.java
+++ b/src/main/java/org/atlasapi/equiv/update/EquivalenceResultUpdater.java
@@ -1,13 +1,13 @@
 package org.atlasapi.equiv.update;
 
 import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
 import org.atlasapi.equiv.update.metadata.EquivalenceUpdaterMetadata;
-import org.atlasapi.reporting.telescope.OwlTelescopeReporter;
 
 
 public interface EquivalenceResultUpdater<T> {
 
-    EquivalenceResult<T> provideEquivalenceResult(T subject, OwlTelescopeReporter telescope);
+    EquivalenceResult<T> provideEquivalenceResult(T subject, EquivToTelescopeResults resultsForTelescope);
 
     EquivalenceUpdaterMetadata getMetadata();
 }

--- a/src/main/java/org/atlasapi/equiv/update/EquivalenceResultUpdater.java
+++ b/src/main/java/org/atlasapi/equiv/update/EquivalenceResultUpdater.java
@@ -1,14 +1,13 @@
 package org.atlasapi.equiv.update;
 
 import org.atlasapi.equiv.results.EquivalenceResult;
-import org.atlasapi.equiv.results.description.ReadableDescription;
 import org.atlasapi.equiv.update.metadata.EquivalenceUpdaterMetadata;
 import org.atlasapi.reporting.telescope.OwlTelescopeReporter;
 
 
 public interface EquivalenceResultUpdater<T> {
 
-    EquivalenceResult<T> provideEquivalenceResult(T subject, OwlTelescopeReporter telescope, ReadableDescription desc);
+    EquivalenceResult<T> provideEquivalenceResult(T subject, OwlTelescopeReporter telescope);
 
     EquivalenceUpdaterMetadata getMetadata();
 }

--- a/src/main/java/org/atlasapi/equiv/update/EquivalenceResultUpdater.java
+++ b/src/main/java/org/atlasapi/equiv/update/EquivalenceResultUpdater.java
@@ -1,0 +1,13 @@
+package org.atlasapi.equiv.update;
+
+import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.equiv.update.metadata.EquivalenceUpdaterMetadata;
+import org.atlasapi.reporting.telescope.OwlTelescopeReporter;
+
+
+public interface EquivalenceResultUpdater<T> {
+
+    EquivalenceResult<T> provideEquivalenceResult(T subject, OwlTelescopeReporter telescope);
+
+    EquivalenceUpdaterMetadata getMetadata();
+}

--- a/src/main/java/org/atlasapi/equiv/update/handlers/providers/EquivalenceResultHandlerProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/handlers/providers/EquivalenceResultHandlerProvider.java
@@ -1,0 +1,15 @@
+package org.atlasapi.equiv.update.handlers.providers;
+
+import org.atlasapi.equiv.handlers.EquivalenceResultHandler;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Content;
+import org.atlasapi.media.entity.Publisher;
+
+import java.util.Set;
+
+public interface EquivalenceResultHandlerProvider<T extends Content> {
+    EquivalenceResultHandler<T> getHandler(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    );
+}

--- a/src/main/java/org/atlasapi/equiv/update/handlers/providers/container/NopContainerHandlerProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/handlers/providers/container/NopContainerHandlerProvider.java
@@ -1,0 +1,33 @@
+package org.atlasapi.equiv.update.handlers.providers.container;
+
+import org.atlasapi.equiv.handlers.EquivalenceResultHandler;
+import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.equiv.update.handlers.providers.EquivalenceResultHandlerProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Container;
+import org.atlasapi.media.entity.Publisher;
+
+import java.util.Set;
+
+public class NopContainerHandlerProvider implements EquivalenceResultHandlerProvider<Container> {
+
+    private NopContainerHandlerProvider() {
+    }
+
+    public static NopContainerHandlerProvider create() {
+        return new NopContainerHandlerProvider();
+    }
+
+    @Override
+    public EquivalenceResultHandler<Container> getHandler(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return new EquivalenceResultHandler<Container>() {
+            @Override
+            public boolean handle(EquivalenceResult<Container> result) {
+                return false;
+            }
+        };
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/handlers/providers/container/NopContainerHandlerProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/handlers/providers/container/NopContainerHandlerProvider.java
@@ -1,7 +1,7 @@
 package org.atlasapi.equiv.update.handlers.providers.container;
 
 import org.atlasapi.equiv.handlers.EquivalenceResultHandler;
-import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.equiv.handlers.NopEquivalenceResultHandler;
 import org.atlasapi.equiv.update.handlers.providers.EquivalenceResultHandlerProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Container;
@@ -23,11 +23,6 @@ public class NopContainerHandlerProvider implements EquivalenceResultHandlerProv
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return new EquivalenceResultHandler<Container>() {
-            @Override
-            public boolean handle(EquivalenceResult<Container> result) {
-                return false;
-            }
-        };
+        return new NopEquivalenceResultHandler<>();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/handlers/providers/container/StandardSeriesHandlerProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/handlers/providers/container/StandardSeriesHandlerProvider.java
@@ -1,0 +1,42 @@
+package org.atlasapi.equiv.update.handlers.providers.container;
+
+import com.google.common.collect.ImmutableList;
+import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
+import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
+import org.atlasapi.equiv.update.handlers.providers.EquivalenceResultHandlerProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Container;
+import org.atlasapi.media.entity.Publisher;
+
+import java.util.Set;
+
+public class StandardSeriesHandlerProvider implements EquivalenceResultHandlerProvider<Container> {
+
+    private StandardSeriesHandlerProvider() {
+    }
+
+    public static StandardSeriesHandlerProvider create() {
+        return new StandardSeriesHandlerProvider();
+    }
+
+    @Override
+    public EquivalenceResultHandler<Container> getHandler(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+                LookupWritingEquivalenceHandler.create(
+                        dependencies.getLookupWriter()
+                ),
+                new ResultWritingEquivalenceHandler<>(
+                        dependencies.getEquivalenceResultStore()
+                ),
+                new EquivalenceSummaryWritingHandler<>(
+                        dependencies.getEquivSummaryStore()
+                )
+        ));
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/handlers/providers/container/StandardTopLevelContainerHandlerProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/handlers/providers/container/StandardTopLevelContainerHandlerProvider.java
@@ -1,0 +1,49 @@
+package org.atlasapi.equiv.update.handlers.providers.container;
+
+import com.google.common.collect.ImmutableList;
+import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EpisodeMatchingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.EquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
+import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
+import org.atlasapi.equiv.update.handlers.providers.EquivalenceResultHandlerProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Container;
+import org.atlasapi.media.entity.Publisher;
+
+import java.util.Set;
+
+public class StandardTopLevelContainerHandlerProvider implements EquivalenceResultHandlerProvider<Container> {
+
+    private StandardTopLevelContainerHandlerProvider() {
+    }
+
+    public static StandardTopLevelContainerHandlerProvider create() {
+        return new StandardTopLevelContainerHandlerProvider();
+    }
+
+    @Override
+    public EquivalenceResultHandler<Container> getHandler(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+                LookupWritingEquivalenceHandler.create(
+                        dependencies.getLookupWriter()
+                ),
+                new EpisodeMatchingEquivalenceHandler(
+                        dependencies.getContentResolver(),
+                        dependencies.getEquivSummaryStore(),
+                        dependencies.getLookupWriter(),
+                        targetPublishers
+                ),
+                new ResultWritingEquivalenceHandler<>(
+                        dependencies.getEquivalenceResultStore()
+                ),
+                new EquivalenceSummaryWritingHandler<>(
+                        dependencies.getEquivSummaryStore()
+                )
+        ));
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/handlers/providers/item/NopItemHandlerProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/handlers/providers/item/NopItemHandlerProvider.java
@@ -1,0 +1,34 @@
+package org.atlasapi.equiv.update.handlers.providers.item;
+
+import org.atlasapi.equiv.handlers.EquivalenceResultHandler;
+import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.equiv.update.handlers.providers.EquivalenceResultHandlerProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Publisher;
+
+import java.util.Set;
+
+public class NopItemHandlerProvider implements EquivalenceResultHandlerProvider<Item> {
+
+    private NopItemHandlerProvider() {
+
+    }
+
+    public static NopItemHandlerProvider create() {
+        return new NopItemHandlerProvider();
+    }
+
+    @Override
+    public EquivalenceResultHandler<Item> getHandler(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return new EquivalenceResultHandler<Item>() {
+            @Override
+            public boolean handle(EquivalenceResult<Item> result) {
+                return false;
+            }
+        };
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/handlers/providers/item/NopItemHandlerProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/handlers/providers/item/NopItemHandlerProvider.java
@@ -1,7 +1,7 @@
 package org.atlasapi.equiv.update.handlers.providers.item;
 
 import org.atlasapi.equiv.handlers.EquivalenceResultHandler;
-import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.equiv.handlers.NopEquivalenceResultHandler;
 import org.atlasapi.equiv.update.handlers.providers.EquivalenceResultHandlerProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Item;
@@ -24,11 +24,6 @@ public class NopItemHandlerProvider implements EquivalenceResultHandlerProvider<
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return new EquivalenceResultHandler<Item>() {
-            @Override
-            public boolean handle(EquivalenceResult<Item> result) {
-                return false;
-            }
-        };
+        return new NopEquivalenceResultHandler<>();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/handlers/providers/item/StandardItemHandlerProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/handlers/providers/item/StandardItemHandlerProvider.java
@@ -1,0 +1,47 @@
+package org.atlasapi.equiv.update.handlers.providers.item;
+
+import com.google.common.collect.ImmutableList;
+import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
+import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
+import org.atlasapi.equiv.update.handlers.providers.EquivalenceResultHandlerProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Publisher;
+
+import java.util.Set;
+
+public class StandardItemHandlerProvider implements EquivalenceResultHandlerProvider<Item> {
+
+    private StandardItemHandlerProvider() {
+
+    }
+
+    public static StandardItemHandlerProvider create() {
+        return new StandardItemHandlerProvider();
+    }
+
+    @Override
+    public EquivalenceResultHandler<Item> getHandler(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+                EpisodeFilteringEquivalenceResultHandler.relaxed(
+                        LookupWritingEquivalenceHandler.create(
+                                dependencies.getLookupWriter()
+                        ),
+                        dependencies.getEquivSummaryStore()
+                ),
+                new ResultWritingEquivalenceHandler<>(
+                        dependencies.getEquivalenceResultStore()
+                ),
+                new EquivalenceSummaryWritingHandler<>(
+                        dependencies.getEquivSummaryStore()
+                )
+        ));
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/handlers/providers/item/StrictEpisodeItemHandlerProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/handlers/providers/item/StrictEpisodeItemHandlerProvider.java
@@ -1,0 +1,47 @@
+package org.atlasapi.equiv.update.handlers.providers.item;
+
+import com.google.common.collect.ImmutableList;
+import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EquivalenceResultHandler;
+import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
+import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
+import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
+import org.atlasapi.equiv.update.handlers.providers.EquivalenceResultHandlerProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Publisher;
+
+import java.util.Set;
+
+public class StrictEpisodeItemHandlerProvider implements EquivalenceResultHandlerProvider<Item> {
+
+    private StrictEpisodeItemHandlerProvider() {
+
+    }
+
+    public static StrictEpisodeItemHandlerProvider create() {
+        return new StrictEpisodeItemHandlerProvider();
+    }
+
+    @Override
+    public EquivalenceResultHandler<Item> getHandler(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+                EpisodeFilteringEquivalenceResultHandler.strict(
+                        LookupWritingEquivalenceHandler.create(
+                                dependencies.getLookupWriter()
+                        ),
+                        dependencies.getEquivSummaryStore()
+                ),
+                new ResultWritingEquivalenceHandler<>(
+                        dependencies.getEquivalenceResultStore()
+                ),
+                new EquivalenceSummaryWritingHandler<>(
+                        dependencies.getEquivSummaryStore()
+                )
+        ));
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/handlers/types/ContainerEquivalenceHandlerType.java
+++ b/src/main/java/org/atlasapi/equiv/update/handlers/types/ContainerEquivalenceHandlerType.java
@@ -1,0 +1,32 @@
+package org.atlasapi.equiv.update.handlers.types;
+
+import org.atlasapi.equiv.update.handlers.providers.EquivalenceResultHandlerProvider;
+import org.atlasapi.equiv.update.handlers.providers.container.NopContainerHandlerProvider;
+import org.atlasapi.equiv.update.handlers.providers.container.StandardSeriesHandlerProvider;
+import org.atlasapi.equiv.update.handlers.providers.container.StandardTopLevelContainerHandlerProvider;
+import org.atlasapi.media.entity.Container;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public enum ContainerEquivalenceHandlerType {
+    NOP_CONTAINER(
+            NopContainerHandlerProvider.create()
+    ),
+    STANDARD_TOP_LEVEL_CONTAINER(
+            StandardTopLevelContainerHandlerProvider.create()
+    ),
+    STANDARD_SERIES(
+            StandardSeriesHandlerProvider.create()
+    )
+    ;
+
+    private final EquivalenceResultHandlerProvider<Container> handlerProvider;
+
+    ContainerEquivalenceHandlerType(EquivalenceResultHandlerProvider<Container> handlerProvider) {
+        this.handlerProvider = checkNotNull(handlerProvider);
+    }
+
+    public EquivalenceResultHandlerProvider<Container> getHandlerProvider() {
+        return handlerProvider;
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/handlers/types/ContainerEquivalenceHandlerType.java
+++ b/src/main/java/org/atlasapi/equiv/update/handlers/types/ContainerEquivalenceHandlerType.java
@@ -9,13 +9,13 @@ import org.atlasapi.media.entity.Container;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public enum ContainerEquivalenceHandlerType {
-    NOP_CONTAINER(
+    NOP_CONTAINER_HANDLER(
             NopContainerHandlerProvider.create()
     ),
-    STANDARD_TOP_LEVEL_CONTAINER(
+    STANDARD_CONTAINER_HANDLER(
             StandardTopLevelContainerHandlerProvider.create()
     ),
-    STANDARD_SERIES(
+    STANDARD_SERIES_HANDLER(
             StandardSeriesHandlerProvider.create()
     )
     ;

--- a/src/main/java/org/atlasapi/equiv/update/handlers/types/ItemEquivalenceHandlerType.java
+++ b/src/main/java/org/atlasapi/equiv/update/handlers/types/ItemEquivalenceHandlerType.java
@@ -9,13 +9,13 @@ import org.atlasapi.media.entity.Item;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public enum ItemEquivalenceHandlerType {
-    NOP_ITEM(
+    NOP_ITEM_HANDLER(
             NopItemHandlerProvider.create()
     ),
-    STANDARD_ITEM(
+    STANDARD_ITEM_HANDLER(
             StandardItemHandlerProvider.create()
     ),
-    STRICT_EPISODE_ITEM(
+    STRICT_EPISODE_ITEM_HANDLER(
             StrictEpisodeItemHandlerProvider.create()
     )
     ;

--- a/src/main/java/org/atlasapi/equiv/update/handlers/types/ItemEquivalenceHandlerType.java
+++ b/src/main/java/org/atlasapi/equiv/update/handlers/types/ItemEquivalenceHandlerType.java
@@ -1,0 +1,32 @@
+package org.atlasapi.equiv.update.handlers.types;
+
+import org.atlasapi.equiv.update.handlers.providers.EquivalenceResultHandlerProvider;
+import org.atlasapi.equiv.update.handlers.providers.item.NopItemHandlerProvider;
+import org.atlasapi.equiv.update.handlers.providers.item.StandardItemHandlerProvider;
+import org.atlasapi.equiv.update.handlers.providers.item.StrictEpisodeItemHandlerProvider;
+import org.atlasapi.media.entity.Item;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public enum ItemEquivalenceHandlerType {
+    NOP_ITEM(
+            NopItemHandlerProvider.create()
+    ),
+    STANDARD_ITEM(
+            StandardItemHandlerProvider.create()
+    ),
+    STRICT_EPISODE_ITEM(
+            StrictEpisodeItemHandlerProvider.create()
+    )
+    ;
+
+    private final EquivalenceResultHandlerProvider<Item> handlerProvider;
+
+    ItemEquivalenceHandlerType(EquivalenceResultHandlerProvider<Item> handlerProvider) {
+        this.handlerProvider = checkNotNull(handlerProvider);
+    }
+
+    public EquivalenceResultHandlerProvider<Item> getHandlerProvider() {
+        return handlerProvider;
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/messagers/providers/EquivalenceResultMessengerProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/messagers/providers/EquivalenceResultMessengerProvider.java
@@ -1,0 +1,15 @@
+package org.atlasapi.equiv.update.messagers.providers;
+
+import org.atlasapi.equiv.messengers.EquivalenceResultMessenger;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Content;
+import org.atlasapi.media.entity.Publisher;
+
+import java.util.Set;
+
+public interface EquivalenceResultMessengerProvider<T extends Content> {
+    EquivalenceResultMessenger<T> getMessenger(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    );
+}

--- a/src/main/java/org/atlasapi/equiv/update/messagers/providers/container/NopContainerMessengerProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/messagers/providers/container/NopContainerMessengerProvider.java
@@ -1,7 +1,7 @@
 package org.atlasapi.equiv.update.messagers.providers.container;
 
 import org.atlasapi.equiv.messengers.EquivalenceResultMessenger;
-import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.equiv.messengers.NopEquivalenceResultMessenger;
 import org.atlasapi.equiv.update.messagers.providers.EquivalenceResultMessengerProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Container;
@@ -23,11 +23,6 @@ public class NopContainerMessengerProvider implements EquivalenceResultMessenger
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return new EquivalenceResultMessenger<Container>() {
-            @Override
-            public void sendMessage(EquivalenceResult<Container> result) {
-
-            }
-        };
+        return new NopEquivalenceResultMessenger<>();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/messagers/providers/container/NopContainerMessengerProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/messagers/providers/container/NopContainerMessengerProvider.java
@@ -1,0 +1,33 @@
+package org.atlasapi.equiv.update.messagers.providers.container;
+
+import org.atlasapi.equiv.messengers.EquivalenceResultMessenger;
+import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.equiv.update.messagers.providers.EquivalenceResultMessengerProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Container;
+import org.atlasapi.media.entity.Publisher;
+
+import java.util.Set;
+
+public class NopContainerMessengerProvider implements EquivalenceResultMessengerProvider<Container> {
+
+    private NopContainerMessengerProvider() {
+    }
+
+    public static NopContainerMessengerProvider create() {
+        return new NopContainerMessengerProvider();
+    }
+
+    @Override
+    public EquivalenceResultMessenger<Container> getMessenger(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return new EquivalenceResultMessenger<Container>() {
+            @Override
+            public void sendMessage(EquivalenceResult<Container> result) {
+
+            }
+        };
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/messagers/providers/container/StandardSeriesMessengerProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/messagers/providers/container/StandardSeriesMessengerProvider.java
@@ -1,0 +1,31 @@
+package org.atlasapi.equiv.update.messagers.providers.container;
+
+import org.atlasapi.equiv.messengers.EquivalenceResultMessenger;
+import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
+import org.atlasapi.equiv.update.messagers.providers.EquivalenceResultMessengerProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Container;
+import org.atlasapi.media.entity.Publisher;
+
+import java.util.Set;
+
+public class StandardSeriesMessengerProvider implements EquivalenceResultMessengerProvider<Container> {
+
+    private StandardSeriesMessengerProvider() {
+    }
+
+    public static StandardSeriesMessengerProvider create() {
+        return new StandardSeriesMessengerProvider();
+    }
+
+    @Override
+    public EquivalenceResultMessenger<Container> getMessenger(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return QueueingEquivalenceResultMessenger.create(
+                dependencies.getMessageSender(),
+                dependencies.getLookupEntryStore()
+        );
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/messagers/providers/container/StandardTopLevelContainerMessengerProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/messagers/providers/container/StandardTopLevelContainerMessengerProvider.java
@@ -1,0 +1,31 @@
+package org.atlasapi.equiv.update.messagers.providers.container;
+
+import org.atlasapi.equiv.messengers.EquivalenceResultMessenger;
+import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
+import org.atlasapi.equiv.update.messagers.providers.EquivalenceResultMessengerProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Container;
+import org.atlasapi.media.entity.Publisher;
+
+import java.util.Set;
+
+public class StandardTopLevelContainerMessengerProvider implements EquivalenceResultMessengerProvider<Container> {
+
+    private StandardTopLevelContainerMessengerProvider() {
+    }
+
+    public static StandardTopLevelContainerMessengerProvider create() {
+        return new StandardTopLevelContainerMessengerProvider();
+    }
+
+    @Override
+    public EquivalenceResultMessenger<Container> getMessenger(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return QueueingEquivalenceResultMessenger.create(
+                dependencies.getMessageSender(),
+                dependencies.getLookupEntryStore()
+        );
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/messagers/providers/item/NopItemMessengerProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/messagers/providers/item/NopItemMessengerProvider.java
@@ -1,0 +1,33 @@
+package org.atlasapi.equiv.update.messagers.providers.item;
+
+import org.atlasapi.equiv.messengers.EquivalenceResultMessenger;
+import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.equiv.update.messagers.providers.EquivalenceResultMessengerProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Publisher;
+
+import java.util.Set;
+
+public class NopItemMessengerProvider implements EquivalenceResultMessengerProvider<Item> {
+
+    private NopItemMessengerProvider() {
+    }
+
+    public static NopItemMessengerProvider create() {
+        return new NopItemMessengerProvider();
+    }
+
+    @Override
+    public EquivalenceResultMessenger<Item> getMessenger(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return new EquivalenceResultMessenger<Item>() {
+            @Override
+            public void sendMessage(EquivalenceResult<Item> result) {
+
+            }
+        };
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/messagers/providers/item/NopItemMessengerProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/messagers/providers/item/NopItemMessengerProvider.java
@@ -1,7 +1,7 @@
 package org.atlasapi.equiv.update.messagers.providers.item;
 
 import org.atlasapi.equiv.messengers.EquivalenceResultMessenger;
-import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.equiv.messengers.NopEquivalenceResultMessenger;
 import org.atlasapi.equiv.update.messagers.providers.EquivalenceResultMessengerProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Item;
@@ -23,11 +23,6 @@ public class NopItemMessengerProvider implements EquivalenceResultMessengerProvi
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return new EquivalenceResultMessenger<Item>() {
-            @Override
-            public void sendMessage(EquivalenceResult<Item> result) {
-
-            }
-        };
+        return new NopEquivalenceResultMessenger<>();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/messagers/providers/item/StandardItemMessengerProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/messagers/providers/item/StandardItemMessengerProvider.java
@@ -1,0 +1,31 @@
+package org.atlasapi.equiv.update.messagers.providers.item;
+
+import org.atlasapi.equiv.messengers.EquivalenceResultMessenger;
+import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
+import org.atlasapi.equiv.update.messagers.providers.EquivalenceResultMessengerProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Publisher;
+
+import java.util.Set;
+
+public class StandardItemMessengerProvider implements EquivalenceResultMessengerProvider<Item> {
+
+    private StandardItemMessengerProvider() {
+    }
+
+    public static StandardItemMessengerProvider create() {
+        return new StandardItemMessengerProvider();
+    }
+
+    @Override
+    public EquivalenceResultMessenger<Item> getMessenger(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    ) {
+        return QueueingEquivalenceResultMessenger.create(
+                dependencies.getMessageSender(),
+                dependencies.getLookupEntryStore()
+        );
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/messagers/types/ContainerEquivalenceMessengerType.java
+++ b/src/main/java/org/atlasapi/equiv/update/messagers/types/ContainerEquivalenceMessengerType.java
@@ -1,0 +1,33 @@
+package org.atlasapi.equiv.update.messagers.types;
+
+import org.atlasapi.equiv.update.messagers.providers.EquivalenceResultMessengerProvider;
+import org.atlasapi.equiv.update.messagers.providers.container.NopContainerMessengerProvider;
+import org.atlasapi.equiv.update.messagers.providers.container.StandardSeriesMessengerProvider;
+import org.atlasapi.equiv.update.messagers.providers.container.StandardTopLevelContainerMessengerProvider;
+import org.atlasapi.media.entity.Container;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public enum ContainerEquivalenceMessengerType {
+    NOP_CONTAINER(
+            NopContainerMessengerProvider.create()
+    ),
+    STANDARD_TOP_LEVEL_CONTAINER(
+            StandardTopLevelContainerMessengerProvider.create()
+    ),
+    STANDARD_SERIES(
+            StandardSeriesMessengerProvider.create()
+    )
+
+    ;
+
+    private final EquivalenceResultMessengerProvider<Container> messengerProvider;
+
+    ContainerEquivalenceMessengerType(EquivalenceResultMessengerProvider<Container> messengerProvider) {
+        this.messengerProvider = checkNotNull(messengerProvider);
+    }
+
+    public EquivalenceResultMessengerProvider<Container> getMessengerProvider() {
+        return messengerProvider;
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/messagers/types/ContainerEquivalenceMessengerType.java
+++ b/src/main/java/org/atlasapi/equiv/update/messagers/types/ContainerEquivalenceMessengerType.java
@@ -9,13 +9,13 @@ import org.atlasapi.media.entity.Container;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public enum ContainerEquivalenceMessengerType {
-    NOP_CONTAINER(
+    NOP_CONTAINER_MESSENGER(
             NopContainerMessengerProvider.create()
     ),
-    STANDARD_TOP_LEVEL_CONTAINER(
+    STANDARD_CONTAINER_MESSENGER(
             StandardTopLevelContainerMessengerProvider.create()
     ),
-    STANDARD_SERIES(
+    STANDARD_SERIES_MESSENGER(
             StandardSeriesMessengerProvider.create()
     )
 

--- a/src/main/java/org/atlasapi/equiv/update/messagers/types/ItemEquivalenceMessengerType.java
+++ b/src/main/java/org/atlasapi/equiv/update/messagers/types/ItemEquivalenceMessengerType.java
@@ -1,0 +1,28 @@
+package org.atlasapi.equiv.update.messagers.types;
+
+import org.atlasapi.equiv.update.messagers.providers.EquivalenceResultMessengerProvider;
+import org.atlasapi.equiv.update.messagers.providers.item.NopItemMessengerProvider;
+import org.atlasapi.equiv.update.messagers.providers.item.StandardItemMessengerProvider;
+import org.atlasapi.media.entity.Item;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public enum ItemEquivalenceMessengerType {
+    NOP_ITEM(
+            NopItemMessengerProvider.create()
+    ),
+    STANDARD_ITEM(
+            StandardItemMessengerProvider.create()
+    ),
+    ;
+
+    private final EquivalenceResultMessengerProvider<Item> messengerProvider;
+
+    ItemEquivalenceMessengerType(EquivalenceResultMessengerProvider<Item> messengerProvider) {
+        this.messengerProvider = checkNotNull(messengerProvider);
+    }
+
+    public EquivalenceResultMessengerProvider<Item> getMessengerProvider() {
+        return messengerProvider;
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/messagers/types/ItemEquivalenceMessengerType.java
+++ b/src/main/java/org/atlasapi/equiv/update/messagers/types/ItemEquivalenceMessengerType.java
@@ -8,10 +8,10 @@ import org.atlasapi.media.entity.Item;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public enum ItemEquivalenceMessengerType {
-    NOP_ITEM(
+    NOP_ITEM_MESSENGER(
             NopItemMessengerProvider.create()
     ),
-    STANDARD_ITEM(
+    STANDARD_ITEM_MESSENGER(
             StandardItemMessengerProvider.create()
     ),
     ;

--- a/src/main/java/org/atlasapi/equiv/update/metadata/ContentEquivalenceResultProviderMetadata.java
+++ b/src/main/java/org/atlasapi/equiv/update/metadata/ContentEquivalenceResultProviderMetadata.java
@@ -1,0 +1,187 @@
+package org.atlasapi.equiv.update.metadata;
+
+import com.google.common.collect.ImmutableList;
+import com.metabroadcast.common.stream.MoreCollectors;
+import org.atlasapi.equiv.generators.EquivalenceGenerator;
+import org.atlasapi.equiv.generators.metadata.EquivalenceGeneratorMetadata;
+import org.atlasapi.equiv.results.extractors.EquivalenceExtractor;
+import org.atlasapi.equiv.scorers.EquivalenceScorer;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.StreamSupport;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class ContentEquivalenceResultProviderMetadata extends EquivalenceUpdaterMetadata {
+
+    private final ImmutableList<EquivalenceGeneratorMetadata> generators;
+    private final ImmutableList<String> scorers;
+    private final String combiner;
+    private final String filter;
+    private final ImmutableList<String> extractor;
+    private final ImmutableList<String> excludedUris;
+    private final ImmutableList<String> excludedIds;
+
+    private ContentEquivalenceResultProviderMetadata(
+            Iterable<EquivalenceGeneratorMetadata> generators,
+            Iterable<String> scorers,
+            String combiner,
+            String filter,
+            Iterable<String> extractors,
+            Iterable<String> excludedUris,
+            Iterable<String> excludedIds
+    ) {
+        this.generators = ImmutableList.copyOf(generators);
+        this.scorers = ImmutableList.copyOf(scorers);
+        this.combiner = checkNotNull(combiner);
+        this.filter = checkNotNull(filter);
+        this.extractor = ImmutableList.copyOf(extractors);
+        this.excludedUris = ImmutableList.copyOf(excludedUris);
+        this.excludedIds = ImmutableList.copyOf(excludedIds);
+    }
+
+    public static GeneratorsStep builder() {
+        return new Builder();
+    }
+
+    public ImmutableList<EquivalenceGeneratorMetadata> getGenerators() {
+        return generators;
+    }
+
+    public ImmutableList<String> getScorers() {
+        return scorers;
+    }
+
+    public String getCombiner() {
+        return combiner;
+    }
+
+    public String getFilter() {
+        return filter;
+    }
+
+    public ImmutableList<String> getExtractor() {
+        return extractor;
+    }
+
+    public ImmutableList<String> getExcludedUris() {
+        return excludedUris;
+    }
+
+    public ImmutableList<String> getExcludedIds() {
+        return excludedIds;
+    }
+
+    public interface GeneratorsStep {
+
+        <T> ScorersStep withGenerators(Iterable<EquivalenceGenerator<T>> generators);
+    }
+
+    public interface ScorersStep {
+
+        <T> CombinerStep withScorers(Iterable<EquivalenceScorer<T>> scorers);
+    }
+
+    public interface CombinerStep {
+
+        FilterStep withCombiner(Object combiner);
+    }
+
+    public interface FilterStep {
+
+        ExtractorStep withFilter(Object filter);
+    }
+
+    public interface ExtractorStep {
+
+        <T> ExcludedUrisStep withExtractors(Iterable<EquivalenceExtractor<T>> extractors);
+    }
+
+    public interface ExcludedUrisStep {
+
+        ExcludedIdsStep withExcludedUris(Set<String> excludedUris);
+    }
+
+    public interface ExcludedIdsStep {
+
+        BuildStep withExcludedIds(Set<String> excludedUris);
+    }
+
+    public interface BuildStep {
+
+        ContentEquivalenceResultProviderMetadata build();
+    }
+
+    public static class Builder implements GeneratorsStep, ScorersStep, CombinerStep, FilterStep,
+            ExtractorStep, ExcludedUrisStep, ExcludedIdsStep, BuildStep {
+
+        private List<EquivalenceGeneratorMetadata> generators;
+        private List<String> scorers;
+        private String combiner;
+        private String filter;
+        private List<String> extractors;
+        private Set<String> excludedUris;
+        private Set<String> excludedIds;
+
+        private Builder() {
+        }
+
+        @Override
+        public <T> ScorersStep withGenerators(Iterable<EquivalenceGenerator<T>> generators) {
+            this.generators = StreamSupport.stream(generators.spliterator(), false)
+                    .map(EquivalenceGenerator::getMetadata)
+                    .collect(MoreCollectors.toImmutableList());
+            return this;
+        }
+
+        @Override
+        public <T> CombinerStep withScorers(Iterable<EquivalenceScorer<T>> scorers) {
+            this.scorers = getClassName(scorers);
+            return this;
+        }
+
+        @Override
+        public FilterStep withCombiner(Object combiner) {
+            this.combiner = getClassName(combiner);
+            return this;
+        }
+
+        @Override
+        public ExtractorStep withFilter(Object filter) {
+            this.filter = getClassName(filter);
+            return this;
+        }
+
+        @Override
+        public <T> ExcludedUrisStep withExtractors(Iterable<EquivalenceExtractor<T>> extractors) {
+            this.extractors = getClassName(extractors);
+            return this;
+        }
+
+        @Override
+        public ExcludedIdsStep withExcludedUris(Set<String> excludedUris) {
+            this.excludedUris = excludedUris;
+            return this;
+        }
+
+        @Override
+        public BuildStep withExcludedIds(Set<String> excludedIds) {
+            this.excludedIds = excludedIds;
+            return this;
+        }
+
+        @Override
+        public ContentEquivalenceResultProviderMetadata build() {
+            return new ContentEquivalenceResultProviderMetadata(
+                    this.generators,
+                    this.scorers,
+                    this.combiner,
+                    this.filter,
+                    this.extractors,
+                    this.excludedUris,
+                    this.excludedIds
+            );
+        }
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/metadata/ContentEquivalenceUpdaterMetadata.java
+++ b/src/main/java/org/atlasapi/equiv/update/metadata/ContentEquivalenceUpdaterMetadata.java
@@ -1,126 +1,51 @@
 package org.atlasapi.equiv.update.metadata;
 
-import java.util.List;
-import java.util.Set;
-import java.util.stream.StreamSupport;
-
-import org.atlasapi.equiv.generators.EquivalenceGenerator;
-import org.atlasapi.equiv.generators.metadata.EquivalenceGeneratorMetadata;
-import org.atlasapi.equiv.handlers.EquivalenceResultHandler;
-import org.atlasapi.equiv.results.extractors.EquivalenceExtractor;
-import org.atlasapi.equiv.scorers.EquivalenceScorer;
-
-import com.metabroadcast.common.stream.MoreCollectors;
-
 import com.google.common.collect.ImmutableList;
+import com.metabroadcast.common.stream.MoreCollectors;
+import org.atlasapi.equiv.handlers.EquivalenceResultHandler;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.media.entity.Content;
+
+import java.util.Collection;
+import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class ContentEquivalenceUpdaterMetadata extends EquivalenceUpdaterMetadata {
 
-    private final ImmutableList<EquivalenceGeneratorMetadata> generators;
-    private final ImmutableList<String> scorers;
-    private final String combiner;
-    private final String filter;
-    private final ImmutableList<String> extractor;
+    private final ImmutableList<EquivalenceUpdaterMetadata> equivalenceResultUpdaterMetadata;
     private final String handler;
-    private final ImmutableList<String> excludedUris;
-    private final ImmutableList<String> excludedIds;
 
     private ContentEquivalenceUpdaterMetadata(
-            Iterable<EquivalenceGeneratorMetadata> generators,
-            Iterable<String> scorers,
-            String combiner,
-            String filter,
-            Iterable<String> extractors,
-            String handler,
-            Iterable<String> excludedUris,
-            Iterable<String> excludedIds
+            Iterable<EquivalenceUpdaterMetadata> equivalenceResultUpdaterMetadata,
+            String handler
     ) {
-        this.generators = ImmutableList.copyOf(generators);
-        this.scorers = ImmutableList.copyOf(scorers);
-        this.combiner = checkNotNull(combiner);
-        this.filter = checkNotNull(filter);
-        this.extractor = ImmutableList.copyOf(extractors);
+        this.equivalenceResultUpdaterMetadata = ImmutableList.copyOf(equivalenceResultUpdaterMetadata);
         this.handler = checkNotNull(handler);
-        this.excludedUris = ImmutableList.copyOf(excludedUris);
-        this.excludedIds = ImmutableList.copyOf(excludedIds);
     }
 
-    public static GeneratorsStep builder() {
+    public static EquivalenceResultUpdatersStep builder() {
         return new Builder();
     }
 
-    public ImmutableList<EquivalenceGeneratorMetadata> getGenerators() {
-        return generators;
-    }
-
-    public ImmutableList<String> getScorers() {
-        return scorers;
-    }
-
-    public String getCombiner() {
-        return combiner;
-    }
-
-    public String getFilter() {
-        return filter;
-    }
-
-    public ImmutableList<String> getExtractor() {
-        return extractor;
+    public ImmutableList<EquivalenceUpdaterMetadata> getEquivalenceResultUpdaterMetadata() {
+        return equivalenceResultUpdaterMetadata;
     }
 
     public String getHandler() {
         return handler;
     }
 
-    public ImmutableList<String> getExcludedUris() {
-        return excludedUris;
-    }
+    public interface EquivalenceResultUpdatersStep {
 
-    public ImmutableList<String> getExcludedIds() {
-        return excludedIds;
-    }
-
-    public interface GeneratorsStep {
-
-        <T> ScorersStep withGenerators(Iterable<EquivalenceGenerator<T>> generators);
-    }
-
-    public interface ScorersStep {
-
-        <T> CombinerStep withScorers(Iterable<EquivalenceScorer<T>> scorers);
-    }
-
-    public interface CombinerStep {
-
-        FilterStep withCombiner(Object combiner);
-    }
-
-    public interface FilterStep {
-
-        ExtractorStep withFilter(Object filter);
-    }
-
-    public interface ExtractorStep {
-
-        <T> HandlerStep withExtractors(Iterable<EquivalenceExtractor<T>> extractors);
+        <T extends Content> HandlerStep withEquivalenceResultUpdaters(
+                Collection<EquivalenceResultUpdater<T>> equivalenceResultUpdaters
+        );
     }
 
     public interface HandlerStep {
 
-        <T> ExcludedUrisStep withHandler(EquivalenceResultHandler<T> handler);
-    }
-
-    public interface ExcludedUrisStep {
-
-        ExcludedIdsStep withExcludedUris(Set<String> excludedUris);
-    }
-
-    public interface ExcludedIdsStep {
-
-        BuildStep withExcludedIds(Set<String> excludedUris);
+        <T> BuildStep withHandler(EquivalenceResultHandler<T> handler);
     }
 
     public interface BuildStep {
@@ -128,82 +53,35 @@ public class ContentEquivalenceUpdaterMetadata extends EquivalenceUpdaterMetadat
         ContentEquivalenceUpdaterMetadata build();
     }
 
-    public static class Builder implements GeneratorsStep, ScorersStep, CombinerStep, FilterStep,
-            ExtractorStep, HandlerStep, ExcludedUrisStep, ExcludedIdsStep, BuildStep {
+    public static class Builder implements EquivalenceResultUpdatersStep, HandlerStep, BuildStep {
 
-        private List<EquivalenceGeneratorMetadata> generators;
-        private List<String> scorers;
-        private String combiner;
-        private String filter;
-        private List<String> extractors;
+        private List<EquivalenceUpdaterMetadata> equivalenceResultUpdaterMetadata;
         private String handler;
-        private Set<String> excludedUris;
-        private Set<String> excludedIds;
 
         private Builder() {
         }
 
         @Override
-        public <T> ScorersStep withGenerators(Iterable<EquivalenceGenerator<T>> generators) {
-            this.generators = StreamSupport.stream(generators.spliterator(), false)
-                    .map(EquivalenceGenerator::getMetadata)
+        public <T extends Content> HandlerStep withEquivalenceResultUpdaters(
+                Collection<EquivalenceResultUpdater<T>> equivalenceResultUpdaters
+        ) {
+            this.equivalenceResultUpdaterMetadata = equivalenceResultUpdaters.stream()
+                    .map(EquivalenceResultUpdater::getMetadata)
                     .collect(MoreCollectors.toImmutableList());
             return this;
         }
 
         @Override
-        public <T> CombinerStep withScorers(Iterable<EquivalenceScorer<T>> scorers) {
-            this.scorers = getClassName(scorers);
-            return this;
-        }
-
-        @Override
-        public FilterStep withCombiner(Object combiner) {
-            this.combiner = getClassName(combiner);
-            return this;
-        }
-
-        @Override
-        public ExtractorStep withFilter(Object filter) {
-            this.filter = getClassName(filter);
-            return this;
-        }
-
-        @Override
-        public <T> HandlerStep withExtractors(Iterable<EquivalenceExtractor<T>> extractors) {
-            this.extractors = getClassName(extractors);
-            return this;
-        }
-
-        @Override
-        public <T> ExcludedUrisStep withHandler(EquivalenceResultHandler<T> handler) {
+        public <T> BuildStep withHandler(EquivalenceResultHandler<T> handler) {
             this.handler = getClassName(handler);
-            return this;
-        }
-
-        @Override
-        public ExcludedIdsStep withExcludedUris(Set<String> excludedUris) {
-            this.excludedUris = excludedUris;
-            return this;
-        }
-
-        @Override
-        public BuildStep withExcludedIds(Set<String> excludedIds) {
-            this.excludedIds = excludedIds;
             return this;
         }
 
         @Override
         public ContentEquivalenceUpdaterMetadata build() {
             return new ContentEquivalenceUpdaterMetadata(
-                    this.generators,
-                    this.scorers,
-                    this.combiner,
-                    this.filter,
-                    this.extractors,
-                    this.handler,
-                    this.excludedUris,
-                    this.excludedIds
+                    this.equivalenceResultUpdaterMetadata,
+                    this.handler
             );
         }
     }

--- a/src/main/java/org/atlasapi/equiv/update/metadata/EquivToTelescopeResult.java
+++ b/src/main/java/org/atlasapi/equiv/update/metadata/EquivToTelescopeResult.java
@@ -1,0 +1,78 @@
+package org.atlasapi.equiv.update.metadata;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+public class EquivToTelescopeResult {
+
+    private String contentId;
+    private String publisher;
+    private List<EquivToTelescopeComponent> generators;
+    private List<EquivToTelescopeComponent> scorers;
+    private List<EquivToTelescopeComponent> combiners;
+    private List<EquivToTelescopeComponent> filters;
+    private List<EquivToTelescopeComponent> extractors;
+
+    private EquivToTelescopeResult(String contentId, String publisher) {
+        this.contentId = contentId;
+        this.publisher = publisher;
+        generators = new ArrayList<>();
+        scorers = new ArrayList<>();
+        combiners = new ArrayList<>();
+        filters = new ArrayList<>();
+        extractors = new ArrayList<>();
+    }
+
+    public static EquivToTelescopeResult create(String contentId, String publisher) {
+        return new EquivToTelescopeResult(contentId, publisher);
+    }
+
+    public void addGeneratorResult(EquivToTelescopeComponent generator) {
+        generators.add(generator);
+    }
+
+    public void addScorerResult(EquivToTelescopeComponent scorer) {
+        scorers.add(scorer);
+    }
+
+    public void addCombinerResult(EquivToTelescopeComponent combiner) {
+        combiners.add(combiner);
+    }
+
+    public void addFilterResult(EquivToTelescopeComponent filter) {
+        filters.add(filter);
+    }
+
+    public void addExtractorResult(EquivToTelescopeComponent extractor) {
+        extractors.add(extractor);
+    }
+
+    public String getContentId() {
+        return contentId;
+    }
+
+    public String getPublisher() {
+        return publisher;
+    }
+
+    public List<EquivToTelescopeComponent> getGenerators() {
+        return generators;
+    }
+
+    public List<EquivToTelescopeComponent> getScorers() {
+        return scorers;
+    }
+
+    public List<EquivToTelescopeComponent> getCombiners() {
+        return combiners;
+    }
+
+    public List<EquivToTelescopeComponent> getFilters() {
+        return filters;
+    }
+
+    public List<EquivToTelescopeComponent> getExtractors() {
+        return extractors;
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/update/metadata/EquivToTelescopeResults.java
+++ b/src/main/java/org/atlasapi/equiv/update/metadata/EquivToTelescopeResults.java
@@ -8,45 +8,20 @@ public class EquivToTelescopeResults {
 
     private String contentId;
     private String publisher;
-    //TODO: combine these into a single object and store a list of such objects - this is due to there now being multiple equiv providers per equiv run
-    private List<EquivToTelescopeComponent> generators;
-    private List<EquivToTelescopeComponent> scorers;
-    private List<EquivToTelescopeComponent> combiners;
-    private List<EquivToTelescopeComponent> filters;
-    private List<EquivToTelescopeComponent> extractors;
+    private List<EquivToTelescopeResult> results;
 
     private EquivToTelescopeResults(String contentId, String publisher) {
         this.contentId = contentId;
         this.publisher = publisher;
-        generators = new ArrayList<>();
-        scorers = new ArrayList<>();
-        combiners = new ArrayList<>();
-        filters = new ArrayList<>();
-        extractors = new ArrayList<>();
+        results = new ArrayList<>();
     }
 
     public static EquivToTelescopeResults create(String contentId, String publisher) {
         return new EquivToTelescopeResults(contentId, publisher);
     }
 
-    public void addGeneratorResult(EquivToTelescopeComponent generator) {
-        generators.add(generator);
-    }
-
-    public void addScorerResult(EquivToTelescopeComponent scorer) {
-        scorers.add(scorer);
-    }
-
-    public void addCombinerResult(EquivToTelescopeComponent combiner) {
-        combiners.add(combiner);
-    }
-
-    public void addFilterResult(EquivToTelescopeComponent filter) {
-        filters.add(filter);
-    }
-
-    public void addExtractorResult(EquivToTelescopeComponent extractor) {
-        extractors.add(extractor);
+    public void addResult(EquivToTelescopeResult result) {
+        results.add(result);
     }
 
     public String getContentId() {
@@ -57,23 +32,7 @@ public class EquivToTelescopeResults {
         return publisher;
     }
 
-    public List<EquivToTelescopeComponent> getGenerators() {
-        return generators;
-    }
-
-    public List<EquivToTelescopeComponent> getScorers() {
-        return scorers;
-    }
-
-    public List<EquivToTelescopeComponent> getCombiners() {
-        return combiners;
-    }
-
-    public List<EquivToTelescopeComponent> getFilters() {
-        return filters;
-    }
-
-    public List<EquivToTelescopeComponent> getExtractors() {
-        return extractors;
+    public List<EquivToTelescopeResult> getResults() {
+        return results;
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/metadata/EquivToTelescopeResults.java
+++ b/src/main/java/org/atlasapi/equiv/update/metadata/EquivToTelescopeResults.java
@@ -8,6 +8,7 @@ public class EquivToTelescopeResults {
 
     private String contentId;
     private String publisher;
+    //TODO: combine these into a single object and store a list of such objects - this is due to there now being multiple equiv providers per equiv run
     private List<EquivToTelescopeComponent> generators;
     private List<EquivToTelescopeComponent> scorers;
     private List<EquivToTelescopeComponent> combiners;

--- a/src/main/java/org/atlasapi/equiv/update/updaters/configuration/UpdaterConfiguration.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/configuration/UpdaterConfiguration.java
@@ -1,10 +1,14 @@
 package org.atlasapi.equiv.update.updaters.configuration;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.atlasapi.equiv.update.handlers.types.ContainerEquivalenceHandlerType;
+import org.atlasapi.equiv.update.handlers.types.ItemEquivalenceHandlerType;
+import org.atlasapi.equiv.update.messagers.types.ContainerEquivalenceMessengerType;
+import org.atlasapi.equiv.update.messagers.types.ItemEquivalenceMessengerType;
 import org.atlasapi.equiv.update.updaters.types.ContainerEquivalenceUpdaterType;
 import org.atlasapi.equiv.update.updaters.types.ItemEquivalenceUpdaterType;
 import org.atlasapi.media.entity.Publisher;
-
-import com.google.common.collect.ImmutableSet;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -12,40 +16,40 @@ public class UpdaterConfiguration {
 
     private final Publisher source;
 
-    private final ItemEquivalenceUpdaterType itemEquivalenceUpdaterType;
-    private final ImmutableSet<Publisher> itemEquivalenceTargetSources;
+    private final ImmutableMap<ItemEquivalenceUpdaterType, ImmutableSet<Publisher>> itemEquivalenceUpdaters;
+    private final ItemEquivalenceHandlerType itemEquivalenceHandlerType;
+    private final ItemEquivalenceMessengerType itemEquivalenceMessengerType;
 
-    private final ContainerEquivalenceUpdaterType topLevelContainerEquivalenceUpdaterType;
-    private final ImmutableSet<Publisher> topLevelContainerTargetSources;
+    private final ImmutableMap<ContainerEquivalenceUpdaterType, ImmutableSet<Publisher>> topLevelContainerEquivalenceUpdaters;
+    private final ContainerEquivalenceHandlerType topLevelContainerEquivalenceHandlerType;
+    private final ContainerEquivalenceMessengerType topLevelContainerEquivalenceMessengerType;
 
-    private final ContainerEquivalenceUpdaterType nonTopLevelContainerEquivalenceUpdaterType;
-    private final ImmutableSet<Publisher> nonTopLevelContainerTargetSources;
+    private final ImmutableMap<ContainerEquivalenceUpdaterType, ImmutableSet<Publisher>> nonTopLevelContainerEquivalenceUpdaters;
+    private final ContainerEquivalenceHandlerType nonTopLevelContainerEquivalenceHandlerType;
+    private final ContainerEquivalenceMessengerType nonTopLevelContainerEquivalenceMessengerType;
 
     private UpdaterConfiguration(
             Publisher source,
-            ItemEquivalenceUpdaterType itemEquivalenceUpdaterType,
-            ImmutableSet<Publisher> itemEquivalenceTargetSources,
-            ContainerEquivalenceUpdaterType topLevelContainerEquivalenceUpdaterType,
-            ImmutableSet<Publisher> topLevelContainerTargetSources,
-            ContainerEquivalenceUpdaterType nonTopLevelContainerEquivalenceUpdaterType,
-            ImmutableSet<Publisher> nonTopLevelContainerTargetSources
+            ImmutableMap<ItemEquivalenceUpdaterType, ImmutableSet<Publisher>> itemEquivalenceUpdaters,
+            ItemEquivalenceHandlerType itemEquivalenceHandlerType,
+            ItemEquivalenceMessengerType itemEquivalenceMessengerType,
+            ImmutableMap<ContainerEquivalenceUpdaterType, ImmutableSet<Publisher>> topLevelContainerEquivalenceUpdaters,
+            ContainerEquivalenceHandlerType topLevelContainerEquivalenceHandlerType,
+            ContainerEquivalenceMessengerType topLevelContainerEquivalenceMessengerType,
+            ImmutableMap<ContainerEquivalenceUpdaterType, ImmutableSet<Publisher>> nonTopLevelContainerEquivalenceUpdaters,
+            ContainerEquivalenceHandlerType nonTopLevelContainerEquivalenceHandlerType,
+            ContainerEquivalenceMessengerType nonTopLevelContainerEquivalenceMessengerType
     ) {
         this.source = checkNotNull(source);
-
-        this.itemEquivalenceUpdaterType = checkNotNull(itemEquivalenceUpdaterType);
-        this.itemEquivalenceTargetSources = ImmutableSet.copyOf(itemEquivalenceTargetSources);
-
-        this.topLevelContainerEquivalenceUpdaterType = checkNotNull(
-                topLevelContainerEquivalenceUpdaterType
-        );
-        this.topLevelContainerTargetSources = ImmutableSet.copyOf(topLevelContainerTargetSources);
-
-        this.nonTopLevelContainerEquivalenceUpdaterType = checkNotNull(
-                nonTopLevelContainerEquivalenceUpdaterType
-        );
-        this.nonTopLevelContainerTargetSources = ImmutableSet.copyOf(
-                nonTopLevelContainerTargetSources
-        );
+        this.itemEquivalenceUpdaters = ImmutableMap.copyOf(itemEquivalenceUpdaters);
+        this.itemEquivalenceHandlerType = checkNotNull(itemEquivalenceHandlerType);
+        this.itemEquivalenceMessengerType = checkNotNull(itemEquivalenceMessengerType);
+        this.topLevelContainerEquivalenceUpdaters = ImmutableMap.copyOf(topLevelContainerEquivalenceUpdaters);
+        this.topLevelContainerEquivalenceHandlerType = checkNotNull(topLevelContainerEquivalenceHandlerType);
+        this.topLevelContainerEquivalenceMessengerType = checkNotNull(topLevelContainerEquivalenceMessengerType);
+        this.nonTopLevelContainerEquivalenceUpdaters = ImmutableMap.copyOf(nonTopLevelContainerEquivalenceUpdaters);
+        this.nonTopLevelContainerEquivalenceHandlerType = checkNotNull(nonTopLevelContainerEquivalenceHandlerType);
+        this.nonTopLevelContainerEquivalenceMessengerType = checkNotNull(nonTopLevelContainerEquivalenceMessengerType);
     }
 
     public static SourceStep builder() {
@@ -56,28 +60,40 @@ public class UpdaterConfiguration {
         return source;
     }
 
-    public ItemEquivalenceUpdaterType getItemEquivalenceUpdaterType() {
-        return itemEquivalenceUpdaterType;
+    public ImmutableMap<ItemEquivalenceUpdaterType, ImmutableSet<Publisher>> getItemEquivalenceUpdaters() {
+        return itemEquivalenceUpdaters;
     }
 
-    public ImmutableSet<Publisher> getItemEquivalenceTargetSources() {
-        return itemEquivalenceTargetSources;
+    public ItemEquivalenceHandlerType getItemEquivalenceHandlerType() {
+        return itemEquivalenceHandlerType;
     }
 
-    public ContainerEquivalenceUpdaterType getTopLevelContainerEquivalenceUpdaterType() {
-        return topLevelContainerEquivalenceUpdaterType;
+    public ItemEquivalenceMessengerType getItemEquivalenceMessengerType() {
+        return itemEquivalenceMessengerType;
     }
 
-    public ImmutableSet<Publisher> getTopLevelContainerTargetSources() {
-        return topLevelContainerTargetSources;
+    public ImmutableMap<ContainerEquivalenceUpdaterType, ImmutableSet<Publisher>> getTopLevelContainerEquivalenceUpdaters() {
+        return topLevelContainerEquivalenceUpdaters;
     }
 
-    public ContainerEquivalenceUpdaterType getNonTopLevelContainerEquivalenceUpdaterType() {
-        return nonTopLevelContainerEquivalenceUpdaterType;
+    public ContainerEquivalenceHandlerType getTopLevelContainerEquivalenceHandlerType() {
+        return topLevelContainerEquivalenceHandlerType;
     }
 
-    public ImmutableSet<Publisher> getNonTopLevelContainerTargetSources() {
-        return nonTopLevelContainerTargetSources;
+    public ContainerEquivalenceMessengerType getTopLevelContainerEquivalenceMessengerType() {
+        return topLevelContainerEquivalenceMessengerType;
+    }
+
+    public ImmutableMap<ContainerEquivalenceUpdaterType, ImmutableSet<Publisher>> getNonTopLevelContainerEquivalenceUpdaters() {
+        return nonTopLevelContainerEquivalenceUpdaters;
+    }
+
+    public ContainerEquivalenceHandlerType getNonTopLevelContainerEquivalenceHandlerType() {
+        return nonTopLevelContainerEquivalenceHandlerType;
+    }
+
+    public ContainerEquivalenceMessengerType getNonTopLevelContainerEquivalenceMessengerType() {
+        return nonTopLevelContainerEquivalenceMessengerType;
     }
 
     public interface SourceStep {
@@ -88,24 +104,27 @@ public class UpdaterConfiguration {
     public interface ItemEquivalenceUpdaterStep {
 
         TopLevelContainerEquivalenceUpdaterStep withItemEquivalenceUpdater(
-                ItemEquivalenceUpdaterType itemEquivalenceUpdaterType,
-                ImmutableSet<Publisher> itemEquivalenceTargetSources
+                ImmutableMap<ItemEquivalenceUpdaterType, ImmutableSet<Publisher>> itemEquivalenceUpdaters,
+                ItemEquivalenceHandlerType itemEquivalenceHandlerType,
+                ItemEquivalenceMessengerType itemEquivalenceMessengerType
         );
     }
 
     public interface TopLevelContainerEquivalenceUpdaterStep {
 
         NonTopLevelContainerEquivalenceUpdaterStep withTopLevelContainerEquivalenceUpdater(
-                ContainerEquivalenceUpdaterType topLevelContainerEquivalenceUpdaterType,
-                ImmutableSet<Publisher> topLevelContainerTargetSources
+                ImmutableMap<ContainerEquivalenceUpdaterType, ImmutableSet<Publisher>> topLevelContainerEquivalenceUpdaters,
+                ContainerEquivalenceHandlerType topLevelContainerEquivalenceHandlerType,
+                ContainerEquivalenceMessengerType topLevelContainerEquivalenceMessengerType
         );
     }
 
     public interface NonTopLevelContainerEquivalenceUpdaterStep {
 
         BuildStep withNonTopLevelContainerEquivalenceUpdater(
-                ContainerEquivalenceUpdaterType nonTopLevelContainerEquivalenceUpdaterType,
-                ImmutableSet<Publisher> nonTopLevelContainerTargetSources
+                ImmutableMap<ContainerEquivalenceUpdaterType, ImmutableSet<Publisher>> nonTopLevelContainerEquivalenceUpdaters,
+                ContainerEquivalenceHandlerType nonTopLevelContainerEquivalenceHandlerType,
+                ContainerEquivalenceMessengerType nonTopLevelContainerEquivalenceMessengerType
         );
     }
 
@@ -120,12 +139,15 @@ public class UpdaterConfiguration {
             BuildStep {
 
         private Publisher source;
-        private ItemEquivalenceUpdaterType itemEquivalenceUpdaterType;
-        private ImmutableSet<Publisher> itemEquivalenceTargetSources;
-        private ContainerEquivalenceUpdaterType topLevelContainerEquivalenceUpdaterType;
-        private ImmutableSet<Publisher> topLevelContainerTargetSources;
-        private ContainerEquivalenceUpdaterType nonTopLevelContainerEquivalenceUpdaterType;
-        private ImmutableSet<Publisher> nonTopLevelContainerTargetSources;
+        private ImmutableMap<ItemEquivalenceUpdaterType, ImmutableSet<Publisher>> itemEquivalenceUpdaters;
+        private ItemEquivalenceHandlerType itemEquivalenceHandlerType;
+        private ItemEquivalenceMessengerType itemEquivalenceMessengerType;
+        private ImmutableMap<ContainerEquivalenceUpdaterType, ImmutableSet<Publisher>> topLevelContainerEquivalenceUpdaters;
+        private ContainerEquivalenceHandlerType topLevelContainerEquivalenceHandlerType;
+        private ContainerEquivalenceMessengerType topLevelContainerEquivalenceMessengerType;
+        private ImmutableMap<ContainerEquivalenceUpdaterType, ImmutableSet<Publisher>> nonTopLevelContainerEquivalenceUpdaters;
+        private ContainerEquivalenceHandlerType nonTopLevelContainerEquivalenceHandlerType;
+        private ContainerEquivalenceMessengerType nonTopLevelContainerEquivalenceMessengerType;
 
         private Builder() {
         }
@@ -138,32 +160,37 @@ public class UpdaterConfiguration {
 
         @Override
         public TopLevelContainerEquivalenceUpdaterStep withItemEquivalenceUpdater(
-                ItemEquivalenceUpdaterType itemEquivalenceUpdaterType,
-                ImmutableSet<Publisher> itemEquivalenceTargetSources
+                ImmutableMap<ItemEquivalenceUpdaterType, ImmutableSet<Publisher>> itemEquivalenceUpdaters,
+                ItemEquivalenceHandlerType itemEquivalenceHandlerType,
+                ItemEquivalenceMessengerType itemEquivalenceMessengerType
         ) {
-            this.itemEquivalenceUpdaterType = itemEquivalenceUpdaterType;
-            this.itemEquivalenceTargetSources = itemEquivalenceTargetSources;
+            this.itemEquivalenceUpdaters = itemEquivalenceUpdaters;
+            this.itemEquivalenceHandlerType = itemEquivalenceHandlerType;
+            this.itemEquivalenceMessengerType = itemEquivalenceMessengerType;
             return this;
         }
 
         @Override
         public NonTopLevelContainerEquivalenceUpdaterStep withTopLevelContainerEquivalenceUpdater(
-                ContainerEquivalenceUpdaterType topLevelContainerEquivalenceUpdaterType,
-                ImmutableSet<Publisher> topLevelContainerTargetSources
+                ImmutableMap<ContainerEquivalenceUpdaterType, ImmutableSet<Publisher>> topLevelContainerEquivalenceUpdaters,
+                ContainerEquivalenceHandlerType topLevelContainerEquivalenceHandlerType,
+                ContainerEquivalenceMessengerType topLevelContainerEquivalenceMessengerType
         ) {
-            this.topLevelContainerEquivalenceUpdaterType = topLevelContainerEquivalenceUpdaterType;
-            this.topLevelContainerTargetSources = topLevelContainerTargetSources;
+            this.topLevelContainerEquivalenceUpdaters = topLevelContainerEquivalenceUpdaters;
+            this.topLevelContainerEquivalenceHandlerType = topLevelContainerEquivalenceHandlerType;
+            this.topLevelContainerEquivalenceMessengerType = topLevelContainerEquivalenceMessengerType;
             return this;
         }
 
         @Override
         public BuildStep withNonTopLevelContainerEquivalenceUpdater(
-                ContainerEquivalenceUpdaterType nonTopLevelContainerEquivalenceUpdaterType,
-                ImmutableSet<Publisher> nonTopLevelContainerTargetSources
+                ImmutableMap<ContainerEquivalenceUpdaterType, ImmutableSet<Publisher>> nonTopLevelContainerEquivalenceUpdaters,
+                ContainerEquivalenceHandlerType nonTopLevelContainerEquivalenceHandlerType,
+                ContainerEquivalenceMessengerType nonTopLevelContainerEquivalenceMessengerType
         ) {
-            this.nonTopLevelContainerEquivalenceUpdaterType =
-                    nonTopLevelContainerEquivalenceUpdaterType;
-            this.nonTopLevelContainerTargetSources = topLevelContainerTargetSources;
+            this.nonTopLevelContainerEquivalenceUpdaters = nonTopLevelContainerEquivalenceUpdaters;
+            this.nonTopLevelContainerEquivalenceHandlerType = nonTopLevelContainerEquivalenceHandlerType;
+            this.nonTopLevelContainerEquivalenceMessengerType = nonTopLevelContainerEquivalenceMessengerType;
             return this;
         }
 
@@ -171,12 +198,15 @@ public class UpdaterConfiguration {
         public UpdaterConfiguration build() {
             return new UpdaterConfiguration(
                     this.source,
-                    this.itemEquivalenceUpdaterType,
-                    this.itemEquivalenceTargetSources,
-                    this.topLevelContainerEquivalenceUpdaterType,
-                    this.topLevelContainerTargetSources,
-                    this.nonTopLevelContainerEquivalenceUpdaterType,
-                    this.nonTopLevelContainerTargetSources
+                    this.itemEquivalenceUpdaters,
+                    this.itemEquivalenceHandlerType,
+                    this.itemEquivalenceMessengerType,
+                    this.topLevelContainerEquivalenceUpdaters,
+                    this.topLevelContainerEquivalenceHandlerType,
+                    this.topLevelContainerEquivalenceMessengerType,
+                    this.nonTopLevelContainerEquivalenceUpdaters,
+                    this.nonTopLevelContainerEquivalenceHandlerType,
+                    this.nonTopLevelContainerEquivalenceMessengerType
             );
         }
     }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/configuration/UpdaterConfigurationRegistry.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/configuration/UpdaterConfigurationRegistry.java
@@ -1069,6 +1069,7 @@ public class UpdaterConfigurationRegistry {
                                         C4_PMLSD,
                                         C5_DATA_SUBMISSION,
                                         BARB_MASTER,
+                                        BARB_TRANSMISSIONS,
                                         BARB_X_MASTER,
                                         BARB_CENSUS
                                 ),

--- a/src/main/java/org/atlasapi/equiv/update/updaters/configuration/UpdaterConfigurationRegistry.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/configuration/UpdaterConfigurationRegistry.java
@@ -1069,10 +1069,10 @@ public class UpdaterConfigurationRegistry {
                                         C4_PMLSD,
                                         C5_DATA_SUBMISSION,
                                         BARB_MASTER,
-                                        BARB_TRANSMISSIONS,
                                         BARB_X_MASTER,
                                         BARB_CENSUS
-                                )
+                                ),
+                                TXLOGS_ITEM, ImmutableSet.of(BARB_TRANSMISSIONS) //TODO: remove after testing
                         ),
                         STANDARD_ITEM_HANDLER,
                         STANDARD_ITEM_MESSENGER

--- a/src/main/java/org/atlasapi/equiv/update/updaters/configuration/UpdaterConfigurationRegistry.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/configuration/UpdaterConfigurationRegistry.java
@@ -1072,8 +1072,7 @@ public class UpdaterConfigurationRegistry {
                                         BARB_TRANSMISSIONS,
                                         BARB_X_MASTER,
                                         BARB_CENSUS
-                                ),
-                                TXLOGS_ITEM, ImmutableSet.of(BARB_TRANSMISSIONS) //TODO: remove after testing
+                                )
                         ),
                         STANDARD_ITEM_HANDLER,
                         STANDARD_ITEM_MESSENGER
@@ -1162,8 +1161,7 @@ public class UpdaterConfigurationRegistry {
                 .withSource(BBC_NITRO)
                 .withItemEquivalenceUpdater(
                         ImmutableMap.of(
-                                STANDARD_ITEM, ImmutableSet.of(PA, UKTV, BARB_TRANSMISSIONS, BARB_MASTER), //TODO: revert changes before merging
-                                TXLOGS_ITEM, ImmutableSet.of(BARB_TRANSMISSIONS)
+                                STANDARD_ITEM, ImmutableSet.of(PA, UKTV, BARB_TRANSMISSIONS, BARB_MASTER)
                         ),
                         STANDARD_ITEM_HANDLER,
                         STANDARD_ITEM_MESSENGER

--- a/src/main/java/org/atlasapi/equiv/update/updaters/configuration/UpdaterConfigurationRegistry.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/configuration/UpdaterConfigurationRegistry.java
@@ -1162,7 +1162,7 @@ public class UpdaterConfigurationRegistry {
                 .withSource(BBC_NITRO)
                 .withItemEquivalenceUpdater(
                         ImmutableMap.of(
-                                STANDARD_ITEM, ImmutableSet.of(PA, UKTV, BARB_MASTER),
+                                STANDARD_ITEM, ImmutableSet.of(PA, UKTV, BARB_TRANSMISSIONS, BARB_MASTER), //TODO: revert changes before merging
                                 TXLOGS_ITEM, ImmutableSet.of(BARB_TRANSMISSIONS)
                         ),
                         STANDARD_ITEM_HANDLER,

--- a/src/main/java/org/atlasapi/equiv/update/updaters/configuration/UpdaterConfigurationRegistry.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/configuration/UpdaterConfigurationRegistry.java
@@ -1162,7 +1162,8 @@ public class UpdaterConfigurationRegistry {
                 .withSource(BBC_NITRO)
                 .withItemEquivalenceUpdater(
                         ImmutableMap.of(
-                                STANDARD_ITEM, ImmutableSet.of(PA, UKTV, BARB_TRANSMISSIONS, BARB_MASTER)
+                                STANDARD_ITEM, ImmutableSet.of(PA, UKTV, BARB_MASTER),
+                                TXLOGS_ITEM, ImmutableSet.of(BARB_TRANSMISSIONS)
                         ),
                         STANDARD_ITEM_HANDLER,
                         STANDARD_ITEM_MESSENGER

--- a/src/main/java/org/atlasapi/equiv/update/updaters/configuration/UpdaterConfigurationRegistry.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/configuration/UpdaterConfigurationRegistry.java
@@ -11,6 +11,17 @@ import org.atlasapi.media.entity.Publisher;
 import java.util.Set;
 
 import static java.lang.String.format;
+import static org.atlasapi.equiv.update.handlers.types.ContainerEquivalenceHandlerType.NOP_CONTAINER_HANDLER;
+import static org.atlasapi.equiv.update.handlers.types.ContainerEquivalenceHandlerType.STANDARD_CONTAINER_HANDLER;
+import static org.atlasapi.equiv.update.handlers.types.ContainerEquivalenceHandlerType.STANDARD_SERIES_HANDLER;
+import static org.atlasapi.equiv.update.handlers.types.ItemEquivalenceHandlerType.NOP_ITEM_HANDLER;
+import static org.atlasapi.equiv.update.handlers.types.ItemEquivalenceHandlerType.STANDARD_ITEM_HANDLER;
+import static org.atlasapi.equiv.update.handlers.types.ItemEquivalenceHandlerType.STRICT_EPISODE_ITEM_HANDLER;
+import static org.atlasapi.equiv.update.messagers.types.ContainerEquivalenceMessengerType.NOP_CONTAINER_MESSENGER;
+import static org.atlasapi.equiv.update.messagers.types.ContainerEquivalenceMessengerType.STANDARD_CONTAINER_MESSENGER;
+import static org.atlasapi.equiv.update.messagers.types.ContainerEquivalenceMessengerType.STANDARD_SERIES_MESSENGER;
+import static org.atlasapi.equiv.update.messagers.types.ItemEquivalenceMessengerType.NOP_ITEM_MESSENGER;
+import static org.atlasapi.equiv.update.messagers.types.ItemEquivalenceMessengerType.STANDARD_ITEM_MESSENGER;
 import static org.atlasapi.equiv.update.updaters.configuration.DefaultConfiguration.MUSIC_SOURCES;
 import static org.atlasapi.equiv.update.updaters.configuration.DefaultConfiguration.NON_STANDARD_SOURCES;
 import static org.atlasapi.equiv.update.updaters.configuration.DefaultConfiguration.TARGET_SOURCES;
@@ -92,7 +103,7 @@ import static org.atlasapi.media.entity.Publisher.YOUVIEW_STAGE;
  * This class contains the source configuration for equivalence. When the equivalence executor
  * picks up an item, it will check its source to see if there is a specific configuration for it,
  * and if there is it will only match it against the specified sources.
- *
+ * <p>
  * WHEN CREATING A NEW CONFIG, keep in mind to add your source to the NON_STANDARD_SOURCES list.
  * If you don't, standard equivalence will run on top of whatever config you have set, and
  * standard equivalence equivs to all sources.
@@ -207,16 +218,21 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(publisher)
                 .withItemEquivalenceUpdater(
-                        STANDARD_ITEM,
-                        MoreSets.add(TARGET_SOURCES, LOVEFILM)
+                        ImmutableMap.of(
+                                STANDARD_ITEM, MoreSets.add(TARGET_SOURCES, LOVEFILM)
+                        ),
+                        STANDARD_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        STANDARD_TOP_LEVEL_CONTAINER,
-                        MoreSets.add(TARGET_SOURCES, LOVEFILM)
+                        ImmutableMap.of(STANDARD_TOP_LEVEL_CONTAINER, MoreSets.add(TARGET_SOURCES, LOVEFILM)),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        STANDARD_SERIES,
-                        TARGET_SOURCES
+                        ImmutableMap.of(STANDARD_SERIES, TARGET_SOURCES),
+                        STANDARD_SERIES_HANDLER,
+                        STANDARD_SERIES_MESSENGER
                 )
                 .build();
     }
@@ -225,23 +241,32 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(WIKIPEDIA)
                 .withItemEquivalenceUpdater(
-                        WIKIPEDIA_ITEM,
-                        ImmutableSet.of(
-                                BBC_NITRO, ITV_CPS, UKTV, C4_PMLSD, C5_DATA_SUBMISSION,
-                                BARB_OVERRIDES, BARB_TRANSMISSIONS, BARB_MASTER
-                        )
+                        ImmutableMap.of(
+                                WIKIPEDIA_ITEM, ImmutableSet.of(
+                                        BBC_NITRO, ITV_CPS, UKTV, C4_PMLSD, C5_DATA_SUBMISSION,
+                                        BARB_OVERRIDES, BARB_TRANSMISSIONS, BARB_MASTER
+                                )
+                        ),
+                        STANDARD_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        WIKIPEDIA_CONTAINER,
-                        ImmutableSet.of(
-                                BBC_NITRO, ITV_CPS, UKTV, C4_PMLSD, C5_DATA_SUBMISSION, BARB_OVERRIDES
-                        )
+                        ImmutableMap.of(
+                                WIKIPEDIA_CONTAINER, ImmutableSet.of(
+                                        BBC_NITRO, ITV_CPS, UKTV, C4_PMLSD, C5_DATA_SUBMISSION, BARB_OVERRIDES
+                                )
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        WIKIPEDIA_CONTAINER,
-                        ImmutableSet.of(
-                                BBC_NITRO, ITV_CPS, UKTV, C4_PMLSD, C5_DATA_SUBMISSION, BARB_OVERRIDES
-                        )
+                        ImmutableMap.of(
+                                WIKIPEDIA_CONTAINER, ImmutableSet.of(
+                                        BBC_NITRO, ITV_CPS, UKTV, C4_PMLSD, C5_DATA_SUBMISSION, BARB_OVERRIDES
+                                )
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .build();
     }
@@ -250,18 +275,23 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(BARB_X_MASTER)
                 .withItemEquivalenceUpdater(
-                        BARB_X_ITEM,
-                        ImmutableSet.of(
-                                BARB_MASTER
-                        )
+                        ImmutableMap.of(
+                                BARB_X_ITEM, ImmutableSet.of(BARB_MASTER)
+                        ),
+                        STANDARD_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        STANDARD_TOP_LEVEL_CONTAINER,
-                        ImmutableSet.of() //there are no
+                        ImmutableMap.of(STANDARD_TOP_LEVEL_CONTAINER, ImmutableSet.of()), //there are no
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        STANDARD_SERIES,
-                        ImmutableSet.of()
+                        ImmutableMap.of(
+                                STANDARD_SERIES, ImmutableSet.of()
+                        ),
+                        STANDARD_SERIES_HANDLER,
+                        STANDARD_SERIES_MESSENGER
                 )
                 .build();
     }
@@ -270,21 +300,30 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(IMDB_API)
                 .withItemEquivalenceUpdater(
-                        IMDB_API_ITEM,
-                        ImmutableSet.of(
-                                BBC_NITRO, ITV_CPS, UKTV, C4_PMLSD, C5_DATA_SUBMISSION,
-                                BARB_OVERRIDES, BARB_TRANSMISSIONS, BARB_MASTER
-                        )
+                        ImmutableMap.of(
+                                IMDB_API_ITEM, ImmutableSet.of(
+                                        BBC_NITRO, ITV_CPS, UKTV, C4_PMLSD, C5_DATA_SUBMISSION,
+                                        BARB_OVERRIDES, BARB_TRANSMISSIONS, BARB_MASTER
+                                )
+                        ),
+                        STANDARD_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        IMDB_API_CONTAINER,
-                        ImmutableSet.of(
-                                BBC_NITRO, ITV_CPS, UKTV, C4_PMLSD, C5_DATA_SUBMISSION, BARB_OVERRIDES
-                        )
+                        ImmutableMap.of(
+                                IMDB_API_CONTAINER, ImmutableSet.of(
+                                        BBC_NITRO, ITV_CPS, UKTV, C4_PMLSD, C5_DATA_SUBMISSION, BARB_OVERRIDES
+                                )
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        IMDB_API_CONTAINER,
-                        ImmutableSet.of()
+                        ImmutableMap.of(
+                                IMDB_API_CONTAINER, ImmutableSet.of()
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .build();
     }
@@ -293,16 +332,25 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(RADIO_TIMES_UPCOMING)
                 .withItemEquivalenceUpdater(
-                        RT_UPCOMING_ITEM,
-                        ImmutableSet.of(AMAZON_UNBOX, PA)
+                        ImmutableMap.of(
+                                RT_UPCOMING_ITEM, ImmutableSet.of(AMAZON_UNBOX, PA)
+                        ),
+                        STANDARD_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        RT_UPCOMING_CONTAINER,
-                        ImmutableSet.of(AMAZON_UNBOX, PA)
+                        ImmutableMap.of(
+                                RT_UPCOMING_CONTAINER, ImmutableSet.of(AMAZON_UNBOX, PA)
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        RT_UPCOMING_CONTAINER,
-                        ImmutableSet.of(AMAZON_UNBOX, PA)
+                        ImmutableMap.of(
+                                RT_UPCOMING_CONTAINER, ImmutableSet.of(AMAZON_UNBOX, PA)
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .build();
     }
@@ -311,16 +359,25 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(BT_SPORT_EBS)
                 .withItemEquivalenceUpdater(
-                        STRICT_ITEM,
-                        MoreSets.add(TARGET_SOURCES, LOVEFILM)
+                        ImmutableMap.of(
+                                STRICT_ITEM, MoreSets.add(TARGET_SOURCES, LOVEFILM)
+                        ),
+                        STANDARD_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        STANDARD_TOP_LEVEL_CONTAINER,
-                        MoreSets.add(TARGET_SOURCES, LOVEFILM)
+                        ImmutableMap.of(
+                                STANDARD_TOP_LEVEL_CONTAINER, MoreSets.add(TARGET_SOURCES, LOVEFILM)
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        STANDARD_SERIES,
-                        TARGET_SOURCES
+                        ImmutableMap.of(
+                                STANDARD_SERIES, TARGET_SOURCES
+                        ),
+                        STANDARD_SERIES_HANDLER,
+                        STANDARD_SERIES_MESSENGER
                 )
                 .build();
     }
@@ -329,16 +386,26 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(AMC_EBS)
                 .withItemEquivalenceUpdater(
-                        STANDARD_ITEM,
-                        MoreSets.add(TARGET_SOURCES, LOVEFILM)
+                        ImmutableMap.of(
+                                STANDARD_ITEM, MoreSets.add(TARGET_SOURCES, LOVEFILM)
+
+                        ),
+                        STANDARD_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        STANDARD_TOP_LEVEL_CONTAINER,
-                        MoreSets.add(TARGET_SOURCES, LOVEFILM)
+                        ImmutableMap.of(
+                                STANDARD_TOP_LEVEL_CONTAINER, MoreSets.add(TARGET_SOURCES, LOVEFILM)
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        STANDARD_SERIES,
-                        ImmutableSet.of(AMC_EBS, PA)
+                        ImmutableMap.of(
+                                STANDARD_SERIES, ImmutableSet.of(AMC_EBS, PA)
+                        ),
+                        STANDARD_SERIES_HANDLER,
+                        STANDARD_SERIES_MESSENGER
                 )
                 .build();
     }
@@ -347,16 +414,25 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(RADIO_TIMES)
                 .withItemEquivalenceUpdater(
-                        RT_ITEM,
-                        ImmutableSet.of(PREVIEW_NETWORKS, AMAZON_UNBOX)
+                        ImmutableMap.of(
+                                RT_ITEM, ImmutableSet.of(PREVIEW_NETWORKS, AMAZON_UNBOX)
+                        ),
+                        STANDARD_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        NOP_CONTAINER,
-                        ImmutableSet.of()
+                        ImmutableMap.of(
+                                NOP_CONTAINER, ImmutableSet.of()
+                        ),
+                        NOP_CONTAINER_HANDLER,
+                        NOP_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        NOP_CONTAINER,
-                        ImmutableSet.of()
+                        ImmutableMap.of(
+                                NOP_CONTAINER, ImmutableSet.of()
+                        ),
+                        NOP_CONTAINER_HANDLER,
+                        NOP_CONTAINER_MESSENGER
                 )
                 .build();
     }
@@ -374,16 +450,25 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(YOUVIEW)
                 .withItemEquivalenceUpdater(
-                        YOUVIEW_ITEM,
-                        targetSources
+                        ImmutableMap.of(
+                                YOUVIEW_ITEM, targetSources
+                        ),
+                        STANDARD_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        BROADCAST_ITEM_CONTAINER,
-                        targetSources
+                        ImmutableMap.of(
+                                BROADCAST_ITEM_CONTAINER, targetSources
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        NOP_CONTAINER,
-                        ImmutableSet.of()
+                        ImmutableMap.of(
+                                NOP_CONTAINER, ImmutableSet.of()
+                        ),
+                        NOP_CONTAINER_HANDLER,
+                        NOP_CONTAINER_MESSENGER
                 )
                 .build();
     }
@@ -401,16 +486,25 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(YOUVIEW_STAGE)
                 .withItemEquivalenceUpdater(
-                        YOUVIEW_ITEM,
-                        targetSources
+                        ImmutableMap.of(
+                                YOUVIEW_ITEM, targetSources
+                        ),
+                        STANDARD_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        BROADCAST_ITEM_CONTAINER,
-                        targetSources
+                        ImmutableMap.of(
+                                BROADCAST_ITEM_CONTAINER, targetSources
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        NOP_CONTAINER,
-                        ImmutableSet.of()
+                        ImmutableMap.of(
+                                NOP_CONTAINER, ImmutableSet.of()
+                        ),
+                        NOP_CONTAINER_HANDLER,
+                        NOP_CONTAINER_MESSENGER
                 )
                 .build();
     }
@@ -428,16 +522,25 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(YOUVIEW_BT)
                 .withItemEquivalenceUpdater(
-                        YOUVIEW_ITEM,
-                        targetSources
+                        ImmutableMap.of(
+                                YOUVIEW_ITEM, targetSources
+                        ),
+                        STANDARD_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        BROADCAST_ITEM_CONTAINER,
-                        targetSources
+                        ImmutableMap.of(
+                                BROADCAST_ITEM_CONTAINER, targetSources
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        NOP_CONTAINER,
-                        ImmutableSet.of()
+                        ImmutableMap.of(
+                                NOP_CONTAINER, ImmutableSet.of()
+                        ),
+                        NOP_CONTAINER_HANDLER,
+                        NOP_CONTAINER_MESSENGER
                 )
                 .build();
     }
@@ -455,16 +558,25 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(YOUVIEW_BT_STAGE)
                 .withItemEquivalenceUpdater(
-                        YOUVIEW_ITEM,
-                        targetSources
+                        ImmutableMap.of(
+                                YOUVIEW_ITEM, targetSources
+                        ),
+                        STANDARD_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        BROADCAST_ITEM_CONTAINER,
-                        targetSources
+                        ImmutableMap.of(
+                                BROADCAST_ITEM_CONTAINER, targetSources
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        NOP_CONTAINER,
-                        ImmutableSet.of()
+                        ImmutableMap.of(
+                                NOP_CONTAINER, ImmutableSet.of()
+                        ),
+                        NOP_CONTAINER_HANDLER,
+                        NOP_CONTAINER_MESSENGER
                 )
                 .build();
     }
@@ -482,16 +594,25 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(YOUVIEW_SCOTLAND_RADIO)
                 .withItemEquivalenceUpdater(
-                        YOUVIEW_ITEM,
-                        targetSources
+                        ImmutableMap.of(
+                                YOUVIEW_ITEM, targetSources
+                        ),
+                        STANDARD_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        BROADCAST_ITEM_CONTAINER,
-                        targetSources
+                        ImmutableMap.of(
+                                BROADCAST_ITEM_CONTAINER, targetSources
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        NOP_CONTAINER,
-                        ImmutableSet.of()
+                        ImmutableMap.of(
+                                NOP_CONTAINER, ImmutableSet.of()
+                        ),
+                        NOP_CONTAINER_HANDLER,
+                        NOP_CONTAINER_MESSENGER
                 )
                 .build();
     }
@@ -509,16 +630,25 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(YOUVIEW_SCOTLAND_RADIO_STAGE)
                 .withItemEquivalenceUpdater(
-                        YOUVIEW_ITEM,
-                        targetSources
+                        ImmutableMap.of(
+                                YOUVIEW_ITEM, targetSources
+                        ),
+                        STANDARD_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        BROADCAST_ITEM_CONTAINER,
-                        targetSources
+                        ImmutableMap.of(
+                                BROADCAST_ITEM_CONTAINER, targetSources
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        NOP_CONTAINER,
-                        ImmutableSet.of()
+                        ImmutableMap.of(
+                                NOP_CONTAINER, ImmutableSet.of()
+                        ),
+                        NOP_CONTAINER_HANDLER,
+                        NOP_CONTAINER_MESSENGER
                 )
                 .build();
     }
@@ -532,17 +662,25 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(BBC_REDUX)
                 .withItemEquivalenceUpdater(
-                        BROADCAST_ITEM,
-                        targetSources
+                        ImmutableMap.of(
+                                BROADCAST_ITEM, targetSources
+                        ),
+                        STANDARD_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        BROADCAST_ITEM_CONTAINER,
-                        targetSources
-
+                        ImmutableMap.of(
+                                BROADCAST_ITEM_CONTAINER, targetSources
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        NOP_CONTAINER,
-                        ImmutableSet.of()
+                        ImmutableMap.of(
+                                NOP_CONTAINER, ImmutableSet.of()
+                        ),
+                        NOP_CONTAINER_HANDLER,
+                        NOP_CONTAINER_MESSENGER
                 )
                 .build();
     }
@@ -551,16 +689,25 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(C4_PRESS)
                 .withItemEquivalenceUpdater(
-                        BROADCAST_ITEM,
-                        ImmutableSet.of(PA)
+                        ImmutableMap.of(
+                                BROADCAST_ITEM, ImmutableSet.of(PA)
+                        ),
+                        STANDARD_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        NOP_CONTAINER,
-                        ImmutableSet.of()
+                        ImmutableMap.of(
+                                NOP_CONTAINER, ImmutableSet.of()
+                        ),
+                        NOP_CONTAINER_HANDLER,
+                        NOP_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        NOP_CONTAINER,
-                        ImmutableSet.of()
+                        ImmutableMap.of(
+                                NOP_CONTAINER, ImmutableSet.of()
+                        ),
+                        NOP_CONTAINER_HANDLER,
+                        NOP_CONTAINER_MESSENGER
                 )
                 .build();
     }
@@ -569,16 +716,25 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(BETTY)
                 .withItemEquivalenceUpdater(
-                        BETTY_ITEM,
-                        ImmutableSet.of(BETTY, YOUVIEW)
+                        ImmutableMap.of(
+                                BETTY_ITEM, ImmutableSet.of(BETTY, YOUVIEW)
+                        ),
+                        STANDARD_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        NOP_CONTAINER,
-                        ImmutableSet.of()
+                        ImmutableMap.of(
+                                NOP_CONTAINER, ImmutableSet.of()
+                        ),
+                        NOP_CONTAINER_HANDLER,
+                        NOP_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        NOP_CONTAINER,
-                        ImmutableSet.of()
+                        ImmutableMap.of(
+                                NOP_CONTAINER, ImmutableSet.of()
+                        ),
+                        NOP_CONTAINER_HANDLER,
+                        NOP_CONTAINER_MESSENGER
                 )
                 .build();
     }
@@ -587,20 +743,29 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(FACEBOOK)
                 .withItemEquivalenceUpdater(
-                        NOP_ITEM,
-                        ImmutableSet.of()
+                        ImmutableMap.of(
+                                NOP_ITEM, ImmutableSet.of()
+                        ),
+                        NOP_ITEM_HANDLER,
+                        NOP_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        FACEBOOK_CONTAINER,
-                        Sets.union(
-                                TARGET_SOURCES,
-                                ImmutableSet.of(FACEBOOK)
-                        )
-                                .immutableCopy()
+                        ImmutableMap.of(
+                                FACEBOOK_CONTAINER, Sets.union(
+                                        TARGET_SOURCES,
+                                        ImmutableSet.of(FACEBOOK)
+                                )
+                                        .immutableCopy()
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        NOP_CONTAINER,
-                        ImmutableSet.of()
+                        ImmutableMap.of(
+                                NOP_CONTAINER, ImmutableSet.of()
+                        ),
+                        NOP_CONTAINER_HANDLER,
+                        NOP_CONTAINER_MESSENGER
                 )
                 .build();
     }
@@ -609,16 +774,25 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(ITUNES)
                 .withItemEquivalenceUpdater(
-                        VOD_ITEM,
-                        TARGET_SOURCES
+                        ImmutableMap.of(
+                                VOD_ITEM, TARGET_SOURCES
+                        ),
+                        STRICT_EPISODE_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        VOD_CONTAINER,
-                        TARGET_SOURCES
+                        ImmutableMap.of(
+                                VOD_CONTAINER, TARGET_SOURCES
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        NOP_CONTAINER,
-                        ImmutableSet.of()
+                        ImmutableMap.of(
+                                NOP_CONTAINER, ImmutableSet.of()
+                        ),
+                        NOP_CONTAINER_HANDLER,
+                        NOP_CONTAINER_MESSENGER
                 )
                 .build();
     }
@@ -633,16 +807,25 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(LOVEFILM)
                 .withItemEquivalenceUpdater(
-                        VOD_WITH_SERIES_SEQUENCE_ITEM,
-                        targetSources
+                        ImmutableMap.of(
+                                VOD_WITH_SERIES_SEQUENCE_ITEM, targetSources
+                        ),
+                        STRICT_EPISODE_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        VOD_CONTAINER,
-                        targetSources
+                        ImmutableMap.of(
+                                VOD_CONTAINER, targetSources
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        NOP_CONTAINER,
-                        ImmutableSet.of()
+                        ImmutableMap.of(
+                                NOP_CONTAINER, ImmutableSet.of()
+                        ),
+                        NOP_CONTAINER_HANDLER,
+                        NOP_CONTAINER_MESSENGER
                 )
                 .build();
     }
@@ -653,16 +836,25 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(NETFLIX)
                 .withItemEquivalenceUpdater(
-                        VOD_ITEM,
-                        targetSources
+                        ImmutableMap.of(
+                                VOD_ITEM, targetSources
+                        ),
+                        STRICT_EPISODE_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        VOD_CONTAINER,
-                        targetSources
+                        ImmutableMap.of(
+                                VOD_CONTAINER, targetSources
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        NOP_CONTAINER,
-                        ImmutableSet.of()
+                        ImmutableMap.of(
+                                NOP_CONTAINER, ImmutableSet.of()
+                        ),
+                        NOP_CONTAINER_HANDLER,
+                        NOP_CONTAINER_MESSENGER
                 )
                 .build();
     }
@@ -674,16 +866,25 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(AMAZON_UNBOX)
                 .withItemEquivalenceUpdater(
-                        AMAZON_ITEM,
-                        targetSources
+                        ImmutableMap.of(
+                                AMAZON_ITEM, targetSources
+                        ),
+                        STRICT_EPISODE_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        AMAZON_CONTAINER,
-                        targetSources
+                        ImmutableMap.of(
+                                AMAZON_CONTAINER, targetSources
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        AMAZON_SERIES,
-                        targetSources
+                        ImmutableMap.of(
+                                AMAZON_SERIES, targetSources
+                        ),
+                        STANDARD_SERIES_HANDLER,
+                        STANDARD_SERIES_MESSENGER
                 )
                 .build();
     }
@@ -692,16 +893,25 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(TALK_TALK)
                 .withItemEquivalenceUpdater(
-                        VOD_ITEM,
-                        TARGET_SOURCES
+                        ImmutableMap.of(
+                                VOD_ITEM, TARGET_SOURCES
+                        ),
+                        STRICT_EPISODE_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        VOD_CONTAINER,
-                        TARGET_SOURCES
+                        ImmutableMap.of(
+                                VOD_CONTAINER, TARGET_SOURCES
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        STANDARD_SERIES,
-                        TARGET_SOURCES
+                        ImmutableMap.of(
+                                STANDARD_SERIES, TARGET_SOURCES
+                        ),
+                        STANDARD_SERIES_HANDLER,
+                        STANDARD_SERIES_MESSENGER
                 )
                 .build();
     }
@@ -710,16 +920,25 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(BT_VOD)
                 .withItemEquivalenceUpdater(
-                        VOD_WITH_SERIES_SEQUENCE_ITEM,
-                        ImmutableSet.of(PA)
+                        ImmutableMap.of(
+                                VOD_WITH_SERIES_SEQUENCE_ITEM, ImmutableSet.of(PA)
+                        ),
+                        STRICT_EPISODE_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        VOD_CONTAINER,
-                        ImmutableSet.of(PA)
+                        ImmutableMap.of(
+                                VOD_CONTAINER, ImmutableSet.of(PA)
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        STANDARD_SERIES,
-                        ImmutableSet.of(PA)
+                        ImmutableMap.of(
+                                STANDARD_SERIES, ImmutableSet.of(PA)
+                        ),
+                        STANDARD_SERIES_HANDLER,
+                        STANDARD_SERIES_MESSENGER
                 )
                 .build();
     }
@@ -730,16 +949,25 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(BT_TVE_VOD)
                 .withItemEquivalenceUpdater(
-                        BT_VOD_ITEM,
-                        targetSources
+                        ImmutableMap.of(
+                                BT_VOD_ITEM, targetSources
+                        ),
+                        STRICT_EPISODE_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        BT_VOD_CONTAINER,
-                        targetSources
+                        ImmutableMap.of(
+                                BT_VOD_CONTAINER, targetSources
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        STANDARD_SERIES,
-                        targetSources
+                        ImmutableMap.of(
+                                STANDARD_SERIES, targetSources
+                        ),
+                        STANDARD_SERIES_HANDLER,
+                        STANDARD_SERIES_MESSENGER
                 )
                 .build();
     }
@@ -751,16 +979,25 @@ public class UpdaterConfigurationRegistry {
                 .map(source -> UpdaterConfiguration.builder()
                         .withSource(source)
                         .withItemEquivalenceUpdater(
-                                BT_VOD_ITEM,
-                                targetSources
+                                ImmutableMap.of(
+                                        BT_VOD_ITEM, targetSources
+                                ),
+                                STRICT_EPISODE_ITEM_HANDLER,
+                                STANDARD_ITEM_MESSENGER
                         )
                         .withTopLevelContainerEquivalenceUpdater(
-                                BT_VOD_CONTAINER,
-                                targetSources
+                                ImmutableMap.of(
+                                        BT_VOD_CONTAINER, targetSources
+                                ),
+                                STANDARD_CONTAINER_HANDLER,
+                                STANDARD_CONTAINER_MESSENGER
                         )
                         .withNonTopLevelContainerEquivalenceUpdater(
-                                STANDARD_SERIES,
-                                targetSources
+                                ImmutableMap.of(
+                                        STANDARD_SERIES, targetSources
+                                ),
+                                STANDARD_SERIES_HANDLER,
+                                STANDARD_SERIES_MESSENGER
                         )
                         .build())
                 .collect(MoreCollectors.toImmutableList());
@@ -770,16 +1007,25 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(RTE)
                 .withItemEquivalenceUpdater(
-                        NOP_ITEM,
-                        ImmutableSet.of()
+                        ImmutableMap.of(
+                                NOP_ITEM, ImmutableSet.of()
+                        ),
+                        NOP_ITEM_HANDLER,
+                        NOP_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        RTE_VOD_CONTAINER,
-                        ImmutableSet.of(PA)
+                        ImmutableMap.of(
+                                RTE_VOD_CONTAINER, ImmutableSet.of(PA)
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        NOP_CONTAINER,
-                        ImmutableSet.of()
+                        ImmutableMap.of(
+                                NOP_CONTAINER, ImmutableSet.of()
+                        ),
+                        NOP_CONTAINER_HANDLER,
+                        NOP_CONTAINER_MESSENGER
                 )
                 .build();
     }
@@ -788,16 +1034,25 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(FIVE)
                 .withItemEquivalenceUpdater(
-                        BARB_ITEM,
-                        ImmutableSet.of(BBC_NITRO, ITV_CPS, UKTV, C4_PMLSD)
+                        ImmutableMap.of(
+                                BARB_ITEM, ImmutableSet.of(BBC_NITRO, ITV_CPS, UKTV, C4_PMLSD)
+                        ),
+                        STANDARD_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        STANDARD_TOP_LEVEL_CONTAINER,
-                        TARGET_SOURCES
+                        ImmutableMap.of(
+                                STANDARD_TOP_LEVEL_CONTAINER, TARGET_SOURCES
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        STANDARD_SERIES,
-                        TARGET_SOURCES
+                        ImmutableMap.of(
+                                STANDARD_SERIES, TARGET_SOURCES
+                        ),
+                        STANDARD_SERIES_HANDLER,
+                        STANDARD_SERIES_MESSENGER
                 )
                 .build();
     }
@@ -806,26 +1061,35 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(BARB_MASTER)
                 .withItemEquivalenceUpdater(
-                        BARB_ITEM,
-                        ImmutableSet.of(
-                                BBC_NITRO,
-                                ITV_CPS,
-                                UKTV,
-                                C4_PMLSD,
-                                C5_DATA_SUBMISSION,
-                                BARB_MASTER,
-                                BARB_TRANSMISSIONS,
-                                BARB_X_MASTER,
-                                BARB_CENSUS
-                        )
+                        ImmutableMap.of(
+                                BARB_ITEM, ImmutableSet.of(
+                                        BBC_NITRO,
+                                        ITV_CPS,
+                                        UKTV,
+                                        C4_PMLSD,
+                                        C5_DATA_SUBMISSION,
+                                        BARB_MASTER,
+                                        BARB_TRANSMISSIONS,
+                                        BARB_X_MASTER,
+                                        BARB_CENSUS
+                                )
+                        ),
+                        STANDARD_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        STANDARD_TOP_LEVEL_CONTAINER,
-                        ImmutableSet.of()
+                        ImmutableMap.of(
+                                STANDARD_TOP_LEVEL_CONTAINER, ImmutableSet.of()
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        STANDARD_SERIES,
-                        ImmutableSet.of()
+                        ImmutableMap.of(
+                                STANDARD_SERIES, ImmutableSet.of()
+                        ),
+                        STANDARD_SERIES_HANDLER,
+                        STANDARD_SERIES_MESSENGER
                 )
                 .build();
     }
@@ -845,62 +1109,49 @@ public class UpdaterConfigurationRegistry {
                                         BARB_MASTER
                                 )
                         ),
-                        null,
-                        null
+                        STANDARD_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        ImmutableMap.of(STANDARD_TOP_LEVEL_CONTAINER, ImmutableSet.of()),
-                        null,
-                        null
+                        ImmutableMap.of(
+                                STANDARD_TOP_LEVEL_CONTAINER, ImmutableSet.of()
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        ImmutableMap.of(STANDARD_SERIES, ImmutableSet.of()),
-                        null,
-                        null
+                        ImmutableMap.of(
+                                STANDARD_SERIES, ImmutableSet.of()
+                        ),
+                        STANDARD_SERIES_HANDLER,
+                        STANDARD_SERIES_MESSENGER
                 )
                 .build();
-
-
-
-//        return UpdaterConfiguration.builder()
-//                .withSource(BARB_TRANSMISSIONS)
-//                .withItemEquivalenceUpdater(
-//                        TXLOGS_ITEM,
-//                        ImmutableSet.of(
-//                                BBC_NITRO,
-//                                ITV_CPS,
-//                                UKTV,
-//                                C4_PMLSD,
-//                                C5_DATA_SUBMISSION,
-//                                BARB_TRANSMISSIONS,
-//                                BARB_MASTER
-//                        )
-//                )
-//                .withTopLevelContainerEquivalenceUpdater(
-//                        STANDARD_TOP_LEVEL_CONTAINER,
-//                        ImmutableSet.of()
-//                )
-//                .withNonTopLevelContainerEquivalenceUpdater(
-//                        STANDARD_SERIES,
-//                        ImmutableSet.of()
-//                )
-//                .build();
     }
 
     private static UpdaterConfiguration makeItvCpsConfiguration() {
         return UpdaterConfiguration.builder()
                 .withSource(ITV_CPS)
                 .withItemEquivalenceUpdater(
-                        BARB_ITEM,
-                        ImmutableSet.of(PA, BBC_NITRO, UKTV, BARB_TRANSMISSIONS, BARB_MASTER)
+                        ImmutableMap.of(
+                                BARB_ITEM, ImmutableSet.of(PA, BBC_NITRO, UKTV, BARB_TRANSMISSIONS, BARB_MASTER)
+                        ),
+                        STANDARD_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        STANDARD_TOP_LEVEL_CONTAINER,
-                        ImmutableSet.of(PA, BBC_NITRO, UKTV)
+                        ImmutableMap.of(
+                                STANDARD_TOP_LEVEL_CONTAINER, ImmutableSet.of(PA, BBC_NITRO, UKTV)
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        STANDARD_SERIES,
-                        ImmutableSet.of(PA, BBC_NITRO, UKTV)
+                        ImmutableMap.of(
+                                STANDARD_SERIES, ImmutableSet.of(PA, BBC_NITRO, UKTV)
+                        ),
+                        STANDARD_SERIES_HANDLER,
+                        STANDARD_SERIES_MESSENGER
                 )
                 .build();
     }
@@ -909,16 +1160,25 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(BBC_NITRO)
                 .withItemEquivalenceUpdater(
-                        STANDARD_ITEM,
-                        ImmutableSet.of(PA, UKTV, BARB_TRANSMISSIONS, BARB_MASTER)
+                        ImmutableMap.of(
+                                STANDARD_ITEM, ImmutableSet.of(PA, UKTV, BARB_TRANSMISSIONS, BARB_MASTER)
+                        ),
+                        STANDARD_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        STANDARD_TOP_LEVEL_CONTAINER,
-                        ImmutableSet.of(PA, UKTV)
+                        ImmutableMap.of(
+                                STANDARD_TOP_LEVEL_CONTAINER, ImmutableSet.of(PA, UKTV)
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        STANDARD_SERIES,
-                        ImmutableSet.of(PA, UKTV)
+                        ImmutableMap.of(
+                                STANDARD_SERIES, ImmutableSet.of(PA, UKTV)
+                        ),
+                        STANDARD_SERIES_HANDLER,
+                        STANDARD_SERIES_MESSENGER
                 )
                 .build();
     }
@@ -927,16 +1187,25 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(C4_PMLSD)
                 .withItemEquivalenceUpdater(
-                        BARB_ITEM,
-                        ImmutableSet.of(PA, RADIO_TIMES, BARB_TRANSMISSIONS, BARB_MASTER)
+                        ImmutableMap.of(
+                                BARB_ITEM, ImmutableSet.of(PA, RADIO_TIMES, BARB_TRANSMISSIONS, BARB_MASTER)
+                        ),
+                        STANDARD_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        STANDARD_TOP_LEVEL_CONTAINER,
-                        TARGET_SOURCES
+                        ImmutableMap.of(
+                                STANDARD_TOP_LEVEL_CONTAINER, TARGET_SOURCES
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        STANDARD_SERIES,
-                        TARGET_SOURCES
+                        ImmutableMap.of(
+                                STANDARD_SERIES, TARGET_SOURCES
+                        ),
+                        STANDARD_SERIES_HANDLER,
+                        STANDARD_SERIES_MESSENGER
                 )
                 .build();
     }
@@ -945,16 +1214,25 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(UKTV)
                 .withItemEquivalenceUpdater(
-                        BARB_ITEM,
-                        ImmutableSet.of(PA, RADIO_TIMES, BARB_TRANSMISSIONS, BARB_MASTER)
+                        ImmutableMap.of(
+                                BARB_ITEM, ImmutableSet.of(PA, RADIO_TIMES, BARB_TRANSMISSIONS, BARB_MASTER)
+                        ),
+                        STANDARD_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        STANDARD_TOP_LEVEL_CONTAINER,
-                        TARGET_SOURCES
+                        ImmutableMap.of(
+                                STANDARD_TOP_LEVEL_CONTAINER, TARGET_SOURCES
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        STANDARD_SERIES,
-                        TARGET_SOURCES
+                        ImmutableMap.of(
+                                STANDARD_SERIES, TARGET_SOURCES
+                        ),
+                        STANDARD_SERIES_HANDLER,
+                        STANDARD_SERIES_MESSENGER
                 )
                 .build();
     }
@@ -963,16 +1241,25 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(C5_DATA_SUBMISSION)
                 .withItemEquivalenceUpdater(
-                        BARB_ITEM,
-                        ImmutableSet.of(PA, RADIO_TIMES, BARB_TRANSMISSIONS, BARB_MASTER)
+                        ImmutableMap.of(
+                                BARB_ITEM, ImmutableSet.of(PA, RADIO_TIMES, BARB_TRANSMISSIONS, BARB_MASTER)
+                        ),
+                        STANDARD_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        STANDARD_TOP_LEVEL_CONTAINER,
-                        TARGET_SOURCES
+                        ImmutableMap.of(
+                                STANDARD_TOP_LEVEL_CONTAINER, TARGET_SOURCES
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        STANDARD_SERIES,
-                        TARGET_SOURCES
+                        ImmutableMap.of(
+                                STANDARD_SERIES, TARGET_SOURCES
+                        ),
+                        STANDARD_SERIES_HANDLER,
+                        STANDARD_SERIES_MESSENGER
                 )
                 .build();
     }
@@ -981,18 +1268,25 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(BARB_CENSUS)
                 .withItemEquivalenceUpdater(
-                        BARB_ITEM,
-                        ImmutableSet.of(
-                                BARB_MASTER
-                        )
+                        ImmutableMap.of(
+                                BARB_ITEM, ImmutableSet.of(BARB_MASTER)
+                        ),
+                        STANDARD_ITEM_HANDLER,
+                        STANDARD_ITEM_MESSENGER
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        STANDARD_TOP_LEVEL_CONTAINER,
-                        ImmutableSet.of()
+                        ImmutableMap.of(
+                                STANDARD_TOP_LEVEL_CONTAINER, ImmutableSet.of()
+                        ),
+                        STANDARD_CONTAINER_HANDLER,
+                        STANDARD_CONTAINER_MESSENGER
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        STANDARD_SERIES,
-                        ImmutableSet.of()
+                        ImmutableMap.of(
+                                STANDARD_SERIES, ImmutableSet.of()
+                        ),
+                        STANDARD_SERIES_HANDLER,
+                        STANDARD_SERIES_MESSENGER
                 )
                 .build();
     }
@@ -1015,16 +1309,25 @@ public class UpdaterConfigurationRegistry {
                 .map(source -> UpdaterConfiguration.builder()
                         .withSource(source)
                         .withItemEquivalenceUpdater(
-                                ROVI_ITEM,
-                                targetSources
+                                ImmutableMap.of(
+                                        ROVI_ITEM, targetSources
+                                ),
+                                STRICT_EPISODE_ITEM_HANDLER,
+                                STANDARD_ITEM_MESSENGER
                         )
                         .withTopLevelContainerEquivalenceUpdater(
-                                STANDARD_TOP_LEVEL_CONTAINER,
-                                targetSources
+                                ImmutableMap.of(
+                                        STANDARD_TOP_LEVEL_CONTAINER, targetSources
+                                ),
+                                STANDARD_CONTAINER_HANDLER,
+                                STANDARD_CONTAINER_MESSENGER
                         )
                         .withNonTopLevelContainerEquivalenceUpdater(
-                                NOP_CONTAINER,
-                                ImmutableSet.of()
+                                ImmutableMap.of(
+                                        NOP_CONTAINER, ImmutableSet.of()
+                                ),
+                                NOP_CONTAINER_HANDLER,
+                                NOP_CONTAINER_MESSENGER
                         )
                         .build())
                 .collect(MoreCollectors.toImmutableList());
@@ -1035,20 +1338,29 @@ public class UpdaterConfigurationRegistry {
                 .map(source -> UpdaterConfiguration.builder()
                         .withSource(source)
                         .withItemEquivalenceUpdater(
-                                MUSIC_ITEM,
-                                Sets.union(
-                                        MUSIC_SOURCES,
-                                        ImmutableSet.of(ITUNES)
-                                )
-                                        .immutableCopy()
+                                ImmutableMap.of(
+                                        MUSIC_ITEM, Sets.union(
+                                                MUSIC_SOURCES,
+                                                ImmutableSet.of(ITUNES)
+                                        )
+                                                .immutableCopy()
+                                ),
+                                STANDARD_ITEM_HANDLER,
+                                STANDARD_ITEM_MESSENGER
                         )
                         .withTopLevelContainerEquivalenceUpdater(
-                                NOP_CONTAINER,
-                                ImmutableSet.of()
+                                ImmutableMap.of(
+                                        NOP_CONTAINER, ImmutableSet.of()
+                                ),
+                                NOP_CONTAINER_HANDLER,
+                                NOP_CONTAINER_MESSENGER
                         )
                         .withNonTopLevelContainerEquivalenceUpdater(
-                                NOP_CONTAINER,
-                                ImmutableSet.of()
+                                ImmutableMap.of(
+                                        NOP_CONTAINER, ImmutableSet.of()
+                                ),
+                                NOP_CONTAINER_HANDLER,
+                                NOP_CONTAINER_MESSENGER
                         )
                         .build())
                 .collect(MoreCollectors.toImmutableList());

--- a/src/main/java/org/atlasapi/equiv/update/updaters/configuration/UpdaterConfigurationRegistry.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/configuration/UpdaterConfigurationRegistry.java
@@ -1,6 +1,7 @@
 package org.atlasapi.equiv.update.updaters.configuration;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.metabroadcast.common.collect.MoreSets;
@@ -833,26 +834,57 @@ public class UpdaterConfigurationRegistry {
         return UpdaterConfiguration.builder()
                 .withSource(BARB_TRANSMISSIONS)
                 .withItemEquivalenceUpdater(
-                        TXLOGS_ITEM,
-                        ImmutableSet.of(
-                                BBC_NITRO,
-                                ITV_CPS,
-                                UKTV,
-                                C4_PMLSD,
-                                C5_DATA_SUBMISSION,
-                                BARB_TRANSMISSIONS,
-                                BARB_MASTER
-                        )
+                        ImmutableMap.of(
+                                TXLOGS_ITEM, ImmutableSet.of(
+                                        BBC_NITRO,
+                                        ITV_CPS,
+                                        UKTV,
+                                        C4_PMLSD,
+                                        C5_DATA_SUBMISSION,
+                                        BARB_TRANSMISSIONS,
+                                        BARB_MASTER
+                                )
+                        ),
+                        null,
+                        null
                 )
                 .withTopLevelContainerEquivalenceUpdater(
-                        STANDARD_TOP_LEVEL_CONTAINER,
-                        ImmutableSet.of()
+                        ImmutableMap.of(STANDARD_TOP_LEVEL_CONTAINER, ImmutableSet.of()),
+                        null,
+                        null
                 )
                 .withNonTopLevelContainerEquivalenceUpdater(
-                        STANDARD_SERIES,
-                        ImmutableSet.of()
+                        ImmutableMap.of(STANDARD_SERIES, ImmutableSet.of()),
+                        null,
+                        null
                 )
                 .build();
+
+
+
+//        return UpdaterConfiguration.builder()
+//                .withSource(BARB_TRANSMISSIONS)
+//                .withItemEquivalenceUpdater(
+//                        TXLOGS_ITEM,
+//                        ImmutableSet.of(
+//                                BBC_NITRO,
+//                                ITV_CPS,
+//                                UKTV,
+//                                C4_PMLSD,
+//                                C5_DATA_SUBMISSION,
+//                                BARB_TRANSMISSIONS,
+//                                BARB_MASTER
+//                        )
+//                )
+//                .withTopLevelContainerEquivalenceUpdater(
+//                        STANDARD_TOP_LEVEL_CONTAINER,
+//                        ImmutableSet.of()
+//                )
+//                .withNonTopLevelContainerEquivalenceUpdater(
+//                        STANDARD_SERIES,
+//                        ImmutableSet.of()
+//                )
+//                .build();
     }
 
     private static UpdaterConfiguration makeItvCpsConfiguration() {

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/EquivalenceResultUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/EquivalenceResultUpdaterProvider.java
@@ -1,0 +1,15 @@
+package org.atlasapi.equiv.update.updaters.providers;
+
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.media.entity.Content;
+import org.atlasapi.media.entity.Publisher;
+
+import java.util.Set;
+
+public interface EquivalenceResultUpdaterProvider<T extends Content> {
+
+    EquivalenceResultUpdater<T> getUpdater(
+            EquivalenceUpdaterProviderDependencies dependencies,
+            Set<Publisher> targetPublishers
+    );
+}

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/AmazonContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/AmazonContainerUpdaterProvider.java
@@ -4,12 +4,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.generators.ExactTitleGenerator;
 import org.atlasapi.equiv.generators.TitleSearchGenerator;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeMatchingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.AddingEquivalenceCombiner;
 import org.atlasapi.equiv.results.combining.RequiredScoreFilteringCombiner;
 import org.atlasapi.equiv.results.extractors.AllWithTheSameHighscoreAndPublisherExtractor;
@@ -24,16 +18,16 @@ import org.atlasapi.equiv.results.filters.SpecializationFilter;
 import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
 import org.atlasapi.equiv.results.scores.ScoreThreshold;
 import org.atlasapi.equiv.scorers.TitleMatchingContainerScorer;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Publisher;
 
 import java.util.Set;
 
-public class AmazonContainerUpdaterProvider implements EquivalenceUpdaterProvider<Container> {
+public class AmazonContainerUpdaterProvider implements EquivalenceResultUpdaterProvider<Container> {
 
     private AmazonContainerUpdaterProvider() {
     }
@@ -43,11 +37,11 @@ public class AmazonContainerUpdaterProvider implements EquivalenceUpdaterProvide
     }
 
     @Override
-    public EquivalenceUpdater<Container> getUpdater(
+    public EquivalenceResultUpdater<Container> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return ContentEquivalenceUpdater.<Container>builder()
+        return ContentEquivalenceResultUpdater.<Container>builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerators(
@@ -106,31 +100,33 @@ public class AmazonContainerUpdaterProvider implements EquivalenceUpdaterProvide
                                 )
                         )
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-                                LookupWritingEquivalenceHandler.create(
-                                        dependencies.getLookupWriter()
-                                ),
-                                new EpisodeMatchingEquivalenceHandler(
-                                        dependencies.getContentResolver(),
-                                        dependencies.getEquivSummaryStore(),
-                                        dependencies.getLookupWriter(),
-                                        targetPublishers
-                                ),
-                                new ResultWritingEquivalenceHandler<>(
-                                        dependencies.getEquivalenceResultStore()
-                                ),
-                                new EquivalenceSummaryWritingHandler<>(
-                                        dependencies.getEquivSummaryStore()
-                                )
-                        ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+//                        //standard
+//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+//                                LookupWritingEquivalenceHandler.create(
+//                                        dependencies.getLookupWriter()
+//                                ),
+//                                new EpisodeMatchingEquivalenceHandler(
+//                                        dependencies.getContentResolver(),
+//                                        dependencies.getEquivSummaryStore(),
+//                                        dependencies.getLookupWriter(),
+//                                        targetPublishers
+//                                ),
+//                                new ResultWritingEquivalenceHandler<>(
+//                                        dependencies.getEquivalenceResultStore()
+//                                ),
+//                                new EquivalenceSummaryWritingHandler<>(
+//                                        dependencies.getEquivSummaryStore()
+//                                )
+//                        ))
+//                )
+//                .withMessenger(
+//                        //standard
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/AmazonContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/AmazonContainerUpdaterProvider.java
@@ -100,33 +100,6 @@ public class AmazonContainerUpdaterProvider implements EquivalenceResultUpdaterP
                                 )
                         )
                 )
-//                .withHandler(
-//                        //standard
-//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-//                                LookupWritingEquivalenceHandler.create(
-//                                        dependencies.getLookupWriter()
-//                                ),
-//                                new EpisodeMatchingEquivalenceHandler(
-//                                        dependencies.getContentResolver(),
-//                                        dependencies.getEquivSummaryStore(),
-//                                        dependencies.getLookupWriter(),
-//                                        targetPublishers
-//                                ),
-//                                new ResultWritingEquivalenceHandler<>(
-//                                        dependencies.getEquivalenceResultStore()
-//                                ),
-//                                new EquivalenceSummaryWritingHandler<>(
-//                                        dependencies.getEquivSummaryStore()
-//                                )
-//                        ))
-//                )
-//                .withMessenger(
-//                        //standard
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/AmazonSeriesUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/AmazonSeriesUpdaterProvider.java
@@ -97,27 +97,6 @@ public class AmazonSeriesUpdaterProvider implements EquivalenceResultUpdaterProv
                                 )
                         )
                 )
-//                .withHandler(
-//                        //standard
-//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-//                                LookupWritingEquivalenceHandler.create(
-//                                        dependencies.getLookupWriter()
-//                                ),
-//                                new ResultWritingEquivalenceHandler<>(
-//                                        dependencies.getEquivalenceResultStore()
-//                                ),
-//                                new EquivalenceSummaryWritingHandler<>(
-//                                        dependencies.getEquivSummaryStore()
-//                                )
-//                        ))
-//                )
-//                .withMessenger(
-//                        //standard
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/AmazonSeriesUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/AmazonSeriesUpdaterProvider.java
@@ -4,11 +4,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.generators.ContainerCandidatesContainerEquivalenceGenerator;
 import org.atlasapi.equiv.generators.ExactTitleGenerator;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.AddingEquivalenceCombiner;
 import org.atlasapi.equiv.results.extractors.AllWithTheSameHighscoreAndPublisherExtractor;
 import org.atlasapi.equiv.results.extractors.PercentThresholdAboveNextBestMatchEquivalenceExtractor;
@@ -24,19 +19,18 @@ import org.atlasapi.equiv.results.filters.SpecializationFilter;
 import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
 import org.atlasapi.equiv.scorers.SequenceContainerScorer;
 import org.atlasapi.equiv.scorers.TitleMatchingContainerScorer;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Container;
-import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
 
 import java.util.Set;
 
 import static org.atlasapi.media.entity.Publisher.AMAZON_UNBOX;
 
-public class AmazonSeriesUpdaterProvider implements EquivalenceUpdaterProvider<Container> {
+public class AmazonSeriesUpdaterProvider implements EquivalenceResultUpdaterProvider<Container> {
 
     private AmazonSeriesUpdaterProvider() {
     }
@@ -46,11 +40,11 @@ public class AmazonSeriesUpdaterProvider implements EquivalenceUpdaterProvider<C
     }
 
     @Override
-    public EquivalenceUpdater<Container> getUpdater(
+    public EquivalenceResultUpdater<Container> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return ContentEquivalenceUpdater.<Container>builder()
+        return ContentEquivalenceResultUpdater.<Container>builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerators(
@@ -103,25 +97,27 @@ public class AmazonSeriesUpdaterProvider implements EquivalenceUpdaterProvider<C
                                 )
                         )
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-                                LookupWritingEquivalenceHandler.create(
-                                        dependencies.getLookupWriter()
-                                ),
-                                new ResultWritingEquivalenceHandler<>(
-                                        dependencies.getEquivalenceResultStore()
-                                ),
-                                new EquivalenceSummaryWritingHandler<>(
-                                        dependencies.getEquivSummaryStore()
-                                )
-                        ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+//                        //standard
+//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+//                                LookupWritingEquivalenceHandler.create(
+//                                        dependencies.getLookupWriter()
+//                                ),
+//                                new ResultWritingEquivalenceHandler<>(
+//                                        dependencies.getEquivalenceResultStore()
+//                                ),
+//                                new EquivalenceSummaryWritingHandler<>(
+//                                        dependencies.getEquivSummaryStore()
+//                                )
+//                        ))
+//                )
+//                .withMessenger(
+//                        //standard
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/BroadcastItemContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/BroadcastItemContainerUpdaterProvider.java
@@ -86,33 +86,6 @@ public class BroadcastItemContainerUpdaterProvider
                                         .atLeastNTimesGreater(1.5)
                         )
                 )
-//                .withHandler(
-//                        //standard
-//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-//                                LookupWritingEquivalenceHandler.create(
-//                                        dependencies.getLookupWriter()
-//                                ),
-//                                new EpisodeMatchingEquivalenceHandler(
-//                                        dependencies.getContentResolver(),
-//                                        dependencies.getEquivSummaryStore(),
-//                                        dependencies.getLookupWriter(),
-//                                        targetPublishers
-//                                ),
-//                                new ResultWritingEquivalenceHandler<>(
-//                                        dependencies.getEquivalenceResultStore()
-//                                ),
-//                                new EquivalenceSummaryWritingHandler<>(
-//                                        dependencies.getEquivSummaryStore()
-//                                )
-//                        ))
-//                )
-//                .withMessenger(
-//                        //standard
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/BroadcastItemContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/BroadcastItemContainerUpdaterProvider.java
@@ -4,12 +4,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.generators.ContainerChildEquivalenceGenerator;
 import org.atlasapi.equiv.generators.TitleSearchGenerator;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeMatchingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
 import org.atlasapi.equiv.results.combining.RequiredScoreFilteringCombiner;
 import org.atlasapi.equiv.results.extractors.MultipleCandidateExtractor;
@@ -24,9 +18,9 @@ import org.atlasapi.equiv.results.filters.PublisherFilter;
 import org.atlasapi.equiv.results.filters.SpecializationFilter;
 import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
 import org.atlasapi.equiv.scorers.TitleMatchingContainerScorer;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Publisher;
@@ -34,7 +28,7 @@ import org.atlasapi.media.entity.Publisher;
 import java.util.Set;
 
 public class BroadcastItemContainerUpdaterProvider
-        implements EquivalenceUpdaterProvider<Container> {
+        implements EquivalenceResultUpdaterProvider<Container> {
 
     private BroadcastItemContainerUpdaterProvider() {
     }
@@ -44,11 +38,11 @@ public class BroadcastItemContainerUpdaterProvider
     }
 
     @Override
-    public EquivalenceUpdater<Container> getUpdater(
+    public EquivalenceResultUpdater<Container> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return ContentEquivalenceUpdater.<Container>builder()
+        return ContentEquivalenceResultUpdater.<Container>builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerators(
@@ -92,31 +86,33 @@ public class BroadcastItemContainerUpdaterProvider
                                         .atLeastNTimesGreater(1.5)
                         )
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-                                LookupWritingEquivalenceHandler.create(
-                                        dependencies.getLookupWriter()
-                                ),
-                                new EpisodeMatchingEquivalenceHandler(
-                                        dependencies.getContentResolver(),
-                                        dependencies.getEquivSummaryStore(),
-                                        dependencies.getLookupWriter(),
-                                        targetPublishers
-                                ),
-                                new ResultWritingEquivalenceHandler<>(
-                                        dependencies.getEquivalenceResultStore()
-                                ),
-                                new EquivalenceSummaryWritingHandler<>(
-                                        dependencies.getEquivSummaryStore()
-                                )
-                        ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+//                        //standard
+//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+//                                LookupWritingEquivalenceHandler.create(
+//                                        dependencies.getLookupWriter()
+//                                ),
+//                                new EpisodeMatchingEquivalenceHandler(
+//                                        dependencies.getContentResolver(),
+//                                        dependencies.getEquivSummaryStore(),
+//                                        dependencies.getLookupWriter(),
+//                                        targetPublishers
+//                                ),
+//                                new ResultWritingEquivalenceHandler<>(
+//                                        dependencies.getEquivalenceResultStore()
+//                                ),
+//                                new EquivalenceSummaryWritingHandler<>(
+//                                        dependencies.getEquivSummaryStore()
+//                                )
+//                        ))
+//                )
+//                .withMessenger(
+//                        //standard
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/BtVodContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/BtVodContainerUpdaterProvider.java
@@ -3,12 +3,6 @@ package org.atlasapi.equiv.update.updaters.providers.container;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.generators.TitleSearchGenerator;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeMatchingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
 import org.atlasapi.equiv.results.combining.RequiredScoreFilteringCombiner;
 import org.atlasapi.equiv.results.extractors.MultipleCandidateExtractor;
@@ -26,16 +20,16 @@ import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.scorers.ContainerHierarchyMatchingScorer;
 import org.atlasapi.equiv.scorers.SubscriptionCatchupBrandDetector;
 import org.atlasapi.equiv.scorers.TitleMatchingContainerScorer;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Publisher;
 
 import java.util.Set;
 
-public class BtVodContainerUpdaterProvider implements EquivalenceUpdaterProvider<Container> {
+public class BtVodContainerUpdaterProvider implements EquivalenceResultUpdaterProvider<Container> {
 
     private BtVodContainerUpdaterProvider() {
     }
@@ -45,11 +39,11 @@ public class BtVodContainerUpdaterProvider implements EquivalenceUpdaterProvider
     }
 
     @Override
-    public EquivalenceUpdater<Container> getUpdater(
+    public EquivalenceResultUpdater<Container> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return ContentEquivalenceUpdater.<Container>builder()
+        return ContentEquivalenceResultUpdater.<Container>builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerator(
@@ -100,31 +94,33 @@ public class BtVodContainerUpdaterProvider implements EquivalenceUpdaterProvider
                                         .atLeastNTimesGreater(1.5)
                         )
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-                                LookupWritingEquivalenceHandler.create(
-                                        dependencies.getLookupWriter()
-                                ),
-                                new EpisodeMatchingEquivalenceHandler(
-                                        dependencies.getContentResolver(),
-                                        dependencies.getEquivSummaryStore(),
-                                        dependencies.getLookupWriter(),
-                                        targetPublishers
-                                ),
-                                new ResultWritingEquivalenceHandler<>(
-                                        dependencies.getEquivalenceResultStore()
-                                ),
-                                new EquivalenceSummaryWritingHandler<>(
-                                        dependencies.getEquivSummaryStore()
-                                )
-                        ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+//                        //standard
+//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+//                                LookupWritingEquivalenceHandler.create(
+//                                        dependencies.getLookupWriter()
+//                                ),
+//                                new EpisodeMatchingEquivalenceHandler(
+//                                        dependencies.getContentResolver(),
+//                                        dependencies.getEquivSummaryStore(),
+//                                        dependencies.getLookupWriter(),
+//                                        targetPublishers
+//                                ),
+//                                new ResultWritingEquivalenceHandler<>(
+//                                        dependencies.getEquivalenceResultStore()
+//                                ),
+//                                new EquivalenceSummaryWritingHandler<>(
+//                                        dependencies.getEquivSummaryStore()
+//                                )
+//                        ))
+//                )
+//                .withMessenger(
+//                        //standard
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/BtVodContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/BtVodContainerUpdaterProvider.java
@@ -94,33 +94,6 @@ public class BtVodContainerUpdaterProvider implements EquivalenceResultUpdaterPr
                                         .atLeastNTimesGreater(1.5)
                         )
                 )
-//                .withHandler(
-//                        //standard
-//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-//                                LookupWritingEquivalenceHandler.create(
-//                                        dependencies.getLookupWriter()
-//                                ),
-//                                new EpisodeMatchingEquivalenceHandler(
-//                                        dependencies.getContentResolver(),
-//                                        dependencies.getEquivSummaryStore(),
-//                                        dependencies.getLookupWriter(),
-//                                        targetPublishers
-//                                ),
-//                                new ResultWritingEquivalenceHandler<>(
-//                                        dependencies.getEquivalenceResultStore()
-//                                ),
-//                                new EquivalenceSummaryWritingHandler<>(
-//                                        dependencies.getEquivSummaryStore()
-//                                )
-//                        ))
-//                )
-//                .withMessenger(
-//                        //standard
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/FacebookContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/FacebookContainerUpdaterProvider.java
@@ -69,33 +69,6 @@ public class FacebookContainerUpdaterProvider implements EquivalenceResultUpdate
                                 PercentThresholdEquivalenceExtractor.moreThanPercent(90)
                         )
                 )
-//                .withHandler(
-//                        //standard
-//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-//                                LookupWritingEquivalenceHandler.create(
-//                                        dependencies.getLookupWriter()
-//                                ),
-//                                new EpisodeMatchingEquivalenceHandler(
-//                                        dependencies.getContentResolver(),
-//                                        dependencies.getEquivSummaryStore(),
-//                                        dependencies.getLookupWriter(),
-//                                        targetPublishers
-//                                ),
-//                                new ResultWritingEquivalenceHandler<>(
-//                                        dependencies.getEquivalenceResultStore()
-//                                ),
-//                                new EquivalenceSummaryWritingHandler<>(
-//                                        dependencies.getEquivSummaryStore()
-//                                )
-//                        ))
-//                )
-//                .withMessenger(
-//                        //standard
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/FacebookContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/FacebookContainerUpdaterProvider.java
@@ -1,15 +1,9 @@
 package org.atlasapi.equiv.update.updaters.providers.container;
 
-import java.util.Set;
-
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.generators.AliasResolvingEquivalenceGenerator;
 import org.atlasapi.equiv.generators.TitleSearchGenerator;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeMatchingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
 import org.atlasapi.equiv.results.extractors.MultipleCandidateExtractor;
 import org.atlasapi.equiv.results.extractors.PercentThresholdEquivalenceExtractor;
@@ -17,17 +11,16 @@ import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
 import org.atlasapi.equiv.results.filters.MinimumScoreFilter;
 import org.atlasapi.equiv.results.filters.SpecializationFilter;
 import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Publisher;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
+import java.util.Set;
 
-public class FacebookContainerUpdaterProvider implements EquivalenceUpdaterProvider<Container> {
+public class FacebookContainerUpdaterProvider implements EquivalenceResultUpdaterProvider<Container> {
 
     private FacebookContainerUpdaterProvider() {
     }
@@ -37,11 +30,11 @@ public class FacebookContainerUpdaterProvider implements EquivalenceUpdaterProvi
     }
 
     @Override
-    public EquivalenceUpdater<Container> getUpdater(
+    public EquivalenceResultUpdater<Container> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return ContentEquivalenceUpdater.<Container>builder()
+        return ContentEquivalenceResultUpdater.<Container>builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerators(
@@ -76,31 +69,33 @@ public class FacebookContainerUpdaterProvider implements EquivalenceUpdaterProvi
                                 PercentThresholdEquivalenceExtractor.moreThanPercent(90)
                         )
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-                                LookupWritingEquivalenceHandler.create(
-                                        dependencies.getLookupWriter()
-                                ),
-                                new EpisodeMatchingEquivalenceHandler(
-                                        dependencies.getContentResolver(),
-                                        dependencies.getEquivSummaryStore(),
-                                        dependencies.getLookupWriter(),
-                                        targetPublishers
-                                ),
-                                new ResultWritingEquivalenceHandler<>(
-                                        dependencies.getEquivalenceResultStore()
-                                ),
-                                new EquivalenceSummaryWritingHandler<>(
-                                        dependencies.getEquivSummaryStore()
-                                )
-                        ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+//                        //standard
+//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+//                                LookupWritingEquivalenceHandler.create(
+//                                        dependencies.getLookupWriter()
+//                                ),
+//                                new EpisodeMatchingEquivalenceHandler(
+//                                        dependencies.getContentResolver(),
+//                                        dependencies.getEquivSummaryStore(),
+//                                        dependencies.getLookupWriter(),
+//                                        targetPublishers
+//                                ),
+//                                new ResultWritingEquivalenceHandler<>(
+//                                        dependencies.getEquivalenceResultStore()
+//                                ),
+//                                new EquivalenceSummaryWritingHandler<>(
+//                                        dependencies.getEquivSummaryStore()
+//                                )
+//                        ))
+//                )
+//                .withMessenger(
+//                        //standard
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/ImdbApiContainerUpdateProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/ImdbApiContainerUpdateProvider.java
@@ -75,33 +75,6 @@ public class ImdbApiContainerUpdateProvider implements EquivalenceResultUpdaterP
                 .withExtractor(
                         AllOverOrEqThresholdExtractor.create(3D)
                 )
-//                .withHandler(
-//                        //standard
-//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-//                                LookupWritingEquivalenceHandler.create(
-//                                        dependencies.getLookupWriter()
-//                                ),
-//                                new EpisodeMatchingEquivalenceHandler(
-//                                        dependencies.getContentResolver(),
-//                                        dependencies.getEquivSummaryStore(),
-//                                        dependencies.getLookupWriter(),
-//                                        targetPublishers
-//                                ),
-//                                new ResultWritingEquivalenceHandler<>(
-//                                        dependencies.getEquivalenceResultStore()
-//                                ),
-//                                new EquivalenceSummaryWritingHandler<>(
-//                                        dependencies.getEquivSummaryStore()
-//                                )
-//                        ))
-//                )
-//                .withMessenger(
-//                        //standard
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/ImdbApiContainerUpdateProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/ImdbApiContainerUpdateProvider.java
@@ -3,12 +3,6 @@ package org.atlasapi.equiv.update.updaters.providers.container;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.generators.TitleSearchGenerator;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeMatchingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.AddingEquivalenceCombiner;
 import org.atlasapi.equiv.results.extractors.AllOverOrEqThresholdExtractor;
 import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
@@ -20,16 +14,16 @@ import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.scorers.ContainerYearScorer;
 import org.atlasapi.equiv.scorers.TitleMatchingContainerScorer;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Publisher;
 
 import java.util.Set;
 
-public class ImdbApiContainerUpdateProvider implements EquivalenceUpdaterProvider<Container> {
+public class ImdbApiContainerUpdateProvider implements EquivalenceResultUpdaterProvider<Container> {
 
     private ImdbApiContainerUpdateProvider() {
 
@@ -40,11 +34,11 @@ public class ImdbApiContainerUpdateProvider implements EquivalenceUpdaterProvide
     }
 
     @Override
-    public EquivalenceUpdater<Container> getUpdater(
+    public EquivalenceResultUpdater<Container> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return ContentEquivalenceUpdater.<Container>builder()
+        return ContentEquivalenceResultUpdater.<Container>builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerator(
@@ -81,31 +75,33 @@ public class ImdbApiContainerUpdateProvider implements EquivalenceUpdaterProvide
                 .withExtractor(
                         AllOverOrEqThresholdExtractor.create(3D)
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-                                LookupWritingEquivalenceHandler.create(
-                                        dependencies.getLookupWriter()
-                                ),
-                                new EpisodeMatchingEquivalenceHandler(
-                                        dependencies.getContentResolver(),
-                                        dependencies.getEquivSummaryStore(),
-                                        dependencies.getLookupWriter(),
-                                        targetPublishers
-                                ),
-                                new ResultWritingEquivalenceHandler<>(
-                                        dependencies.getEquivalenceResultStore()
-                                ),
-                                new EquivalenceSummaryWritingHandler<>(
-                                        dependencies.getEquivSummaryStore()
-                                )
-                        ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+//                        //standard
+//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+//                                LookupWritingEquivalenceHandler.create(
+//                                        dependencies.getLookupWriter()
+//                                ),
+//                                new EpisodeMatchingEquivalenceHandler(
+//                                        dependencies.getContentResolver(),
+//                                        dependencies.getEquivSummaryStore(),
+//                                        dependencies.getLookupWriter(),
+//                                        targetPublishers
+//                                ),
+//                                new ResultWritingEquivalenceHandler<>(
+//                                        dependencies.getEquivalenceResultStore()
+//                                ),
+//                                new EquivalenceSummaryWritingHandler<>(
+//                                        dependencies.getEquivSummaryStore()
+//                                )
+//                        ))
+//                )
+//                .withMessenger(
+//                        //standard
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/NopContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/NopContainerUpdaterProvider.java
@@ -3,7 +3,7 @@ package org.atlasapi.equiv.update.updaters.providers.container;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import org.atlasapi.equiv.results.EquivalenceResult;
-import org.atlasapi.equiv.results.description.ReadableDescription;
+import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.update.EquivalenceResultUpdater;
 import org.atlasapi.equiv.update.metadata.EquivalenceUpdaterMetadata;
@@ -34,8 +34,7 @@ public class NopContainerUpdaterProvider implements EquivalenceResultUpdaterProv
             @Override
             public EquivalenceResult<Container> provideEquivalenceResult(
                     Container subject,
-                    OwlTelescopeReporter telescope,
-                    ReadableDescription desc
+                    OwlTelescopeReporter telescope
             ) {
                 return new EquivalenceResult<>(
                         subject,
@@ -44,7 +43,7 @@ public class NopContainerUpdaterProvider implements EquivalenceResultUpdaterProv
                                 .<Container>fromSource(getClass().getSimpleName())
                                 .build(),
                         ImmutableMultimap.of(),
-                        desc
+                        new DefaultDescription()
                     );
             }
 

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/NopContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/NopContainerUpdaterProvider.java
@@ -3,7 +3,7 @@ package org.atlasapi.equiv.update.updaters.providers.container;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import org.atlasapi.equiv.results.EquivalenceResult;
-import org.atlasapi.equiv.results.description.DefaultDescription;
+import org.atlasapi.equiv.results.description.ReadableDescription;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.update.EquivalenceResultUpdater;
 import org.atlasapi.equiv.update.metadata.EquivalenceUpdaterMetadata;
@@ -32,7 +32,11 @@ public class NopContainerUpdaterProvider implements EquivalenceResultUpdaterProv
     ) {
         return new EquivalenceResultUpdater<Container>() {
             @Override
-            public EquivalenceResult<Container> provideEquivalenceResult(Container subject, OwlTelescopeReporter telescope) {
+            public EquivalenceResult<Container> provideEquivalenceResult(
+                    Container subject,
+                    OwlTelescopeReporter telescope,
+                    ReadableDescription desc
+            ) {
                 return new EquivalenceResult<>(
                         subject,
                         ImmutableList.of(),
@@ -40,7 +44,7 @@ public class NopContainerUpdaterProvider implements EquivalenceResultUpdaterProv
                                 .<Container>fromSource(getClass().getSimpleName())
                                 .build(),
                         ImmutableMultimap.of(),
-                        new DefaultDescription()
+                        desc
                     );
             }
 

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/NopContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/NopContainerUpdaterProvider.java
@@ -2,16 +2,19 @@ package org.atlasapi.equiv.update.updaters.providers.container;
 
 import java.util.Set;
 
+import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
 import org.atlasapi.equiv.update.EquivalenceUpdater;
 import org.atlasapi.equiv.update.metadata.EquivalenceUpdaterMetadata;
 import org.atlasapi.equiv.update.metadata.NopEquivalenceUpdaterMetadata;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.reporting.telescope.OwlTelescopeReporter;
 
-public class NopContainerUpdaterProvider implements EquivalenceUpdaterProvider<Container> {
+public class NopContainerUpdaterProvider implements EquivalenceResultUpdaterProvider<Container> {
 
     private NopContainerUpdaterProvider() {
     }
@@ -20,21 +23,21 @@ public class NopContainerUpdaterProvider implements EquivalenceUpdaterProvider<C
         return new NopContainerUpdaterProvider();
     }
 
+    //TODO return meaningful objects
     @Override
-    public EquivalenceUpdater<Container> getUpdater(
+    public EquivalenceResultUpdater<Container> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return new EquivalenceUpdater<Container>() {
-
+        return new EquivalenceResultUpdater<Container>() {
             @Override
-            public boolean updateEquivalences(Container subject, OwlTelescopeReporter telescope) {
-                return false;
+            public EquivalenceResult<Container> provideEquivalenceResult(Container subject, OwlTelescopeReporter telescope) {
+                return null;
             }
 
             @Override
-            public EquivalenceUpdaterMetadata getMetadata(Set<Publisher> sources) {
-                return NopEquivalenceUpdaterMetadata.create();
+            public EquivalenceUpdaterMetadata getMetadata() {
+                return null;
             }
         };
     }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/NopContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/NopContainerUpdaterProvider.java
@@ -6,13 +6,13 @@ import org.atlasapi.equiv.results.EquivalenceResult;
 import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
 import org.atlasapi.equiv.update.metadata.EquivalenceUpdaterMetadata;
 import org.atlasapi.equiv.update.metadata.NopEquivalenceUpdaterMetadata;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Publisher;
-import org.atlasapi.reporting.telescope.OwlTelescopeReporter;
 
 import java.util.Set;
 
@@ -34,7 +34,7 @@ public class NopContainerUpdaterProvider implements EquivalenceResultUpdaterProv
             @Override
             public EquivalenceResult<Container> provideEquivalenceResult(
                     Container subject,
-                    OwlTelescopeReporter telescope
+                    EquivToTelescopeResults resultsForTelescope
             ) {
                 return new EquivalenceResult<>(
                         subject,

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/NopContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/NopContainerUpdaterProvider.java
@@ -1,18 +1,20 @@
 package org.atlasapi.equiv.update.updaters.providers.container;
 
-import java.util.Set;
-
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultimap;
 import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.equiv.results.description.DefaultDescription;
+import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.update.EquivalenceResultUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
 import org.atlasapi.equiv.update.metadata.EquivalenceUpdaterMetadata;
 import org.atlasapi.equiv.update.metadata.NopEquivalenceUpdaterMetadata;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.reporting.telescope.OwlTelescopeReporter;
+
+import java.util.Set;
 
 public class NopContainerUpdaterProvider implements EquivalenceResultUpdaterProvider<Container> {
 
@@ -23,7 +25,6 @@ public class NopContainerUpdaterProvider implements EquivalenceResultUpdaterProv
         return new NopContainerUpdaterProvider();
     }
 
-    //TODO return meaningful objects
     @Override
     public EquivalenceResultUpdater<Container> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
@@ -32,12 +33,20 @@ public class NopContainerUpdaterProvider implements EquivalenceResultUpdaterProv
         return new EquivalenceResultUpdater<Container>() {
             @Override
             public EquivalenceResult<Container> provideEquivalenceResult(Container subject, OwlTelescopeReporter telescope) {
-                return null;
+                return new EquivalenceResult<>(
+                        subject,
+                        ImmutableList.of(),
+                        DefaultScoredCandidates
+                                .<Container>fromSource(getClass().getSimpleName())
+                                .build(),
+                        ImmutableMultimap.of(),
+                        new DefaultDescription()
+                    );
             }
 
             @Override
             public EquivalenceUpdaterMetadata getMetadata() {
-                return null;
+                return NopEquivalenceUpdaterMetadata.create();
             }
         };
     }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/RtUpcomingContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/RtUpcomingContainerUpdaterProvider.java
@@ -95,34 +95,6 @@ public class RtUpcomingContainerUpdaterProvider
                                         .atLeastNTimesGreater(1.5)
                         )
                 )
-//                .withHandler(
-//                        //standard
-//                        new DelegatingEquivalenceResultHandler<>(
-//                                ImmutableList.of(
-//                                        LookupWritingEquivalenceHandler.create(
-//                                                dependencies.getLookupWriter()
-//                                        ),
-//                                        new EpisodeMatchingEquivalenceHandler(
-//                                                dependencies.getContentResolver(),
-//                                                dependencies.getEquivSummaryStore(),
-//                                                dependencies.getLookupWriter(),
-//                                                targetPublishers
-//                                        ),
-//                                        new ResultWritingEquivalenceHandler<>(
-//                                                dependencies.getEquivalenceResultStore()
-//                                        ),
-//                                        new EquivalenceSummaryWritingHandler<>(
-//                                                dependencies.getEquivSummaryStore()
-//                                        )
-//                                ))
-//                )
-//                .withMessenger(
-//                        //standard
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/RtUpcomingContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/RtUpcomingContainerUpdaterProvider.java
@@ -5,12 +5,6 @@ import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.generators.ContainerChildEquivalenceGenerator;
 import org.atlasapi.equiv.generators.ScalingEquivalenceGenerator;
 import org.atlasapi.equiv.generators.TitleSearchGenerator;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeMatchingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
 import org.atlasapi.equiv.results.combining.RequiredScoreFilteringCombiner;
 import org.atlasapi.equiv.results.extractors.MultipleCandidateExtractor;
@@ -25,9 +19,9 @@ import org.atlasapi.equiv.results.filters.SpecializationFilter;
 import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
 import org.atlasapi.equiv.scorers.EquivalenceScorer;
 import org.atlasapi.equiv.scorers.TitleMatchingContainerScorer;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Publisher;
@@ -35,7 +29,7 @@ import org.atlasapi.media.entity.Publisher;
 import java.util.Set;
 
 public class RtUpcomingContainerUpdaterProvider
-        implements EquivalenceUpdaterProvider<Container> {
+        implements EquivalenceResultUpdaterProvider<Container> {
 
     private RtUpcomingContainerUpdaterProvider() {
     }
@@ -45,11 +39,11 @@ public class RtUpcomingContainerUpdaterProvider
     }
 
     @Override
-    public EquivalenceUpdater<Container> getUpdater(
+    public EquivalenceResultUpdater<Container> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return ContentEquivalenceUpdater.<Container>builder()
+        return ContentEquivalenceResultUpdater.<Container>builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerators(
@@ -101,32 +95,34 @@ public class RtUpcomingContainerUpdaterProvider
                                         .atLeastNTimesGreater(1.5)
                         )
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(
-                                ImmutableList.of(
-                                        LookupWritingEquivalenceHandler.create(
-                                                dependencies.getLookupWriter()
-                                        ),
-                                        new EpisodeMatchingEquivalenceHandler(
-                                                dependencies.getContentResolver(),
-                                                dependencies.getEquivSummaryStore(),
-                                                dependencies.getLookupWriter(),
-                                                targetPublishers
-                                        ),
-                                        new ResultWritingEquivalenceHandler<>(
-                                                dependencies.getEquivalenceResultStore()
-                                        ),
-                                        new EquivalenceSummaryWritingHandler<>(
-                                                dependencies.getEquivSummaryStore()
-                                        )
-                                ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+//                        //standard
+//                        new DelegatingEquivalenceResultHandler<>(
+//                                ImmutableList.of(
+//                                        LookupWritingEquivalenceHandler.create(
+//                                                dependencies.getLookupWriter()
+//                                        ),
+//                                        new EpisodeMatchingEquivalenceHandler(
+//                                                dependencies.getContentResolver(),
+//                                                dependencies.getEquivSummaryStore(),
+//                                                dependencies.getLookupWriter(),
+//                                                targetPublishers
+//                                        ),
+//                                        new ResultWritingEquivalenceHandler<>(
+//                                                dependencies.getEquivalenceResultStore()
+//                                        ),
+//                                        new EquivalenceSummaryWritingHandler<>(
+//                                                dependencies.getEquivSummaryStore()
+//                                        )
+//                                ))
+//                )
+//                .withMessenger(
+//                        //standard
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/RteContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/RteContainerUpdaterProvider.java
@@ -3,12 +3,6 @@ package org.atlasapi.equiv.update.updaters.providers.container;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.generators.TitleSearchGenerator;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeMatchingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
 import org.atlasapi.equiv.results.combining.RequiredScoreFilteringCombiner;
 import org.atlasapi.equiv.results.extractors.MultipleCandidateExtractor;
@@ -26,16 +20,16 @@ import org.atlasapi.equiv.results.scores.ScoreThreshold;
 import org.atlasapi.equiv.scorers.ContainerHierarchyMatchingScorer;
 import org.atlasapi.equiv.scorers.SubscriptionCatchupBrandDetector;
 import org.atlasapi.equiv.scorers.TitleMatchingContainerScorer;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Publisher;
 
 import java.util.Set;
 
-public class RteContainerUpdaterProvider implements EquivalenceUpdaterProvider<Container> {
+public class RteContainerUpdaterProvider implements EquivalenceResultUpdaterProvider<Container> {
 
     private RteContainerUpdaterProvider() {
     }
@@ -45,11 +39,11 @@ public class RteContainerUpdaterProvider implements EquivalenceUpdaterProvider<C
     }
 
     @Override
-    public EquivalenceUpdater<Container> getUpdater(
+    public EquivalenceResultUpdater<Container> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return ContentEquivalenceUpdater.<Container>builder()
+        return ContentEquivalenceResultUpdater.<Container>builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerator(
@@ -100,31 +94,33 @@ public class RteContainerUpdaterProvider implements EquivalenceUpdaterProvider<C
                                         .atLeastNTimesGreater(1.5)
                         )
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-                                LookupWritingEquivalenceHandler.create(
-                                        dependencies.getLookupWriter()
-                                ),
-                                new EpisodeMatchingEquivalenceHandler(
-                                        dependencies.getContentResolver(),
-                                        dependencies.getEquivSummaryStore(),
-                                        dependencies.getLookupWriter(),
-                                        targetPublishers
-                                ),
-                                new ResultWritingEquivalenceHandler<>(
-                                        dependencies.getEquivalenceResultStore()
-                                ),
-                                new EquivalenceSummaryWritingHandler<>(
-                                        dependencies.getEquivSummaryStore()
-                                )
-                        ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+//                        //standard
+//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+//                                LookupWritingEquivalenceHandler.create(
+//                                        dependencies.getLookupWriter()
+//                                ),
+//                                new EpisodeMatchingEquivalenceHandler(
+//                                        dependencies.getContentResolver(),
+//                                        dependencies.getEquivSummaryStore(),
+//                                        dependencies.getLookupWriter(),
+//                                        targetPublishers
+//                                ),
+//                                new ResultWritingEquivalenceHandler<>(
+//                                        dependencies.getEquivalenceResultStore()
+//                                ),
+//                                new EquivalenceSummaryWritingHandler<>(
+//                                        dependencies.getEquivSummaryStore()
+//                                )
+//                        ))
+//                )
+//                .withMessenger(
+//                        //standard
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/RteContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/RteContainerUpdaterProvider.java
@@ -94,33 +94,6 @@ public class RteContainerUpdaterProvider implements EquivalenceResultUpdaterProv
                                         .atLeastNTimesGreater(1.5)
                         )
                 )
-//                .withHandler(
-//                        //standard
-//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-//                                LookupWritingEquivalenceHandler.create(
-//                                        dependencies.getLookupWriter()
-//                                ),
-//                                new EpisodeMatchingEquivalenceHandler(
-//                                        dependencies.getContentResolver(),
-//                                        dependencies.getEquivSummaryStore(),
-//                                        dependencies.getLookupWriter(),
-//                                        targetPublishers
-//                                ),
-//                                new ResultWritingEquivalenceHandler<>(
-//                                        dependencies.getEquivalenceResultStore()
-//                                ),
-//                                new EquivalenceSummaryWritingHandler<>(
-//                                        dependencies.getEquivSummaryStore()
-//                                )
-//                        ))
-//                )
-//                .withMessenger(
-//                        //standard
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/StandardSeriesUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/StandardSeriesUpdaterProvider.java
@@ -76,25 +76,6 @@ public class StandardSeriesUpdaterProvider implements EquivalenceResultUpdaterPr
                                 PercentThresholdEquivalenceExtractor.moreThanPercent(90)
                         )
                 )
-//                .withHandler(
-//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-//                                LookupWritingEquivalenceHandler.create(
-//                                        dependencies.getLookupWriter()
-//                                ),
-//                                new ResultWritingEquivalenceHandler<>(
-//                                        dependencies.getEquivalenceResultStore()
-//                                ),
-//                                new EquivalenceSummaryWritingHandler<>(
-//                                        dependencies.getEquivSummaryStore()
-//                                )
-//                        ))
-//                )
-//                .withMessenger(
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/StandardSeriesUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/StandardSeriesUpdaterProvider.java
@@ -2,11 +2,6 @@ package org.atlasapi.equiv.update.updaters.providers.container;
 
 import com.google.common.collect.ImmutableList;
 import org.atlasapi.equiv.generators.ContainerCandidatesContainerEquivalenceGenerator;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
 import org.atlasapi.equiv.results.extractors.MultipleCandidateExtractor;
 import org.atlasapi.equiv.results.extractors.PercentThresholdEquivalenceExtractor;
@@ -21,16 +16,16 @@ import org.atlasapi.equiv.results.filters.PublisherFilter;
 import org.atlasapi.equiv.results.filters.SpecializationFilter;
 import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
 import org.atlasapi.equiv.scorers.SequenceContainerScorer;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Publisher;
 
 import java.util.Set;
 
-public class StandardSeriesUpdaterProvider implements EquivalenceUpdaterProvider<Container> {
+public class StandardSeriesUpdaterProvider implements EquivalenceResultUpdaterProvider<Container> {
 
     private StandardSeriesUpdaterProvider() {
     }
@@ -40,11 +35,11 @@ public class StandardSeriesUpdaterProvider implements EquivalenceUpdaterProvider
     }
 
     @Override
-    public EquivalenceUpdater<Container> getUpdater(
+    public EquivalenceResultUpdater<Container> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return ContentEquivalenceUpdater.<Container>builder()
+        return ContentEquivalenceResultUpdater.<Container>builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerator(
@@ -81,25 +76,25 @@ public class StandardSeriesUpdaterProvider implements EquivalenceUpdaterProvider
                                 PercentThresholdEquivalenceExtractor.moreThanPercent(90)
                         )
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-                                LookupWritingEquivalenceHandler.create(
-                                        dependencies.getLookupWriter()
-                                ),
-                                new ResultWritingEquivalenceHandler<>(
-                                        dependencies.getEquivalenceResultStore()
-                                ),
-                                new EquivalenceSummaryWritingHandler<>(
-                                        dependencies.getEquivSummaryStore()
-                                )
-                        ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+//                                LookupWritingEquivalenceHandler.create(
+//                                        dependencies.getLookupWriter()
+//                                ),
+//                                new ResultWritingEquivalenceHandler<>(
+//                                        dependencies.getEquivalenceResultStore()
+//                                ),
+//                                new EquivalenceSummaryWritingHandler<>(
+//                                        dependencies.getEquivSummaryStore()
+//                                )
+//                        ))
+//                )
+//                .withMessenger(
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/StandardTopLevelContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/StandardTopLevelContainerUpdaterProvider.java
@@ -96,31 +96,6 @@ public class StandardTopLevelContainerUpdaterProvider
                                         .atLeastNTimesGreater(1.5)
                         )
                 )
-//                .withHandler(
-//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-//                                LookupWritingEquivalenceHandler.create(
-//                                        dependencies.getLookupWriter()
-//                                ),
-//                                new EpisodeMatchingEquivalenceHandler(
-//                                        dependencies.getContentResolver(),
-//                                        dependencies.getEquivSummaryStore(),
-//                                        dependencies.getLookupWriter(),
-//                                        targetPublishers
-//                                ),
-//                                new ResultWritingEquivalenceHandler<>(
-//                                        dependencies.getEquivalenceResultStore()
-//                                ),
-//                                new EquivalenceSummaryWritingHandler<>(
-//                                        dependencies.getEquivSummaryStore()
-//                                )
-//                        ))
-//                )
-//                .withMessenger(
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/StandardTopLevelContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/StandardTopLevelContainerUpdaterProvider.java
@@ -5,12 +5,6 @@ import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.generators.ContainerChildEquivalenceGenerator;
 import org.atlasapi.equiv.generators.ScalingEquivalenceGenerator;
 import org.atlasapi.equiv.generators.TitleSearchGenerator;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeMatchingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
 import org.atlasapi.equiv.results.combining.RequiredScoreFilteringCombiner;
 import org.atlasapi.equiv.results.extractors.MultipleCandidateExtractor;
@@ -26,9 +20,9 @@ import org.atlasapi.equiv.results.filters.SpecializationFilter;
 import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
 import org.atlasapi.equiv.scorers.EquivalenceScorer;
 import org.atlasapi.equiv.scorers.TitleMatchingContainerScorer;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Publisher;
@@ -36,7 +30,7 @@ import org.atlasapi.media.entity.Publisher;
 import java.util.Set;
 
 public class StandardTopLevelContainerUpdaterProvider
-        implements EquivalenceUpdaterProvider<Container> {
+        implements EquivalenceResultUpdaterProvider<Container> {
 
     private StandardTopLevelContainerUpdaterProvider() { }
 
@@ -45,11 +39,11 @@ public class StandardTopLevelContainerUpdaterProvider
     }
 
     @Override
-    public EquivalenceUpdater<Container> getUpdater(
+    public EquivalenceResultUpdater<Container> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return ContentEquivalenceUpdater.<Container> builder()
+        return ContentEquivalenceResultUpdater.<Container> builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerators(
@@ -102,31 +96,31 @@ public class StandardTopLevelContainerUpdaterProvider
                                         .atLeastNTimesGreater(1.5)
                         )
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-                                LookupWritingEquivalenceHandler.create(
-                                        dependencies.getLookupWriter()
-                                ),
-                                new EpisodeMatchingEquivalenceHandler(
-                                        dependencies.getContentResolver(),
-                                        dependencies.getEquivSummaryStore(),
-                                        dependencies.getLookupWriter(),
-                                        targetPublishers
-                                ),
-                                new ResultWritingEquivalenceHandler<>(
-                                        dependencies.getEquivalenceResultStore()
-                                ),
-                                new EquivalenceSummaryWritingHandler<>(
-                                        dependencies.getEquivSummaryStore()
-                                )
-                        ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+//                                LookupWritingEquivalenceHandler.create(
+//                                        dependencies.getLookupWriter()
+//                                ),
+//                                new EpisodeMatchingEquivalenceHandler(
+//                                        dependencies.getContentResolver(),
+//                                        dependencies.getEquivSummaryStore(),
+//                                        dependencies.getLookupWriter(),
+//                                        targetPublishers
+//                                ),
+//                                new ResultWritingEquivalenceHandler<>(
+//                                        dependencies.getEquivalenceResultStore()
+//                                ),
+//                                new EquivalenceSummaryWritingHandler<>(
+//                                        dependencies.getEquivSummaryStore()
+//                                )
+//                        ))
+//                )
+//                .withMessenger(
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/VodContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/VodContainerUpdaterProvider.java
@@ -3,12 +3,6 @@ package org.atlasapi.equiv.update.updaters.providers.container;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.generators.TitleSearchGenerator;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeMatchingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
 import org.atlasapi.equiv.results.combining.RequiredScoreFilteringCombiner;
 import org.atlasapi.equiv.results.extractors.MultipleCandidateExtractor;
@@ -27,16 +21,16 @@ import org.atlasapi.equiv.results.scores.ScoreThreshold;
 import org.atlasapi.equiv.scorers.ContainerHierarchyMatchingScorer;
 import org.atlasapi.equiv.scorers.SubscriptionCatchupBrandDetector;
 import org.atlasapi.equiv.scorers.TitleMatchingContainerScorer;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Publisher;
 
 import java.util.Set;
 
-public class VodContainerUpdaterProvider implements EquivalenceUpdaterProvider<Container> {
+public class VodContainerUpdaterProvider implements EquivalenceResultUpdaterProvider<Container> {
 
     private VodContainerUpdaterProvider() {
     }
@@ -46,11 +40,11 @@ public class VodContainerUpdaterProvider implements EquivalenceUpdaterProvider<C
     }
 
     @Override
-    public EquivalenceUpdater<Container> getUpdater(
+    public EquivalenceResultUpdater<Container> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return ContentEquivalenceUpdater.<Container>builder()
+        return ContentEquivalenceResultUpdater.<Container>builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerator(
@@ -102,31 +96,33 @@ public class VodContainerUpdaterProvider implements EquivalenceUpdaterProvider<C
                                         .atLeastNTimesGreater(1.5)
                                 )
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-                                LookupWritingEquivalenceHandler.create(
-                                        dependencies.getLookupWriter()
-                                ),
-                                new EpisodeMatchingEquivalenceHandler(
-                                        dependencies.getContentResolver(),
-                                        dependencies.getEquivSummaryStore(),
-                                        dependencies.getLookupWriter(),
-                                        targetPublishers
-                                ),
-                                new ResultWritingEquivalenceHandler<>(
-                                        dependencies.getEquivalenceResultStore()
-                                ),
-                                new EquivalenceSummaryWritingHandler<>(
-                                        dependencies.getEquivSummaryStore()
-                                )
-                        ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+//                        //standard
+//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+//                                LookupWritingEquivalenceHandler.create(
+//                                        dependencies.getLookupWriter()
+//                                ),
+//                                new EpisodeMatchingEquivalenceHandler(
+//                                        dependencies.getContentResolver(),
+//                                        dependencies.getEquivSummaryStore(),
+//                                        dependencies.getLookupWriter(),
+//                                        targetPublishers
+//                                ),
+//                                new ResultWritingEquivalenceHandler<>(
+//                                        dependencies.getEquivalenceResultStore()
+//                                ),
+//                                new EquivalenceSummaryWritingHandler<>(
+//                                        dependencies.getEquivSummaryStore()
+//                                )
+//                        ))
+//                )
+//                .withMessenger(
+//                        //standard
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/VodContainerUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/VodContainerUpdaterProvider.java
@@ -96,33 +96,6 @@ public class VodContainerUpdaterProvider implements EquivalenceResultUpdaterProv
                                         .atLeastNTimesGreater(1.5)
                                 )
                 )
-//                .withHandler(
-//                        //standard
-//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-//                                LookupWritingEquivalenceHandler.create(
-//                                        dependencies.getLookupWriter()
-//                                ),
-//                                new EpisodeMatchingEquivalenceHandler(
-//                                        dependencies.getContentResolver(),
-//                                        dependencies.getEquivSummaryStore(),
-//                                        dependencies.getLookupWriter(),
-//                                        targetPublishers
-//                                ),
-//                                new ResultWritingEquivalenceHandler<>(
-//                                        dependencies.getEquivalenceResultStore()
-//                                ),
-//                                new EquivalenceSummaryWritingHandler<>(
-//                                        dependencies.getEquivSummaryStore()
-//                                )
-//                        ))
-//                )
-//                .withMessenger(
-//                        //standard
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/WikipediaContainerUpdateProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/WikipediaContainerUpdateProvider.java
@@ -75,33 +75,6 @@ public class WikipediaContainerUpdateProvider implements EquivalenceResultUpdate
                 .withExtractor(
                         AllOverOrEqThresholdExtractor.create(3D)
                 )
-//                .withHandler(
-//                        //standard
-//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-//                                LookupWritingEquivalenceHandler.create(
-//                                        dependencies.getLookupWriter()
-//                                ),
-//                                new EpisodeMatchingEquivalenceHandler(
-//                                        dependencies.getContentResolver(),
-//                                        dependencies.getEquivSummaryStore(),
-//                                        dependencies.getLookupWriter(),
-//                                        targetPublishers
-//                                ),
-//                                new ResultWritingEquivalenceHandler<>(
-//                                        dependencies.getEquivalenceResultStore()
-//                                ),
-//                                new EquivalenceSummaryWritingHandler<>(
-//                                        dependencies.getEquivSummaryStore()
-//                                )
-//                        ))
-//                )
-//                .withMessenger(
-//                        //standard
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/WikipediaContainerUpdateProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/container/WikipediaContainerUpdateProvider.java
@@ -3,12 +3,6 @@ package org.atlasapi.equiv.update.updaters.providers.container;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.generators.TitleSearchGenerator;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeMatchingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.AddingEquivalenceCombiner;
 import org.atlasapi.equiv.results.extractors.AllOverOrEqThresholdExtractor;
 import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
@@ -20,16 +14,16 @@ import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.scorers.ContainerYearScorer;
 import org.atlasapi.equiv.scorers.TitleMatchingContainerScorer;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Publisher;
 
 import java.util.Set;
 
-public class WikipediaContainerUpdateProvider implements EquivalenceUpdaterProvider<Container> {
+public class WikipediaContainerUpdateProvider implements EquivalenceResultUpdaterProvider<Container> {
 
     private WikipediaContainerUpdateProvider() {
 
@@ -40,11 +34,11 @@ public class WikipediaContainerUpdateProvider implements EquivalenceUpdaterProvi
     }
 
     @Override
-    public EquivalenceUpdater<Container> getUpdater(
+    public EquivalenceResultUpdater<Container> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return ContentEquivalenceUpdater.<Container>builder()
+        return ContentEquivalenceResultUpdater.<Container>builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerator(
@@ -81,31 +75,33 @@ public class WikipediaContainerUpdateProvider implements EquivalenceUpdaterProvi
                 .withExtractor(
                         AllOverOrEqThresholdExtractor.create(3D)
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-                                LookupWritingEquivalenceHandler.create(
-                                        dependencies.getLookupWriter()
-                                ),
-                                new EpisodeMatchingEquivalenceHandler(
-                                        dependencies.getContentResolver(),
-                                        dependencies.getEquivSummaryStore(),
-                                        dependencies.getLookupWriter(),
-                                        targetPublishers
-                                ),
-                                new ResultWritingEquivalenceHandler<>(
-                                        dependencies.getEquivalenceResultStore()
-                                ),
-                                new EquivalenceSummaryWritingHandler<>(
-                                        dependencies.getEquivSummaryStore()
-                                )
-                        ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+//                        //standard
+//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+//                                LookupWritingEquivalenceHandler.create(
+//                                        dependencies.getLookupWriter()
+//                                ),
+//                                new EpisodeMatchingEquivalenceHandler(
+//                                        dependencies.getContentResolver(),
+//                                        dependencies.getEquivSummaryStore(),
+//                                        dependencies.getLookupWriter(),
+//                                        targetPublishers
+//                                ),
+//                                new ResultWritingEquivalenceHandler<>(
+//                                        dependencies.getEquivalenceResultStore()
+//                                ),
+//                                new EquivalenceSummaryWritingHandler<>(
+//                                        dependencies.getEquivSummaryStore()
+//                                )
+//                        ))
+//                )
+//                .withMessenger(
+//                        //standard
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/AmazonItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/AmazonItemUpdaterProvider.java
@@ -6,12 +6,6 @@ import org.atlasapi.application.v3.DefaultApplication;
 import org.atlasapi.equiv.generators.ContainerCandidatesItemEquivalenceGenerator;
 import org.atlasapi.equiv.generators.ExactTitleGenerator;
 import org.atlasapi.equiv.generators.FilmEquivalenceGenerator;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.AddingEquivalenceCombiner;
 import org.atlasapi.equiv.results.combining.RequiredScoreFilteringCombiner;
 import org.atlasapi.equiv.results.extractors.AllOverOrEqThresholdExtractor;
@@ -28,9 +22,9 @@ import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.scorers.SequenceItemScorer;
 import org.atlasapi.equiv.scorers.TitleMatchingItemScorer;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
@@ -39,7 +33,7 @@ import java.util.Set;
 
 import static org.atlasapi.media.entity.Publisher.AMAZON_UNBOX;
 
-public class AmazonItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+public class AmazonItemUpdaterProvider implements EquivalenceResultUpdaterProvider<Item> {
 
     private AmazonItemUpdaterProvider() {
     }
@@ -49,11 +43,11 @@ public class AmazonItemUpdaterProvider implements EquivalenceUpdaterProvider<Ite
     }
 
     @Override
-    public EquivalenceUpdater<Item> getUpdater(
+    public EquivalenceResultUpdater<Item> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return ContentEquivalenceUpdater.<Item>builder()
+        return ContentEquivalenceResultUpdater.<Item>builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerators(
@@ -120,28 +114,30 @@ public class AmazonItemUpdaterProvider implements EquivalenceUpdaterProvider<Ite
 
                         )
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-                                EpisodeFilteringEquivalenceResultHandler.strict(
-                                        LookupWritingEquivalenceHandler.create(
-                                                dependencies.getLookupWriter()
-                                        ),
-                                        dependencies.getEquivSummaryStore()
-                                ),
-                                new ResultWritingEquivalenceHandler<>(
-                                        dependencies.getEquivalenceResultStore()
-                                ),
-                                new EquivalenceSummaryWritingHandler<>(
-                                        dependencies.getEquivSummaryStore()
-                                )
-                        ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+//                        //TODO: standard strict
+//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+//                                EpisodeFilteringEquivalenceResultHandler.strict(
+//                                        LookupWritingEquivalenceHandler.create(
+//                                                dependencies.getLookupWriter()
+//                                        ),
+//                                        dependencies.getEquivSummaryStore()
+//                                ),
+//                                new ResultWritingEquivalenceHandler<>(
+//                                        dependencies.getEquivalenceResultStore()
+//                                ),
+//                                new EquivalenceSummaryWritingHandler<>(
+//                                        dependencies.getEquivSummaryStore()
+//                                )
+//                        ))
+//                )
+//                .withMessenger(
+//                        //standard
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/AmazonItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/AmazonItemUpdaterProvider.java
@@ -114,30 +114,6 @@ public class AmazonItemUpdaterProvider implements EquivalenceResultUpdaterProvid
 
                         )
                 )
-//                .withHandler(
-//                        //TODO: standard strict
-//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-//                                EpisodeFilteringEquivalenceResultHandler.strict(
-//                                        LookupWritingEquivalenceHandler.create(
-//                                                dependencies.getLookupWriter()
-//                                        ),
-//                                        dependencies.getEquivSummaryStore()
-//                                ),
-//                                new ResultWritingEquivalenceHandler<>(
-//                                        dependencies.getEquivalenceResultStore()
-//                                ),
-//                                new EquivalenceSummaryWritingHandler<>(
-//                                        dependencies.getEquivSummaryStore()
-//                                )
-//                        ))
-//                )
-//                .withMessenger(
-//                        //standard
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BarbItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BarbItemUpdaterProvider.java
@@ -3,15 +3,8 @@ package org.atlasapi.equiv.update.updaters.providers.item;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import org.atlasapi.equiv.generators.BarbAliasEquivalenceGeneratorAndScorer;
 import org.atlasapi.equiv.generators.BroadcastMatchingItemEquivalenceGeneratorAndScorer;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.AddingEquivalenceCombiner;
 import org.atlasapi.equiv.results.extractors.AllOverOrEqHighestNonEmptyThresholdExtractor;
 import org.atlasapi.equiv.results.extractors.AllOverOrEqThresholdExtractor;
@@ -27,9 +20,9 @@ import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.scorers.BarbTitleMatchingItemScorer;
 import org.atlasapi.equiv.scorers.DescriptionMatchingScorer;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
@@ -40,7 +33,7 @@ import java.util.Set;
 
 import static org.atlasapi.media.entity.Publisher.BARB_TRANSMISSIONS;
 
-public class BarbItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+public class BarbItemUpdaterProvider implements EquivalenceResultUpdaterProvider<Item> {
 
 
     private BarbItemUpdaterProvider() {
@@ -52,10 +45,10 @@ public class BarbItemUpdaterProvider implements EquivalenceUpdaterProvider<Item>
     }
 
     @Override
-    public EquivalenceUpdater<Item> getUpdater(
+    public EquivalenceResultUpdater<Item> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies, Set<Publisher> targetPublishers
     ) {
-        return ContentEquivalenceUpdater.<Item>builder()
+        return ContentEquivalenceResultUpdater.<Item>builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerators(
@@ -119,28 +112,30 @@ public class BarbItemUpdaterProvider implements EquivalenceUpdaterProvider<Item>
                                 new AllOverOrEqHighestNonEmptyThresholdExtractor<>(ImmutableSet.of(10D, 4D))
                         )
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-                                EpisodeFilteringEquivalenceResultHandler.relaxed(
-                                        LookupWritingEquivalenceHandler.create(
-                                                dependencies.getLookupWriter()
-                                        ),
-                                        dependencies.getEquivSummaryStore()
-                                ),
-                                new ResultWritingEquivalenceHandler<>(
-                                        dependencies.getEquivalenceResultStore()
-                                ),
-                                new EquivalenceSummaryWritingHandler<>(
-                                        dependencies.getEquivSummaryStore()
-                                )
-                        ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+//                        //standard
+//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+//                                EpisodeFilteringEquivalenceResultHandler.relaxed(
+//                                        LookupWritingEquivalenceHandler.create(
+//                                                dependencies.getLookupWriter()
+//                                        ),
+//                                        dependencies.getEquivSummaryStore()
+//                                ),
+//                                new ResultWritingEquivalenceHandler<>(
+//                                        dependencies.getEquivalenceResultStore()
+//                                ),
+//                                new EquivalenceSummaryWritingHandler<>(
+//                                        dependencies.getEquivSummaryStore()
+//                                )
+//                        ))
+//                )
+//                .withMessenger(
+//                        //standard
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BarbItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BarbItemUpdaterProvider.java
@@ -112,30 +112,6 @@ public class BarbItemUpdaterProvider implements EquivalenceResultUpdaterProvider
                                 new AllOverOrEqHighestNonEmptyThresholdExtractor<>(ImmutableSet.of(10D, 4D))
                         )
                 )
-//                .withHandler(
-//                        //standard
-//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-//                                EpisodeFilteringEquivalenceResultHandler.relaxed(
-//                                        LookupWritingEquivalenceHandler.create(
-//                                                dependencies.getLookupWriter()
-//                                        ),
-//                                        dependencies.getEquivSummaryStore()
-//                                ),
-//                                new ResultWritingEquivalenceHandler<>(
-//                                        dependencies.getEquivalenceResultStore()
-//                                ),
-//                                new EquivalenceSummaryWritingHandler<>(
-//                                        dependencies.getEquivSummaryStore()
-//                                )
-//                        ))
-//                )
-//                .withMessenger(
-//                        //standard
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BarbXItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BarbXItemUpdaterProvider.java
@@ -3,12 +3,6 @@ package org.atlasapi.equiv.update.updaters.providers.item;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.generators.BarbAliasEquivalenceGeneratorAndScorer;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.AddingEquivalenceCombiner;
 import org.atlasapi.equiv.results.extractors.AllOverOrEqThresholdExtractor;
 import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
@@ -21,9 +15,9 @@ import org.atlasapi.equiv.results.filters.SpecializationFilter;
 import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.scorers.TitleMatchingItemScorer;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
@@ -31,7 +25,7 @@ import org.atlasapi.persistence.lookup.mongo.MongoLookupEntryStore;
 
 import java.util.Set;
 
-public class BarbXItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+public class BarbXItemUpdaterProvider implements EquivalenceResultUpdaterProvider<Item> {
 
 
     private BarbXItemUpdaterProvider() {
@@ -43,10 +37,10 @@ public class BarbXItemUpdaterProvider implements EquivalenceUpdaterProvider<Item
     }
 
     @Override
-    public EquivalenceUpdater<Item> getUpdater(
+    public EquivalenceResultUpdater<Item> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies, Set<Publisher> targetPublishers
     ) {
-        return ContentEquivalenceUpdater.<Item>builder()
+        return ContentEquivalenceResultUpdater.<Item>builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerators(
@@ -86,28 +80,30 @@ public class BarbXItemUpdaterProvider implements EquivalenceUpdaterProvider<Item
                 .withExtractor(
                         AllOverOrEqThresholdExtractor.create(10.0)
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-                                EpisodeFilteringEquivalenceResultHandler.relaxed(
-                                        LookupWritingEquivalenceHandler.create(
-                                                dependencies.getLookupWriter()
-                                        ),
-                                        dependencies.getEquivSummaryStore()
-                                ),
-                                new ResultWritingEquivalenceHandler<>(
-                                        dependencies.getEquivalenceResultStore()
-                                ),
-                                new EquivalenceSummaryWritingHandler<>(
-                                        dependencies.getEquivSummaryStore()
-                                )
-                        ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+//                        //standard
+//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+//                                EpisodeFilteringEquivalenceResultHandler.relaxed(
+//                                        LookupWritingEquivalenceHandler.create(
+//                                                dependencies.getLookupWriter()
+//                                        ),
+//                                        dependencies.getEquivSummaryStore()
+//                                ),
+//                                new ResultWritingEquivalenceHandler<>(
+//                                        dependencies.getEquivalenceResultStore()
+//                                ),
+//                                new EquivalenceSummaryWritingHandler<>(
+//                                        dependencies.getEquivSummaryStore()
+//                                )
+//                        ))
+//                )
+//                .withMessenger(
+//                        //standard
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BarbXItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BarbXItemUpdaterProvider.java
@@ -80,30 +80,6 @@ public class BarbXItemUpdaterProvider implements EquivalenceResultUpdaterProvide
                 .withExtractor(
                         AllOverOrEqThresholdExtractor.create(10.0)
                 )
-//                .withHandler(
-//                        //standard
-//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-//                                EpisodeFilteringEquivalenceResultHandler.relaxed(
-//                                        LookupWritingEquivalenceHandler.create(
-//                                                dependencies.getLookupWriter()
-//                                        ),
-//                                        dependencies.getEquivSummaryStore()
-//                                ),
-//                                new ResultWritingEquivalenceHandler<>(
-//                                        dependencies.getEquivalenceResultStore()
-//                                ),
-//                                new EquivalenceSummaryWritingHandler<>(
-//                                        dependencies.getEquivSummaryStore()
-//                                )
-//                        ))
-//                )
-//                .withMessenger(
-//                        //standard
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BettyItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BettyItemUpdaterProvider.java
@@ -54,30 +54,6 @@ public class BettyItemUpdaterProvider implements EquivalenceResultUpdaterProvide
                 .withExtractor(
                         new PercentThresholdEquivalenceExtractor<>(0.95)
                 )
-//                .withHandler(
-//                        //standard
-//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-//                                EpisodeFilteringEquivalenceResultHandler.relaxed(
-//                                        LookupWritingEquivalenceHandler.create(
-//                                                dependencies.getLookupWriter()
-//                                        ),
-//                                        dependencies.getEquivSummaryStore()
-//                                ),
-//                                new ResultWritingEquivalenceHandler<>(
-//                                        dependencies.getEquivalenceResultStore()
-//                                ),
-//                                new EquivalenceSummaryWritingHandler<>(
-//                                        dependencies.getEquivSummaryStore()
-//                                )
-//                        ))
-//                )
-//                .withMessenger(
-//                        //standard
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BettyItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BettyItemUpdaterProvider.java
@@ -1,31 +1,23 @@
 package org.atlasapi.equiv.update.updaters.providers.item;
 
-import java.util.Set;
-
+import com.google.common.base.Predicates;
 import org.atlasapi.equiv.generators.BroadcastMatchingItemEquivalenceGeneratorAndScorer;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
 import org.atlasapi.equiv.results.extractors.PercentThresholdEquivalenceExtractor;
 import org.atlasapi.equiv.results.filters.AlwaysTrueFilter;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.scorers.BroadcastAliasScorer;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
-
-import com.google.common.base.Predicates;
-import com.google.common.collect.ImmutableList;
 import org.joda.time.Duration;
 
-public class BettyItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+import java.util.Set;
+
+public class BettyItemUpdaterProvider implements EquivalenceResultUpdaterProvider<Item> {
 
     private BettyItemUpdaterProvider() {
     }
@@ -35,12 +27,12 @@ public class BettyItemUpdaterProvider implements EquivalenceUpdaterProvider<Item
     }
 
     @Override
-    public EquivalenceUpdater<Item> getUpdater(
+    public EquivalenceResultUpdater<Item> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
 
-        return ContentEquivalenceUpdater.<Item>builder()
+        return ContentEquivalenceResultUpdater.<Item>builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerator(new BroadcastMatchingItemEquivalenceGeneratorAndScorer(
@@ -62,28 +54,30 @@ public class BettyItemUpdaterProvider implements EquivalenceUpdaterProvider<Item
                 .withExtractor(
                         new PercentThresholdEquivalenceExtractor<>(0.95)
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-                                EpisodeFilteringEquivalenceResultHandler.relaxed(
-                                        LookupWritingEquivalenceHandler.create(
-                                                dependencies.getLookupWriter()
-                                        ),
-                                        dependencies.getEquivSummaryStore()
-                                ),
-                                new ResultWritingEquivalenceHandler<>(
-                                        dependencies.getEquivalenceResultStore()
-                                ),
-                                new EquivalenceSummaryWritingHandler<>(
-                                        dependencies.getEquivSummaryStore()
-                                )
-                        ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+//                        //standard
+//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+//                                EpisodeFilteringEquivalenceResultHandler.relaxed(
+//                                        LookupWritingEquivalenceHandler.create(
+//                                                dependencies.getLookupWriter()
+//                                        ),
+//                                        dependencies.getEquivSummaryStore()
+//                                ),
+//                                new ResultWritingEquivalenceHandler<>(
+//                                        dependencies.getEquivalenceResultStore()
+//                                ),
+//                                new EquivalenceSummaryWritingHandler<>(
+//                                        dependencies.getEquivSummaryStore()
+//                                )
+//                        ))
+//                )
+//                .withMessenger(
+//                        //standard
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BroadcastItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BroadcastItemUpdaterProvider.java
@@ -5,12 +5,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.generators.BroadcastMatchingItemEquivalenceGeneratorAndScorer;
 import org.atlasapi.equiv.generators.EquivalenceGenerator;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
 import org.atlasapi.equiv.results.extractors.PercentThresholdAboveNextBestMatchEquivalenceExtractor;
 import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
@@ -29,9 +23,9 @@ import org.atlasapi.equiv.scorers.DescriptionTitleMatchingScorer;
 import org.atlasapi.equiv.scorers.SequenceItemScorer;
 import org.atlasapi.equiv.scorers.TitleMatchingItemScorer;
 import org.atlasapi.equiv.scorers.TitleSubsetBroadcastItemScorer;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
@@ -39,7 +33,7 @@ import org.joda.time.Duration;
 
 import java.util.Set;
 
-public class BroadcastItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+public class BroadcastItemUpdaterProvider implements EquivalenceResultUpdaterProvider<Item> {
 
     private BroadcastItemUpdaterProvider() {
     }
@@ -49,11 +43,11 @@ public class BroadcastItemUpdaterProvider implements EquivalenceUpdaterProvider<
     }
 
     @Override
-    public EquivalenceUpdater<Item> getUpdater(
+    public EquivalenceResultUpdater<Item> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return ContentEquivalenceUpdater.<Item>builder()
+        return ContentEquivalenceResultUpdater.<Item>builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerators(
@@ -100,28 +94,30 @@ public class BroadcastItemUpdaterProvider implements EquivalenceUpdaterProvider<
                         PercentThresholdAboveNextBestMatchEquivalenceExtractor
                                 .atLeastNTimesGreater(1.5)
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-                                EpisodeFilteringEquivalenceResultHandler.relaxed(
-                                        LookupWritingEquivalenceHandler.create(
-                                                dependencies.getLookupWriter()
-                                        ),
-                                        dependencies.getEquivSummaryStore()
-                                ),
-                                new ResultWritingEquivalenceHandler<>(
-                                        dependencies.getEquivalenceResultStore()
-                                ),
-                                new EquivalenceSummaryWritingHandler<>(
-                                        dependencies.getEquivSummaryStore()
-                                )
-                        ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+//                        //standard
+//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+//                                EpisodeFilteringEquivalenceResultHandler.relaxed(
+//                                        LookupWritingEquivalenceHandler.create(
+//                                                dependencies.getLookupWriter()
+//                                        ),
+//                                        dependencies.getEquivSummaryStore()
+//                                ),
+//                                new ResultWritingEquivalenceHandler<>(
+//                                        dependencies.getEquivalenceResultStore()
+//                                ),
+//                                new EquivalenceSummaryWritingHandler<>(
+//                                        dependencies.getEquivSummaryStore()
+//                                )
+//                        ))
+//                )
+//                .withMessenger(
+//                        //standard
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BroadcastItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BroadcastItemUpdaterProvider.java
@@ -94,30 +94,6 @@ public class BroadcastItemUpdaterProvider implements EquivalenceResultUpdaterPro
                         PercentThresholdAboveNextBestMatchEquivalenceExtractor
                                 .atLeastNTimesGreater(1.5)
                 )
-//                .withHandler(
-//                        //standard
-//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-//                                EpisodeFilteringEquivalenceResultHandler.relaxed(
-//                                        LookupWritingEquivalenceHandler.create(
-//                                                dependencies.getLookupWriter()
-//                                        ),
-//                                        dependencies.getEquivSummaryStore()
-//                                ),
-//                                new ResultWritingEquivalenceHandler<>(
-//                                        dependencies.getEquivalenceResultStore()
-//                                ),
-//                                new EquivalenceSummaryWritingHandler<>(
-//                                        dependencies.getEquivSummaryStore()
-//                                )
-//                        ))
-//                )
-//                .withMessenger(
-//                        //standard
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BtVodItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BtVodItemUpdaterProvider.java
@@ -101,30 +101,6 @@ public class BtVodItemUpdaterProvider implements EquivalenceResultUpdaterProvide
                         PercentThresholdAboveNextBestMatchEquivalenceExtractor
                                 .atLeastNTimesGreater(1.5)
                 )
-//                .withHandler(
-//                        //TODO standard strict
-//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-//                                EpisodeFilteringEquivalenceResultHandler.strict(
-//                                        LookupWritingEquivalenceHandler.create(
-//                                                dependencies.getLookupWriter()
-//                                        ),
-//                                        dependencies.getEquivSummaryStore()
-//                                ),
-//                                new ResultWritingEquivalenceHandler<>(
-//                                        dependencies.getEquivalenceResultStore()
-//                                ),
-//                                new EquivalenceSummaryWritingHandler<>(
-//                                        dependencies.getEquivSummaryStore()
-//                                )
-//                        ))
-//                )
-//                .withMessenger(
-//                        //standard
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BtVodItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BtVodItemUpdaterProvider.java
@@ -5,12 +5,6 @@ import com.google.common.collect.ImmutableSet;
 import org.atlasapi.application.v3.DefaultApplication;
 import org.atlasapi.equiv.generators.ContainerCandidatesItemEquivalenceGenerator;
 import org.atlasapi.equiv.generators.FilmEquivalenceGenerator;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
 import org.atlasapi.equiv.results.combining.RequiredScoreFilteringCombiner;
 import org.atlasapi.equiv.results.extractors.PercentThresholdAboveNextBestMatchEquivalenceExtractor;
@@ -27,16 +21,16 @@ import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.scorers.SequenceItemScorer;
 import org.atlasapi.equiv.scorers.SeriesSequenceItemScorer;
 import org.atlasapi.equiv.scorers.TitleMatchingItemScorer;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
 
 import java.util.Set;
 
-public class BtVodItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+public class BtVodItemUpdaterProvider implements EquivalenceResultUpdaterProvider<Item> {
 
     private BtVodItemUpdaterProvider() {
     }
@@ -46,11 +40,11 @@ public class BtVodItemUpdaterProvider implements EquivalenceUpdaterProvider<Item
     }
 
     @Override
-    public EquivalenceUpdater<Item> getUpdater(
+    public EquivalenceResultUpdater<Item> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return ContentEquivalenceUpdater.<Item>builder()
+        return ContentEquivalenceResultUpdater.<Item>builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerators(
@@ -107,28 +101,30 @@ public class BtVodItemUpdaterProvider implements EquivalenceUpdaterProvider<Item
                         PercentThresholdAboveNextBestMatchEquivalenceExtractor
                                 .atLeastNTimesGreater(1.5)
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-                                EpisodeFilteringEquivalenceResultHandler.strict(
-                                        LookupWritingEquivalenceHandler.create(
-                                                dependencies.getLookupWriter()
-                                        ),
-                                        dependencies.getEquivSummaryStore()
-                                ),
-                                new ResultWritingEquivalenceHandler<>(
-                                        dependencies.getEquivalenceResultStore()
-                                ),
-                                new EquivalenceSummaryWritingHandler<>(
-                                        dependencies.getEquivSummaryStore()
-                                )
-                        ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+//                        //TODO standard strict
+//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+//                                EpisodeFilteringEquivalenceResultHandler.strict(
+//                                        LookupWritingEquivalenceHandler.create(
+//                                                dependencies.getLookupWriter()
+//                                        ),
+//                                        dependencies.getEquivSummaryStore()
+//                                ),
+//                                new ResultWritingEquivalenceHandler<>(
+//                                        dependencies.getEquivalenceResultStore()
+//                                ),
+//                                new EquivalenceSummaryWritingHandler<>(
+//                                        dependencies.getEquivSummaryStore()
+//                                )
+//                        ))
+//                )
+//                .withMessenger(
+//                        //standard
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/ImdbApitemUpdateProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/ImdbApitemUpdateProvider.java
@@ -91,30 +91,6 @@ public class ImdbApitemUpdateProvider implements EquivalenceResultUpdaterProvide
                 .withExtractor(
                         AllOverOrEqThresholdExtractor.create(3D)
                 )
-//                .withHandler(
-//                        //standard
-//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-//                                EpisodeFilteringEquivalenceResultHandler.relaxed(
-//                                        LookupWritingEquivalenceHandler.create(
-//                                                dependencies.getLookupWriter()
-//                                        ),
-//                                        dependencies.getEquivSummaryStore()
-//                                ),
-//                                new ResultWritingEquivalenceHandler<>(
-//                                        dependencies.getEquivalenceResultStore()
-//                                ),
-//                                new EquivalenceSummaryWritingHandler<>(
-//                                        dependencies.getEquivSummaryStore()
-//                                )
-//                        ))
-//                )
-//                .withMessenger(
-//                        //standard
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/ImdbApitemUpdateProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/ImdbApitemUpdateProvider.java
@@ -5,12 +5,6 @@ import com.google.common.collect.ImmutableSet;
 import org.atlasapi.application.v3.DefaultApplication;
 import org.atlasapi.equiv.generators.FilmEquivalenceGenerator;
 import org.atlasapi.equiv.generators.TitleSearchGenerator;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.AddingEquivalenceCombiner;
 import org.atlasapi.equiv.results.extractors.AllOverOrEqThresholdExtractor;
 import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
@@ -23,16 +17,16 @@ import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.scorers.BarbTitleMatchingItemScorer;
 import org.atlasapi.equiv.scorers.ItemYearScorer;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
 
 import java.util.Set;
 
-public class ImdbApitemUpdateProvider implements EquivalenceUpdaterProvider<Item> {
+public class ImdbApitemUpdateProvider implements EquivalenceResultUpdaterProvider<Item> {
 
     private ImdbApitemUpdateProvider() {
 
@@ -43,11 +37,11 @@ public class ImdbApitemUpdateProvider implements EquivalenceUpdaterProvider<Item
     }
 
     @Override
-    public EquivalenceUpdater<Item> getUpdater(
+    public EquivalenceResultUpdater<Item> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return ContentEquivalenceUpdater.<Item>builder()
+        return ContentEquivalenceResultUpdater.<Item>builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerators(
@@ -97,28 +91,30 @@ public class ImdbApitemUpdateProvider implements EquivalenceUpdaterProvider<Item
                 .withExtractor(
                         AllOverOrEqThresholdExtractor.create(3D)
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-                                EpisodeFilteringEquivalenceResultHandler.relaxed(
-                                        LookupWritingEquivalenceHandler.create(
-                                                dependencies.getLookupWriter()
-                                        ),
-                                        dependencies.getEquivSummaryStore()
-                                ),
-                                new ResultWritingEquivalenceHandler<>(
-                                        dependencies.getEquivalenceResultStore()
-                                ),
-                                new EquivalenceSummaryWritingHandler<>(
-                                        dependencies.getEquivSummaryStore()
-                                )
-                        ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+//                        //standard
+//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+//                                EpisodeFilteringEquivalenceResultHandler.relaxed(
+//                                        LookupWritingEquivalenceHandler.create(
+//                                                dependencies.getLookupWriter()
+//                                        ),
+//                                        dependencies.getEquivSummaryStore()
+//                                ),
+//                                new ResultWritingEquivalenceHandler<>(
+//                                        dependencies.getEquivalenceResultStore()
+//                                ),
+//                                new EquivalenceSummaryWritingHandler<>(
+//                                        dependencies.getEquivSummaryStore()
+//                                )
+//                        ))
+//                )
+//                .withMessenger(
+//                        //standard
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/MusicItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/MusicItemUpdaterProvider.java
@@ -1,31 +1,23 @@
 package org.atlasapi.equiv.update.updaters.providers.item;
 
-import java.util.Set;
-
 import org.atlasapi.equiv.generators.SongTitleTransform;
 import org.atlasapi.equiv.generators.TitleSearchGenerator;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
 import org.atlasapi.equiv.results.extractors.MusicEquivalenceExtractor;
 import org.atlasapi.equiv.results.filters.AlwaysTrueFilter;
 import org.atlasapi.equiv.scorers.CrewMemberScorer;
 import org.atlasapi.equiv.scorers.SongCrewMemberExtractor;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.media.entity.Song;
 
-import com.google.common.collect.ImmutableList;
+import java.util.Set;
 
-public class MusicItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+public class MusicItemUpdaterProvider implements EquivalenceResultUpdaterProvider<Item> {
 
     private MusicItemUpdaterProvider() {
     }
@@ -35,10 +27,10 @@ public class MusicItemUpdaterProvider implements EquivalenceUpdaterProvider<Item
     }
 
     @Override
-    public EquivalenceUpdater<Item> getUpdater(
+    public EquivalenceResultUpdater<Item> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies, Set<Publisher> targetPublishers
     ) {
-        return ContentEquivalenceUpdater.<Item>builder()
+        return ContentEquivalenceResultUpdater.<Item>builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerator(
@@ -64,28 +56,30 @@ public class MusicItemUpdaterProvider implements EquivalenceUpdaterProvider<Item
                 .withExtractor(
                         new MusicEquivalenceExtractor()
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-                                EpisodeFilteringEquivalenceResultHandler.relaxed(
-                                        LookupWritingEquivalenceHandler.create(
-                                                dependencies.getLookupWriter()
-                                        ),
-                                        dependencies.getEquivSummaryStore()
-                                ),
-                                new ResultWritingEquivalenceHandler<>(
-                                        dependencies.getEquivalenceResultStore()
-                                ),
-                                new EquivalenceSummaryWritingHandler<>(
-                                        dependencies.getEquivSummaryStore()
-                                )
-                        ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+//                        //standard
+//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+//                                EpisodeFilteringEquivalenceResultHandler.relaxed(
+//                                        LookupWritingEquivalenceHandler.create(
+//                                                dependencies.getLookupWriter()
+//                                        ),
+//                                        dependencies.getEquivSummaryStore()
+//                                ),
+//                                new ResultWritingEquivalenceHandler<>(
+//                                        dependencies.getEquivalenceResultStore()
+//                                ),
+//                                new EquivalenceSummaryWritingHandler<>(
+//                                        dependencies.getEquivSummaryStore()
+//                                )
+//                        ))
+//                )
+//                .withMessenger(
+//                        //standard
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/MusicItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/MusicItemUpdaterProvider.java
@@ -56,30 +56,6 @@ public class MusicItemUpdaterProvider implements EquivalenceResultUpdaterProvide
                 .withExtractor(
                         new MusicEquivalenceExtractor()
                 )
-//                .withHandler(
-//                        //standard
-//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-//                                EpisodeFilteringEquivalenceResultHandler.relaxed(
-//                                        LookupWritingEquivalenceHandler.create(
-//                                                dependencies.getLookupWriter()
-//                                        ),
-//                                        dependencies.getEquivSummaryStore()
-//                                ),
-//                                new ResultWritingEquivalenceHandler<>(
-//                                        dependencies.getEquivalenceResultStore()
-//                                ),
-//                                new EquivalenceSummaryWritingHandler<>(
-//                                        dependencies.getEquivSummaryStore()
-//                                )
-//                        ))
-//                )
-//                .withMessenger(
-//                        //standard
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/NopItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/NopItemUpdaterProvider.java
@@ -6,13 +6,13 @@ import org.atlasapi.equiv.results.EquivalenceResult;
 import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
 import org.atlasapi.equiv.update.metadata.EquivalenceUpdaterMetadata;
 import org.atlasapi.equiv.update.metadata.NopEquivalenceUpdaterMetadata;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
-import org.atlasapi.reporting.telescope.OwlTelescopeReporter;
 
 import java.util.Set;
 
@@ -34,7 +34,7 @@ public class NopItemUpdaterProvider implements EquivalenceResultUpdaterProvider<
             @Override
             public EquivalenceResult<Item> provideEquivalenceResult(
                     Item subject,
-                    OwlTelescopeReporter telescope
+                    EquivToTelescopeResults resultsForTelescope
             ) {
                 return new EquivalenceResult<>(
                         subject,

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/NopItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/NopItemUpdaterProvider.java
@@ -2,16 +2,19 @@ package org.atlasapi.equiv.update.updaters.providers.item;
 
 import java.util.Set;
 
+import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
 import org.atlasapi.equiv.update.EquivalenceUpdater;
 import org.atlasapi.equiv.update.metadata.EquivalenceUpdaterMetadata;
 import org.atlasapi.equiv.update.metadata.NopEquivalenceUpdaterMetadata;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.reporting.telescope.OwlTelescopeReporter;
 
-public class NopItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+public class NopItemUpdaterProvider implements EquivalenceResultUpdaterProvider<Item> {
 
     private NopItemUpdaterProvider() {
     }
@@ -20,21 +23,21 @@ public class NopItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> 
         return new NopItemUpdaterProvider();
     }
 
+    //TODO: return meaningful objects
     @Override
-    public EquivalenceUpdater<Item> getUpdater(
+    public EquivalenceResultUpdater<Item> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return new EquivalenceUpdater<Item>() {
-
+        return new EquivalenceResultUpdater<Item>() {
             @Override
-            public boolean updateEquivalences(Item subject, OwlTelescopeReporter telescope) {
-                return false;
+            public EquivalenceResult<Item> provideEquivalenceResult(Item subject, OwlTelescopeReporter telescope) {
+                return null;
             }
 
             @Override
-            public EquivalenceUpdaterMetadata getMetadata(Set<Publisher> sources) {
-                return NopEquivalenceUpdaterMetadata.create();
+            public EquivalenceUpdaterMetadata getMetadata() {
+                return null;
             }
         };
     }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/NopItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/NopItemUpdaterProvider.java
@@ -3,7 +3,7 @@ package org.atlasapi.equiv.update.updaters.providers.item;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import org.atlasapi.equiv.results.EquivalenceResult;
-import org.atlasapi.equiv.results.description.ReadableDescription;
+import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.update.EquivalenceResultUpdater;
 import org.atlasapi.equiv.update.metadata.EquivalenceUpdaterMetadata;
@@ -34,8 +34,7 @@ public class NopItemUpdaterProvider implements EquivalenceResultUpdaterProvider<
             @Override
             public EquivalenceResult<Item> provideEquivalenceResult(
                     Item subject,
-                    OwlTelescopeReporter telescope,
-                    ReadableDescription desc
+                    OwlTelescopeReporter telescope
             ) {
                 return new EquivalenceResult<>(
                         subject,
@@ -44,7 +43,7 @@ public class NopItemUpdaterProvider implements EquivalenceResultUpdaterProvider<
                                 .<Item>fromSource(getClass().getSimpleName())
                                 .build(),
                         ImmutableMultimap.of(),
-                        desc
+                        new DefaultDescription()
                 );
             }
 

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/NopItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/NopItemUpdaterProvider.java
@@ -1,18 +1,20 @@
 package org.atlasapi.equiv.update.updaters.providers.item;
 
-import java.util.Set;
-
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultimap;
 import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.equiv.results.description.DefaultDescription;
+import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.update.EquivalenceResultUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
 import org.atlasapi.equiv.update.metadata.EquivalenceUpdaterMetadata;
 import org.atlasapi.equiv.update.metadata.NopEquivalenceUpdaterMetadata;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.reporting.telescope.OwlTelescopeReporter;
+
+import java.util.Set;
 
 public class NopItemUpdaterProvider implements EquivalenceResultUpdaterProvider<Item> {
 
@@ -23,7 +25,6 @@ public class NopItemUpdaterProvider implements EquivalenceResultUpdaterProvider<
         return new NopItemUpdaterProvider();
     }
 
-    //TODO: return meaningful objects
     @Override
     public EquivalenceResultUpdater<Item> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
@@ -32,12 +33,20 @@ public class NopItemUpdaterProvider implements EquivalenceResultUpdaterProvider<
         return new EquivalenceResultUpdater<Item>() {
             @Override
             public EquivalenceResult<Item> provideEquivalenceResult(Item subject, OwlTelescopeReporter telescope) {
-                return null;
+                return new EquivalenceResult<>(
+                        subject,
+                        ImmutableList.of(),
+                        DefaultScoredCandidates
+                                .<Item>fromSource(getClass().getSimpleName())
+                                .build(),
+                        ImmutableMultimap.of(),
+                        new DefaultDescription()
+                );
             }
 
             @Override
             public EquivalenceUpdaterMetadata getMetadata() {
-                return null;
+                return NopEquivalenceUpdaterMetadata.create();
             }
         };
     }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/NopItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/NopItemUpdaterProvider.java
@@ -3,7 +3,7 @@ package org.atlasapi.equiv.update.updaters.providers.item;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import org.atlasapi.equiv.results.EquivalenceResult;
-import org.atlasapi.equiv.results.description.DefaultDescription;
+import org.atlasapi.equiv.results.description.ReadableDescription;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.update.EquivalenceResultUpdater;
 import org.atlasapi.equiv.update.metadata.EquivalenceUpdaterMetadata;
@@ -32,7 +32,11 @@ public class NopItemUpdaterProvider implements EquivalenceResultUpdaterProvider<
     ) {
         return new EquivalenceResultUpdater<Item>() {
             @Override
-            public EquivalenceResult<Item> provideEquivalenceResult(Item subject, OwlTelescopeReporter telescope) {
+            public EquivalenceResult<Item> provideEquivalenceResult(
+                    Item subject,
+                    OwlTelescopeReporter telescope,
+                    ReadableDescription desc
+            ) {
                 return new EquivalenceResult<>(
                         subject,
                         ImmutableList.of(),
@@ -40,7 +44,7 @@ public class NopItemUpdaterProvider implements EquivalenceResultUpdaterProvider<
                                 .<Item>fromSource(getClass().getSimpleName())
                                 .build(),
                         ImmutableMultimap.of(),
-                        new DefaultDescription()
+                        desc
                 );
             }
 

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/RoviItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/RoviItemUpdaterProvider.java
@@ -101,30 +101,6 @@ public class RoviItemUpdaterProvider implements EquivalenceResultUpdaterProvider
                 .withExtractor(
                         PercentThresholdEquivalenceExtractor.moreThanPercent(90)
                 )
-//                .withHandler(
-//                        //TODO: strict
-//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-//                                EpisodeFilteringEquivalenceResultHandler.strict(
-//                                        LookupWritingEquivalenceHandler.create(
-//                                                dependencies.getLookupWriter()
-//                                        ),
-//                                        dependencies.getEquivSummaryStore()
-//                                ),
-//                                new ResultWritingEquivalenceHandler<>(
-//                                        dependencies.getEquivalenceResultStore()
-//                                ),
-//                                new EquivalenceSummaryWritingHandler<>(
-//                                        dependencies.getEquivSummaryStore()
-//                                )
-//                        ))
-//                )
-//                .withMessenger(
-//                        //standard
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/RoviItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/RoviItemUpdaterProvider.java
@@ -7,12 +7,6 @@ import org.atlasapi.application.v3.DefaultApplication;
 import org.atlasapi.equiv.generators.BroadcastMatchingItemEquivalenceGeneratorAndScorer;
 import org.atlasapi.equiv.generators.ContainerCandidatesItemEquivalenceGenerator;
 import org.atlasapi.equiv.generators.FilmEquivalenceGenerator;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
 import org.atlasapi.equiv.results.combining.RequiredScoreFilteringCombiner;
 import org.atlasapi.equiv.results.extractors.PercentThresholdEquivalenceExtractor;
@@ -28,9 +22,9 @@ import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.scorers.SequenceItemScorer;
 import org.atlasapi.equiv.scorers.TitleMatchingItemScorer;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
@@ -38,7 +32,7 @@ import org.joda.time.Duration;
 
 import java.util.Set;
 
-public class RoviItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+public class RoviItemUpdaterProvider implements EquivalenceResultUpdaterProvider<Item> {
 
     private RoviItemUpdaterProvider() {
     }
@@ -48,11 +42,11 @@ public class RoviItemUpdaterProvider implements EquivalenceUpdaterProvider<Item>
     }
 
     @Override
-    public EquivalenceUpdater<Item> getUpdater(
+    public EquivalenceResultUpdater<Item> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return ContentEquivalenceUpdater.<Item>builder()
+        return ContentEquivalenceResultUpdater.<Item>builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerators(
@@ -107,28 +101,30 @@ public class RoviItemUpdaterProvider implements EquivalenceUpdaterProvider<Item>
                 .withExtractor(
                         PercentThresholdEquivalenceExtractor.moreThanPercent(90)
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-                                EpisodeFilteringEquivalenceResultHandler.strict(
-                                        LookupWritingEquivalenceHandler.create(
-                                                dependencies.getLookupWriter()
-                                        ),
-                                        dependencies.getEquivSummaryStore()
-                                ),
-                                new ResultWritingEquivalenceHandler<>(
-                                        dependencies.getEquivalenceResultStore()
-                                ),
-                                new EquivalenceSummaryWritingHandler<>(
-                                        dependencies.getEquivSummaryStore()
-                                )
-                        ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+//                        //TODO: strict
+//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+//                                EpisodeFilteringEquivalenceResultHandler.strict(
+//                                        LookupWritingEquivalenceHandler.create(
+//                                                dependencies.getLookupWriter()
+//                                        ),
+//                                        dependencies.getEquivSummaryStore()
+//                                ),
+//                                new ResultWritingEquivalenceHandler<>(
+//                                        dependencies.getEquivalenceResultStore()
+//                                ),
+//                                new EquivalenceSummaryWritingHandler<>(
+//                                        dependencies.getEquivSummaryStore()
+//                                )
+//                        ))
+//                )
+//                .withMessenger(
+//                        //standard
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/RtItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/RtItemUpdaterProvider.java
@@ -5,12 +5,6 @@ import com.google.common.collect.ImmutableSet;
 import org.atlasapi.application.v3.DefaultApplication;
 import org.atlasapi.equiv.generators.FilmEquivalenceGenerator;
 import org.atlasapi.equiv.generators.RadioTimesFilmEquivalenceGenerator;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
 import org.atlasapi.equiv.results.extractors.PercentThresholdEquivalenceExtractor;
 import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
@@ -22,16 +16,16 @@ import org.atlasapi.equiv.results.filters.MinimumScoreFilter;
 import org.atlasapi.equiv.results.filters.PublisherFilter;
 import org.atlasapi.equiv.results.filters.SpecializationFilter;
 import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
 
 import java.util.Set;
 
-public class RtItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+public class RtItemUpdaterProvider implements EquivalenceResultUpdaterProvider<Item> {
 
     private RtItemUpdaterProvider() {
     }
@@ -41,11 +35,11 @@ public class RtItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
     }
 
     @Override
-    public EquivalenceUpdater<Item> getUpdater(
+    public EquivalenceResultUpdater<Item> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return ContentEquivalenceUpdater.<Item>builder()
+        return ContentEquivalenceResultUpdater.<Item>builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerators(
@@ -87,27 +81,29 @@ public class RtItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
                 .withExtractor(
                         PercentThresholdEquivalenceExtractor.moreThanPercent(90)
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-                                EpisodeFilteringEquivalenceResultHandler.relaxed(
-                                        LookupWritingEquivalenceHandler.create(
-                                                dependencies.getLookupWriter()
-                                        ),
-                                        dependencies.getEquivSummaryStore()
-                                ),
-                                new ResultWritingEquivalenceHandler<>(
-                                        dependencies.getEquivalenceResultStore()),
-                                new EquivalenceSummaryWritingHandler<>(
-                                        dependencies.getEquivSummaryStore()
-                                )
-                        ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+//                        //standard
+//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+//                                EpisodeFilteringEquivalenceResultHandler.relaxed(
+//                                        LookupWritingEquivalenceHandler.create(
+//                                                dependencies.getLookupWriter()
+//                                        ),
+//                                        dependencies.getEquivSummaryStore()
+//                                ),
+//                                new ResultWritingEquivalenceHandler<>(
+//                                        dependencies.getEquivalenceResultStore()),
+//                                new EquivalenceSummaryWritingHandler<>(
+//                                        dependencies.getEquivSummaryStore()
+//                                )
+//                        ))
+//                )
+//                .withMessenger(
+//                        //standard
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/RtItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/RtItemUpdaterProvider.java
@@ -81,29 +81,6 @@ public class RtItemUpdaterProvider implements EquivalenceResultUpdaterProvider<I
                 .withExtractor(
                         PercentThresholdEquivalenceExtractor.moreThanPercent(90)
                 )
-//                .withHandler(
-//                        //standard
-//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-//                                EpisodeFilteringEquivalenceResultHandler.relaxed(
-//                                        LookupWritingEquivalenceHandler.create(
-//                                                dependencies.getLookupWriter()
-//                                        ),
-//                                        dependencies.getEquivSummaryStore()
-//                                ),
-//                                new ResultWritingEquivalenceHandler<>(
-//                                        dependencies.getEquivalenceResultStore()),
-//                                new EquivalenceSummaryWritingHandler<>(
-//                                        dependencies.getEquivSummaryStore()
-//                                )
-//                        ))
-//                )
-//                .withMessenger(
-//                        //standard
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/RtUpcomingItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/RtUpcomingItemUpdaterProvider.java
@@ -83,30 +83,6 @@ public class RtUpcomingItemUpdaterProvider implements EquivalenceResultUpdaterPr
                         PercentThresholdAboveNextBestMatchEquivalenceExtractor
                                 .atLeastNTimesGreater(1.5)
                 )
-//                .withHandler(
-//                        //standard
-//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-//                                EpisodeFilteringEquivalenceResultHandler.relaxed(
-//                                        LookupWritingEquivalenceHandler.create(
-//                                                dependencies.getLookupWriter()
-//                                        ),
-//                                        dependencies.getEquivSummaryStore()
-//                                ),
-//                                new ResultWritingEquivalenceHandler<>(
-//                                        dependencies.getEquivalenceResultStore()
-//                                ),
-//                                new EquivalenceSummaryWritingHandler<>(
-//                                        dependencies.getEquivSummaryStore()
-//                                )
-//                        ))
-//                )
-//                .withMessenger(
-//                        //standard
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/RtUpcomingItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/RtUpcomingItemUpdaterProvider.java
@@ -4,12 +4,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.generators.EquivalenceGenerator;
 import org.atlasapi.equiv.generators.TitleSearchGenerator;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
 import org.atlasapi.equiv.results.extractors.PercentThresholdAboveNextBestMatchEquivalenceExtractor;
 import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
@@ -25,16 +19,16 @@ import org.atlasapi.equiv.scorers.DescriptionMatchingScorer;
 import org.atlasapi.equiv.scorers.DescriptionTitleMatchingScorer;
 import org.atlasapi.equiv.scorers.SequenceItemScorer;
 import org.atlasapi.equiv.scorers.TitleMatchingItemScorer;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
 
 import java.util.Set;
 
-public class RtUpcomingItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+public class RtUpcomingItemUpdaterProvider implements EquivalenceResultUpdaterProvider<Item> {
 
     private RtUpcomingItemUpdaterProvider() { }
 
@@ -43,11 +37,11 @@ public class RtUpcomingItemUpdaterProvider implements EquivalenceUpdaterProvider
     }
 
     @Override
-    public EquivalenceUpdater<Item> getUpdater(
+    public EquivalenceResultUpdater<Item> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return ContentEquivalenceUpdater.<Item>builder()
+        return ContentEquivalenceResultUpdater.<Item>builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerators(
@@ -89,28 +83,30 @@ public class RtUpcomingItemUpdaterProvider implements EquivalenceUpdaterProvider
                         PercentThresholdAboveNextBestMatchEquivalenceExtractor
                                 .atLeastNTimesGreater(1.5)
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-                                EpisodeFilteringEquivalenceResultHandler.relaxed(
-                                        LookupWritingEquivalenceHandler.create(
-                                                dependencies.getLookupWriter()
-                                        ),
-                                        dependencies.getEquivSummaryStore()
-                                ),
-                                new ResultWritingEquivalenceHandler<>(
-                                        dependencies.getEquivalenceResultStore()
-                                ),
-                                new EquivalenceSummaryWritingHandler<>(
-                                        dependencies.getEquivSummaryStore()
-                                )
-                        ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+//                        //standard
+//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+//                                EpisodeFilteringEquivalenceResultHandler.relaxed(
+//                                        LookupWritingEquivalenceHandler.create(
+//                                                dependencies.getLookupWriter()
+//                                        ),
+//                                        dependencies.getEquivSummaryStore()
+//                                ),
+//                                new ResultWritingEquivalenceHandler<>(
+//                                        dependencies.getEquivalenceResultStore()
+//                                ),
+//                                new EquivalenceSummaryWritingHandler<>(
+//                                        dependencies.getEquivSummaryStore()
+//                                )
+//                        ))
+//                )
+//                .withMessenger(
+//                        //standard
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/StandardItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/StandardItemUpdaterProvider.java
@@ -88,28 +88,6 @@ public class StandardItemUpdaterProvider implements EquivalenceResultUpdaterProv
                         PercentThresholdAboveNextBestMatchEquivalenceExtractor
                                 .atLeastNTimesGreater(1.5)
                 )
-//                .withHandler(
-//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-//                                EpisodeFilteringEquivalenceResultHandler.relaxed(
-//                                        LookupWritingEquivalenceHandler.create(
-//                                                dependencies.getLookupWriter()
-//                                        ),
-//                                        dependencies.getEquivSummaryStore()
-//                                ),
-//                                new ResultWritingEquivalenceHandler<>(
-//                                        dependencies.getEquivalenceResultStore()
-//                                ),
-//                                new EquivalenceSummaryWritingHandler<>(
-//                                        dependencies.getEquivSummaryStore()
-//                                )
-//                        ))
-//                )
-//                .withMessenger(
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/StandardItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/StandardItemUpdaterProvider.java
@@ -5,12 +5,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.generators.BroadcastMatchingItemEquivalenceGeneratorAndScorer;
 import org.atlasapi.equiv.generators.EquivalenceGenerator;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
 import org.atlasapi.equiv.results.extractors.PercentThresholdAboveNextBestMatchEquivalenceExtractor;
 import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
@@ -27,9 +21,9 @@ import org.atlasapi.equiv.scorers.DescriptionMatchingScorer;
 import org.atlasapi.equiv.scorers.DescriptionTitleMatchingScorer;
 import org.atlasapi.equiv.scorers.SequenceItemScorer;
 import org.atlasapi.equiv.scorers.TitleMatchingItemScorer;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
@@ -37,7 +31,7 @@ import org.joda.time.Duration;
 
 import java.util.Set;
 
-public class StandardItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+public class StandardItemUpdaterProvider implements EquivalenceResultUpdaterProvider<Item> {
 
     private StandardItemUpdaterProvider() {}
 
@@ -46,11 +40,11 @@ public class StandardItemUpdaterProvider implements EquivalenceUpdaterProvider<I
     }
 
     @Override
-    public EquivalenceUpdater<Item> getUpdater(
+    public EquivalenceResultUpdater<Item> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return ContentEquivalenceUpdater.<Item>builder()
+        return ContentEquivalenceResultUpdater.<Item>builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerators(
@@ -94,28 +88,28 @@ public class StandardItemUpdaterProvider implements EquivalenceUpdaterProvider<I
                         PercentThresholdAboveNextBestMatchEquivalenceExtractor
                                 .atLeastNTimesGreater(1.5)
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-                                EpisodeFilteringEquivalenceResultHandler.relaxed(
-                                        LookupWritingEquivalenceHandler.create(
-                                                dependencies.getLookupWriter()
-                                        ),
-                                        dependencies.getEquivSummaryStore()
-                                ),
-                                new ResultWritingEquivalenceHandler<>(
-                                        dependencies.getEquivalenceResultStore()
-                                ),
-                                new EquivalenceSummaryWritingHandler<>(
-                                        dependencies.getEquivSummaryStore()
-                                )
-                        ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+//                                EpisodeFilteringEquivalenceResultHandler.relaxed(
+//                                        LookupWritingEquivalenceHandler.create(
+//                                                dependencies.getLookupWriter()
+//                                        ),
+//                                        dependencies.getEquivSummaryStore()
+//                                ),
+//                                new ResultWritingEquivalenceHandler<>(
+//                                        dependencies.getEquivalenceResultStore()
+//                                ),
+//                                new EquivalenceSummaryWritingHandler<>(
+//                                        dependencies.getEquivSummaryStore()
+//                                )
+//                        ))
+//                )
+//                .withMessenger(
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/StrictStandardUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/StrictStandardUpdaterProvider.java
@@ -88,30 +88,6 @@ public class StrictStandardUpdaterProvider implements EquivalenceResultUpdaterPr
                         PercentThresholdAboveNextBestMatchEquivalenceExtractor
                                 .atLeastNTimesGreater(1.5)
                 )
-//                .withHandler(
-//                        //standard
-//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-//                                EpisodeFilteringEquivalenceResultHandler.relaxed(
-//                                        LookupWritingEquivalenceHandler.create(
-//                                                dependencies.getLookupWriter()
-//                                        ),
-//                                        dependencies.getEquivSummaryStore()
-//                                ),
-//                                new ResultWritingEquivalenceHandler<>(
-//                                        dependencies.getEquivalenceResultStore()
-//                                ),
-//                                new EquivalenceSummaryWritingHandler<>(
-//                                        dependencies.getEquivSummaryStore()
-//                                )
-//                        ))
-//                )
-//                .withMessenger(
-//                        //standard
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/StrictStandardUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/StrictStandardUpdaterProvider.java
@@ -5,12 +5,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.generators.BroadcastMatchingItemEquivalenceGeneratorAndScorer;
 import org.atlasapi.equiv.generators.EquivalenceGenerator;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
 import org.atlasapi.equiv.results.extractors.PercentThresholdAboveNextBestMatchEquivalenceExtractor;
 import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
@@ -27,9 +21,9 @@ import org.atlasapi.equiv.scorers.DescriptionMatchingScorer;
 import org.atlasapi.equiv.scorers.DescriptionTitleMatchingScorer;
 import org.atlasapi.equiv.scorers.SequenceItemScorer;
 import org.atlasapi.equiv.scorers.TitleMatchingItemScorer;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
@@ -37,7 +31,7 @@ import org.joda.time.Duration;
 
 import java.util.Set;
 
-public class StrictStandardUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+public class StrictStandardUpdaterProvider implements EquivalenceResultUpdaterProvider<Item> {
 
     private StrictStandardUpdaterProvider() { }
 
@@ -46,11 +40,11 @@ public class StrictStandardUpdaterProvider implements EquivalenceUpdaterProvider
     }
 
     @Override
-    public EquivalenceUpdater<Item> getUpdater(
+    public EquivalenceResultUpdater<Item> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return ContentEquivalenceUpdater.<Item>builder()
+        return ContentEquivalenceResultUpdater.<Item>builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerators(
@@ -94,28 +88,30 @@ public class StrictStandardUpdaterProvider implements EquivalenceUpdaterProvider
                         PercentThresholdAboveNextBestMatchEquivalenceExtractor
                                 .atLeastNTimesGreater(1.5)
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-                                EpisodeFilteringEquivalenceResultHandler.relaxed(
-                                        LookupWritingEquivalenceHandler.create(
-                                                dependencies.getLookupWriter()
-                                        ),
-                                        dependencies.getEquivSummaryStore()
-                                ),
-                                new ResultWritingEquivalenceHandler<>(
-                                        dependencies.getEquivalenceResultStore()
-                                ),
-                                new EquivalenceSummaryWritingHandler<>(
-                                        dependencies.getEquivSummaryStore()
-                                )
-                        ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+//                        //standard
+//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+//                                EpisodeFilteringEquivalenceResultHandler.relaxed(
+//                                        LookupWritingEquivalenceHandler.create(
+//                                                dependencies.getLookupWriter()
+//                                        ),
+//                                        dependencies.getEquivSummaryStore()
+//                                ),
+//                                new ResultWritingEquivalenceHandler<>(
+//                                        dependencies.getEquivalenceResultStore()
+//                                ),
+//                                new EquivalenceSummaryWritingHandler<>(
+//                                        dependencies.getEquivSummaryStore()
+//                                )
+//                        ))
+//                )
+//                .withMessenger(
+//                        //standard
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/TxlogsItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/TxlogsItemUpdaterProvider.java
@@ -5,12 +5,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.generators.BarbAliasEquivalenceGeneratorAndScorer;
 import org.atlasapi.equiv.generators.BroadcastMatchingItemEquivalenceGeneratorAndScorer;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.AddingEquivalenceCombiner;
 import org.atlasapi.equiv.results.extractors.AllOverOrEqHighestNonEmptyThresholdExtractor;
 import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
@@ -24,9 +18,9 @@ import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.scorers.BarbTitleMatchingItemScorer;
 import org.atlasapi.equiv.scorers.DescriptionMatchingScorer;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
@@ -35,7 +29,7 @@ import org.joda.time.Duration;
 
 import java.util.Set;
 
-public class TxlogsItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+public class TxlogsItemUpdaterProvider implements EquivalenceResultUpdaterProvider<Item> {
 
 
     private TxlogsItemUpdaterProvider() {
@@ -47,10 +41,10 @@ public class TxlogsItemUpdaterProvider implements EquivalenceUpdaterProvider<Ite
     }
 
     @Override
-    public EquivalenceUpdater<Item> getUpdater(
+    public EquivalenceResultUpdater<Item> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies, Set<Publisher> targetPublishers
     ) {
-        return ContentEquivalenceUpdater.<Item>builder()
+        return ContentEquivalenceResultUpdater.<Item>builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerators(
@@ -113,28 +107,30 @@ public class TxlogsItemUpdaterProvider implements EquivalenceUpdaterProvider<Ite
                         // one source is 10, we can still extract other publishers whose highest threshold was 4
                         new AllOverOrEqHighestNonEmptyThresholdExtractor<>(ImmutableSet.of(10D, 4D))
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-                                EpisodeFilteringEquivalenceResultHandler.relaxed(
-                                        LookupWritingEquivalenceHandler.create(
-                                                dependencies.getLookupWriter()
-                                        ),
-                                        dependencies.getEquivSummaryStore()
-                                ),
-                                new ResultWritingEquivalenceHandler<>(
-                                        dependencies.getEquivalenceResultStore()
-                                ),
-                                new EquivalenceSummaryWritingHandler<>(
-                                        dependencies.getEquivSummaryStore()
-                                )
-                        ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+                //standard
+//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+//                                EpisodeFilteringEquivalenceResultHandler.relaxed(
+//                                        LookupWritingEquivalenceHandler.create(
+//                                                dependencies.getLookupWriter()
+//                                        ),
+//                                        dependencies.getEquivSummaryStore()
+//                                ),
+//                                new ResultWritingEquivalenceHandler<>(
+//                                        dependencies.getEquivalenceResultStore()
+//                                ),
+//                                new EquivalenceSummaryWritingHandler<>(
+//                                        dependencies.getEquivSummaryStore()
+//                                )
+//                        ))
+//                )
+//                .withMessenger(
+                //standard
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/TxlogsItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/TxlogsItemUpdaterProvider.java
@@ -107,30 +107,6 @@ public class TxlogsItemUpdaterProvider implements EquivalenceResultUpdaterProvid
                         // one source is 10, we can still extract other publishers whose highest threshold was 4
                         new AllOverOrEqHighestNonEmptyThresholdExtractor<>(ImmutableSet.of(10D, 4D))
                 )
-//                .withHandler(
-                //standard
-//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-//                                EpisodeFilteringEquivalenceResultHandler.relaxed(
-//                                        LookupWritingEquivalenceHandler.create(
-//                                                dependencies.getLookupWriter()
-//                                        ),
-//                                        dependencies.getEquivSummaryStore()
-//                                ),
-//                                new ResultWritingEquivalenceHandler<>(
-//                                        dependencies.getEquivalenceResultStore()
-//                                ),
-//                                new EquivalenceSummaryWritingHandler<>(
-//                                        dependencies.getEquivSummaryStore()
-//                                )
-//                        ))
-//                )
-//                .withMessenger(
-                //standard
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/VodItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/VodItemUpdaterProvider.java
@@ -5,12 +5,6 @@ import com.google.common.collect.ImmutableSet;
 import org.atlasapi.application.v3.DefaultApplication;
 import org.atlasapi.equiv.generators.ContainerCandidatesItemEquivalenceGenerator;
 import org.atlasapi.equiv.generators.FilmEquivalenceGenerator;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
 import org.atlasapi.equiv.results.combining.RequiredScoreFilteringCombiner;
 import org.atlasapi.equiv.results.extractors.PercentThresholdEquivalenceExtractor;
@@ -26,16 +20,16 @@ import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.scorers.SequenceItemScorer;
 import org.atlasapi.equiv.scorers.TitleMatchingItemScorer;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
 
 import java.util.Set;
 
-public class VodItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+public class VodItemUpdaterProvider implements EquivalenceResultUpdaterProvider<Item> {
 
     private VodItemUpdaterProvider() {
     }
@@ -45,11 +39,11 @@ public class VodItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> 
     }
 
     @Override
-    public EquivalenceUpdater<Item> getUpdater(
+    public EquivalenceResultUpdater<Item> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return ContentEquivalenceUpdater.<Item>builder()
+        return ContentEquivalenceResultUpdater.<Item>builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerators(
@@ -97,28 +91,30 @@ public class VodItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> 
                 .withExtractor(
                         PercentThresholdEquivalenceExtractor.moreThanPercent(90)
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-                                EpisodeFilteringEquivalenceResultHandler.strict(
-                                        LookupWritingEquivalenceHandler.create(
-                                                dependencies.getLookupWriter()
-                                        ),
-                                        dependencies.getEquivSummaryStore()
-                                ),
-                                new ResultWritingEquivalenceHandler<>(
-                                        dependencies.getEquivalenceResultStore()
-                                ),
-                                new EquivalenceSummaryWritingHandler<>(
-                                        dependencies.getEquivSummaryStore()
-                                )
-                        ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+//                        //TODO: strict
+//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+//                                EpisodeFilteringEquivalenceResultHandler.strict(
+//                                        LookupWritingEquivalenceHandler.create(
+//                                                dependencies.getLookupWriter()
+//                                        ),
+//                                        dependencies.getEquivSummaryStore()
+//                                ),
+//                                new ResultWritingEquivalenceHandler<>(
+//                                        dependencies.getEquivalenceResultStore()
+//                                ),
+//                                new EquivalenceSummaryWritingHandler<>(
+//                                        dependencies.getEquivSummaryStore()
+//                                )
+//                        ))
+//                )
+//                .withMessenger(
+//                        //standard
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/VodItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/VodItemUpdaterProvider.java
@@ -91,30 +91,6 @@ public class VodItemUpdaterProvider implements EquivalenceResultUpdaterProvider<
                 .withExtractor(
                         PercentThresholdEquivalenceExtractor.moreThanPercent(90)
                 )
-//                .withHandler(
-//                        //TODO: strict
-//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-//                                EpisodeFilteringEquivalenceResultHandler.strict(
-//                                        LookupWritingEquivalenceHandler.create(
-//                                                dependencies.getLookupWriter()
-//                                        ),
-//                                        dependencies.getEquivSummaryStore()
-//                                ),
-//                                new ResultWritingEquivalenceHandler<>(
-//                                        dependencies.getEquivalenceResultStore()
-//                                ),
-//                                new EquivalenceSummaryWritingHandler<>(
-//                                        dependencies.getEquivSummaryStore()
-//                                )
-//                        ))
-//                )
-//                .withMessenger(
-//                        //standard
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/VodItemWithSeriesSequenceUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/VodItemWithSeriesSequenceUpdaterProvider.java
@@ -94,30 +94,6 @@ public class VodItemWithSeriesSequenceUpdaterProvider implements EquivalenceResu
                 .withExtractor(
                         PercentThresholdEquivalenceExtractor.moreThanPercent(90)
                 )
-//                .withHandler(
-//                        //TODO: strict
-//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-//                                EpisodeFilteringEquivalenceResultHandler.strict(
-//                                        LookupWritingEquivalenceHandler.create(
-//                                                dependencies.getLookupWriter()
-//                                        ),
-//                                        dependencies.getEquivSummaryStore()
-//                                ),
-//                                new ResultWritingEquivalenceHandler<>(
-//                                        dependencies.getEquivalenceResultStore()
-//                                ),
-//                                new EquivalenceSummaryWritingHandler<>(
-//                                        dependencies.getEquivSummaryStore()
-//                                )
-//                        ))
-//                )
-//                .withMessenger(
-//                        //standard
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/VodItemWithSeriesSequenceUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/VodItemWithSeriesSequenceUpdaterProvider.java
@@ -5,12 +5,6 @@ import com.google.common.collect.ImmutableSet;
 import org.atlasapi.application.v3.DefaultApplication;
 import org.atlasapi.equiv.generators.ContainerCandidatesItemEquivalenceGenerator;
 import org.atlasapi.equiv.generators.FilmEquivalenceGenerator;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
 import org.atlasapi.equiv.results.combining.RequiredScoreFilteringCombiner;
 import org.atlasapi.equiv.results.extractors.PercentThresholdEquivalenceExtractor;
@@ -27,16 +21,16 @@ import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.scorers.SequenceItemScorer;
 import org.atlasapi.equiv.scorers.SeriesSequenceItemScorer;
 import org.atlasapi.equiv.scorers.TitleMatchingItemScorer;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
 
 import java.util.Set;
 
-public class VodItemWithSeriesSequenceUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+public class VodItemWithSeriesSequenceUpdaterProvider implements EquivalenceResultUpdaterProvider<Item> {
 
     private VodItemWithSeriesSequenceUpdaterProvider() {
     }
@@ -46,11 +40,11 @@ public class VodItemWithSeriesSequenceUpdaterProvider implements EquivalenceUpda
     }
 
     @Override
-    public EquivalenceUpdater<Item> getUpdater(
+    public EquivalenceResultUpdater<Item> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return ContentEquivalenceUpdater.<Item>builder()
+        return ContentEquivalenceResultUpdater.<Item>builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerators(
@@ -100,28 +94,30 @@ public class VodItemWithSeriesSequenceUpdaterProvider implements EquivalenceUpda
                 .withExtractor(
                         PercentThresholdEquivalenceExtractor.moreThanPercent(90)
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-                                EpisodeFilteringEquivalenceResultHandler.strict(
-                                        LookupWritingEquivalenceHandler.create(
-                                                dependencies.getLookupWriter()
-                                        ),
-                                        dependencies.getEquivSummaryStore()
-                                ),
-                                new ResultWritingEquivalenceHandler<>(
-                                        dependencies.getEquivalenceResultStore()
-                                ),
-                                new EquivalenceSummaryWritingHandler<>(
-                                        dependencies.getEquivSummaryStore()
-                                )
-                        ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+//                        //TODO: strict
+//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+//                                EpisodeFilteringEquivalenceResultHandler.strict(
+//                                        LookupWritingEquivalenceHandler.create(
+//                                                dependencies.getLookupWriter()
+//                                        ),
+//                                        dependencies.getEquivSummaryStore()
+//                                ),
+//                                new ResultWritingEquivalenceHandler<>(
+//                                        dependencies.getEquivalenceResultStore()
+//                                ),
+//                                new EquivalenceSummaryWritingHandler<>(
+//                                        dependencies.getEquivSummaryStore()
+//                                )
+//                        ))
+//                )
+//                .withMessenger(
+//                        //standard
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/WikipediaItemUpdateProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/WikipediaItemUpdateProvider.java
@@ -5,12 +5,6 @@ import com.google.common.collect.ImmutableSet;
 import org.atlasapi.application.v3.DefaultApplication;
 import org.atlasapi.equiv.generators.FilmEquivalenceGenerator;
 import org.atlasapi.equiv.generators.TitleSearchGenerator;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.AddingEquivalenceCombiner;
 import org.atlasapi.equiv.results.extractors.AllOverOrEqThresholdExtractor;
 import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
@@ -23,16 +17,16 @@ import org.atlasapi.equiv.results.filters.UnpublishedContentFilter;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.scorers.BarbTitleMatchingItemScorer;
 import org.atlasapi.equiv.scorers.ItemYearScorer;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
 
 import java.util.Set;
 
-public class WikipediaItemUpdateProvider implements EquivalenceUpdaterProvider<Item> {
+public class WikipediaItemUpdateProvider implements EquivalenceResultUpdaterProvider<Item> {
 
     private WikipediaItemUpdateProvider() {
 
@@ -43,11 +37,11 @@ public class WikipediaItemUpdateProvider implements EquivalenceUpdaterProvider<I
     }
 
     @Override
-    public EquivalenceUpdater<Item> getUpdater(
+    public EquivalenceResultUpdater<Item> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return ContentEquivalenceUpdater.<Item>builder()
+        return ContentEquivalenceResultUpdater.<Item>builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerators(
@@ -97,28 +91,30 @@ public class WikipediaItemUpdateProvider implements EquivalenceUpdaterProvider<I
                 .withExtractor(
                         AllOverOrEqThresholdExtractor.create(3D)
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-                                EpisodeFilteringEquivalenceResultHandler.relaxed(
-                                        LookupWritingEquivalenceHandler.create(
-                                                dependencies.getLookupWriter()
-                                        ),
-                                        dependencies.getEquivSummaryStore()
-                                ),
-                                new ResultWritingEquivalenceHandler<>(
-                                        dependencies.getEquivalenceResultStore()
-                                ),
-                                new EquivalenceSummaryWritingHandler<>(
-                                        dependencies.getEquivSummaryStore()
-                                )
-                        ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+//                        //standard
+//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+//                                EpisodeFilteringEquivalenceResultHandler.relaxed(
+//                                        LookupWritingEquivalenceHandler.create(
+//                                                dependencies.getLookupWriter()
+//                                        ),
+//                                        dependencies.getEquivSummaryStore()
+//                                ),
+//                                new ResultWritingEquivalenceHandler<>(
+//                                        dependencies.getEquivalenceResultStore()
+//                                ),
+//                                new EquivalenceSummaryWritingHandler<>(
+//                                        dependencies.getEquivSummaryStore()
+//                                )
+//                        ))
+//                )
+//                .withMessenger(
+//                        //standard
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/WikipediaItemUpdateProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/WikipediaItemUpdateProvider.java
@@ -91,30 +91,6 @@ public class WikipediaItemUpdateProvider implements EquivalenceResultUpdaterProv
                 .withExtractor(
                         AllOverOrEqThresholdExtractor.create(3D)
                 )
-//                .withHandler(
-//                        //standard
-//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-//                                EpisodeFilteringEquivalenceResultHandler.relaxed(
-//                                        LookupWritingEquivalenceHandler.create(
-//                                                dependencies.getLookupWriter()
-//                                        ),
-//                                        dependencies.getEquivSummaryStore()
-//                                ),
-//                                new ResultWritingEquivalenceHandler<>(
-//                                        dependencies.getEquivalenceResultStore()
-//                                ),
-//                                new EquivalenceSummaryWritingHandler<>(
-//                                        dependencies.getEquivSummaryStore()
-//                                )
-//                        ))
-//                )
-//                .withMessenger(
-//                        //standard
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/YouviewItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/YouviewItemUpdaterProvider.java
@@ -5,12 +5,6 @@ import com.google.common.collect.ImmutableSet;
 import com.metabroadcast.common.time.DateTimeZones;
 import org.atlasapi.equiv.generators.BroadcastMatchingItemEquivalenceGeneratorAndScorer;
 import org.atlasapi.equiv.generators.EquivalenceGenerator;
-import org.atlasapi.equiv.handlers.DelegatingEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EpisodeFilteringEquivalenceResultHandler;
-import org.atlasapi.equiv.handlers.EquivalenceSummaryWritingHandler;
-import org.atlasapi.equiv.handlers.LookupWritingEquivalenceHandler;
-import org.atlasapi.equiv.handlers.ResultWritingEquivalenceHandler;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.results.combining.NullScoreAwareAveragingCombiner;
 import org.atlasapi.equiv.results.extractors.PercentThresholdAboveNextBestMatchEquivalenceExtractor;
 import org.atlasapi.equiv.results.filters.ConjunctiveFilter;
@@ -29,9 +23,9 @@ import org.atlasapi.equiv.scorers.DescriptionTitleMatchingScorer;
 import org.atlasapi.equiv.scorers.SequenceItemScorer;
 import org.atlasapi.equiv.scorers.TitleMatchingItemScorer;
 import org.atlasapi.equiv.scorers.TitleSubsetBroadcastItemScorer;
-import org.atlasapi.equiv.update.ContentEquivalenceUpdater;
-import org.atlasapi.equiv.update.EquivalenceUpdater;
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.ContentEquivalenceResultUpdater;
+import org.atlasapi.equiv.update.EquivalenceResultUpdater;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
@@ -40,7 +34,7 @@ import org.joda.time.Duration;
 
 import java.util.Set;
 
-public class YouviewItemUpdaterProvider implements EquivalenceUpdaterProvider<Item> {
+public class YouviewItemUpdaterProvider implements EquivalenceResultUpdaterProvider<Item> {
 
     private YouviewItemUpdaterProvider() {
     }
@@ -50,12 +44,12 @@ public class YouviewItemUpdaterProvider implements EquivalenceUpdaterProvider<It
     }
 
     @Override
-    public EquivalenceUpdater<Item> getUpdater(
+    public EquivalenceResultUpdater<Item> getUpdater(
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
 
-        return ContentEquivalenceUpdater.<Item>builder()
+        return ContentEquivalenceResultUpdater.<Item>builder()
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerators(
@@ -109,27 +103,29 @@ public class YouviewItemUpdaterProvider implements EquivalenceUpdaterProvider<It
                         PercentThresholdAboveNextBestMatchEquivalenceExtractor
                                 .atLeastNTimesGreater(1.5)
                 )
-                .withHandler(
-                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-                                EpisodeFilteringEquivalenceResultHandler.relaxed(
-                                        LookupWritingEquivalenceHandler.create(
-                                                dependencies.getLookupWriter()
-                                        ),
-                                        dependencies.getEquivSummaryStore()
-                                ),
-                                new ResultWritingEquivalenceHandler<>(
-                                        dependencies.getEquivalenceResultStore()),
-                                new EquivalenceSummaryWritingHandler<>(
-                                        dependencies.getEquivSummaryStore()
-                                )
-                        ))
-                )
-                .withMessenger(
-                        QueueingEquivalenceResultMessenger.create(
-                                dependencies.getMessageSender(),
-                                dependencies.getLookupEntryStore()
-                        )
-                )
+//                .withHandler(
+//                        //standard
+//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
+//                                EpisodeFilteringEquivalenceResultHandler.relaxed(
+//                                        LookupWritingEquivalenceHandler.create(
+//                                                dependencies.getLookupWriter()
+//                                        ),
+//                                        dependencies.getEquivSummaryStore()
+//                                ),
+//                                new ResultWritingEquivalenceHandler<>(
+//                                        dependencies.getEquivalenceResultStore()),
+//                                new EquivalenceSummaryWritingHandler<>(
+//                                        dependencies.getEquivSummaryStore()
+//                                )
+//                        ))
+//                )
+//                .withMessenger(
+//                        //standard
+//                        QueueingEquivalenceResultMessenger.create(
+//                                dependencies.getMessageSender(),
+//                                dependencies.getLookupEntryStore()
+//                        )
+//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/YouviewItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/YouviewItemUpdaterProvider.java
@@ -103,29 +103,6 @@ public class YouviewItemUpdaterProvider implements EquivalenceResultUpdaterProvi
                         PercentThresholdAboveNextBestMatchEquivalenceExtractor
                                 .atLeastNTimesGreater(1.5)
                 )
-//                .withHandler(
-//                        //standard
-//                        new DelegatingEquivalenceResultHandler<>(ImmutableList.of(
-//                                EpisodeFilteringEquivalenceResultHandler.relaxed(
-//                                        LookupWritingEquivalenceHandler.create(
-//                                                dependencies.getLookupWriter()
-//                                        ),
-//                                        dependencies.getEquivSummaryStore()
-//                                ),
-//                                new ResultWritingEquivalenceHandler<>(
-//                                        dependencies.getEquivalenceResultStore()),
-//                                new EquivalenceSummaryWritingHandler<>(
-//                                        dependencies.getEquivSummaryStore()
-//                                )
-//                        ))
-//                )
-//                .withMessenger(
-//                        //standard
-//                        QueueingEquivalenceResultMessenger.create(
-//                                dependencies.getMessageSender(),
-//                                dependencies.getLookupEntryStore()
-//                        )
-//                )
                 .build();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/types/ContainerEquivalenceUpdaterType.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/types/ContainerEquivalenceUpdaterType.java
@@ -1,6 +1,6 @@
 package org.atlasapi.equiv.update.updaters.types;
 
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.container.AmazonContainerUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.container.AmazonSeriesUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.container.BroadcastItemContainerUpdaterProvider;
@@ -60,13 +60,13 @@ public enum ContainerEquivalenceUpdaterType {
     ),
     ;
 
-    private final EquivalenceUpdaterProvider<Container> provider;
+    private final EquivalenceResultUpdaterProvider<Container> provider;
 
-    ContainerEquivalenceUpdaterType(EquivalenceUpdaterProvider<Container> provider) {
+    ContainerEquivalenceUpdaterType(EquivalenceResultUpdaterProvider<Container> provider) {
         this.provider = checkNotNull(provider);
     }
 
-    public EquivalenceUpdaterProvider<Container> getProvider() {
+    public EquivalenceResultUpdaterProvider<Container> getProvider() {
         return provider;
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/types/ItemEquivalenceUpdaterType.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/types/ItemEquivalenceUpdaterType.java
@@ -9,6 +9,7 @@ import org.atlasapi.equiv.update.updaters.providers.item.BroadcastItemUpdaterPro
 import org.atlasapi.equiv.update.updaters.providers.item.BtVodItemUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.item.ImdbApitemUpdateProvider;
 import org.atlasapi.equiv.update.updaters.providers.item.MusicItemUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.item.NopItemUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.item.RoviItemUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.item.RtItemUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.item.RtUpcomingItemUpdaterProvider;
@@ -24,6 +25,9 @@ import org.atlasapi.media.entity.Item;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public enum ItemEquivalenceUpdaterType {
+    NOP_ITEM(
+            NopItemUpdaterProvider.create()
+    ),
     STANDARD_ITEM(
             StandardItemUpdaterProvider.create()
     ),

--- a/src/main/java/org/atlasapi/equiv/update/updaters/types/ItemEquivalenceUpdaterType.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/types/ItemEquivalenceUpdaterType.java
@@ -1,6 +1,6 @@
 package org.atlasapi.equiv.update.updaters.types;
 
-import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.item.AmazonItemUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.item.BarbItemUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.item.BarbXItemUpdaterProvider;
@@ -9,7 +9,6 @@ import org.atlasapi.equiv.update.updaters.providers.item.BroadcastItemUpdaterPro
 import org.atlasapi.equiv.update.updaters.providers.item.BtVodItemUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.item.ImdbApitemUpdateProvider;
 import org.atlasapi.equiv.update.updaters.providers.item.MusicItemUpdaterProvider;
-import org.atlasapi.equiv.update.updaters.providers.item.NopItemUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.item.RoviItemUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.item.RtItemUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.item.RtUpcomingItemUpdaterProvider;
@@ -25,9 +24,6 @@ import org.atlasapi.media.entity.Item;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public enum ItemEquivalenceUpdaterType {
-    NOP_ITEM(
-            NopItemUpdaterProvider.create()
-    ),
     STANDARD_ITEM(
             StandardItemUpdaterProvider.create()
     ),
@@ -84,13 +80,13 @@ public enum ItemEquivalenceUpdaterType {
     )
     ;
 
-    private final EquivalenceUpdaterProvider<Item> provider;
+    private final EquivalenceResultUpdaterProvider<Item> provider;
 
-    ItemEquivalenceUpdaterType(EquivalenceUpdaterProvider<Item> provider) {
+    ItemEquivalenceUpdaterType(EquivalenceResultUpdaterProvider<Item> provider) {
         this.provider = checkNotNull(provider);
     }
 
-    public EquivalenceUpdaterProvider<Item> getProvider() {
+    public EquivalenceResultUpdaterProvider<Item> getProvider() {
         return provider;
     }
 }

--- a/src/main/webapp/WEB-INF/templates/equivalence/equivalence-widgets-js.soy
+++ b/src/main/webapp/WEB-INF/templates/equivalence/equivalence-widgets-js.soy
@@ -42,7 +42,8 @@
     {if length($result.resultTables) > 1}
         <p class="resultTableLinks">
             {for $i in range(length($result.resultTables))}
-              <span> | </span><a href="#{$i + 1}">{$i + 1}</a>
+              <a href="#{$i + 1}">{$i + 1}</a>
+              {if {$i + 1} < length($result.resultTables)}}<span> | </span>{/if}
             {/for}
             <br>
             <a name="{index($resultTable) + 1}"></a>

--- a/src/main/webapp/WEB-INF/templates/equivalence/equivalence-widgets-js.soy
+++ b/src/main/webapp/WEB-INF/templates/equivalence/equivalence-widgets-js.soy
@@ -43,7 +43,7 @@
         <p class="resultTableLinks">
             {for $i in range(length($result.resultTables))}
               <a href="#{$i + 1}">{$i + 1}</a>
-              {if ($i + 1) < length($result.resultTables)}}<span> | </span>{/if}
+              {if ($i + 1) < length($result.resultTables)}<span> | </span>{/if}
             {/for}
             <br>
             <a name="{index($resultTable) + 1}"></a>

--- a/src/main/webapp/WEB-INF/templates/equivalence/equivalence-widgets-js.soy
+++ b/src/main/webapp/WEB-INF/templates/equivalence/equivalence-widgets-js.soy
@@ -42,10 +42,10 @@
     {if length($result.resultTables) > 1}
         <p class="resultTableLinks">
             {for $i in range(length($result.resultTables))}
-              <a href="#{$i + 1}">{$i + 1}</a>
+              <span> | </span><a href="#{$i + 1}">{$i + 1}</a>
             {/for}
             <br>
-            <a name="index($resultTable) + 1"></a>
+            <a name="{index($resultTable) + 1}"></a>
         </p>
     {/if}
     {if length($resultTable.equivalences) > 0}

--- a/src/main/webapp/WEB-INF/templates/equivalence/equivalence-widgets-js.soy
+++ b/src/main/webapp/WEB-INF/templates/equivalence/equivalence-widgets-js.soy
@@ -35,76 +35,88 @@
  */
 {template .result}
 <h2>{$result.title} - <span class="target-uri">{$result.id}</span> <a style="margin-left:5px;vertical-align:middle" href="{$result.id}"><img src="/static/images/external.png"></a></h2>
-{if length($result.equivalences) > 0}
-<table>
-    <tr>
-        <td></td>
-        <th>Suggested</th>
-        <th></th>
-        <th>Combined</th>
-        {foreach $source in $result.sources}
-        <th>{$source}</th>
-        {/foreach}
-        <th>Expected</th>
-        <th>Not Expected</th>
-        <th>Neither</th>
-        <td></td>
-    </tr>
-{foreach $equivalence in $result.equivalences}
-  <tr id="{$equivalence.id}"{if $equivalence.strong} class="strong"{/if}>
-    <td>{if $equivalence.strong}✔{else}✘{/if}</td>
-    <td><a href="?uri={$equivalence.encodedId}">{$equivalence.title} ({$equivalence.publisher})</a></td>
-    <td><a href="{$equivalence.id}"><img src="/static/images/external.png"></a></td>
-    {if $equivalence.scores['combined'] == false}
-        <td>N/A</td>
-    {else}
-	    <td {if $equivalence.scores['combined'] > 0} title="{print round($equivalence.scores['combined']/$result.totals['combined']*100) }%"{/if}>
-	        {round($equivalence.scores['combined'], 5)}
-	    </td>
-    {/if}
-    {foreach $source in $result.sources}
-	    {if $equivalence.scores[$source] == false}
-	        <td>N/A</td>
-	    {else}
-	        <td {if $equivalence.scores[$source] > 0} title="{print round($equivalence.scores[$source]/$result.totals[$source]*100) }%"{/if}>
-	            {round($equivalence.scores[$source], 5)}
-	        </td>
-	    {/if}
-    {/foreach}
-    <td><input type="radio" name="{$equivalence.encodedId}" value="expect" {if $equivalence.expected == 'expected'}checked{/if}></td>
-    <td><input type="radio" name="{$equivalence.encodedId}" value="notExpect" {if $equivalence.expected == 'notexpected'}checked{/if}></td>
-    <td><input type="radio" name="{$equivalence.encodedId}" value="unknown" {if $equivalence.expected == 'unknown'}checked{/if}></td>
-    {if isFirst($equivalence)}
-        <td rowspan="{print length($result.equivalences)}"><input id={$result.encodedId} class="resultProbeUpdate" type="submit" value="Update Probe" style="font-size:12px"/></td>
-    {/if}
-  </tr>
-{/foreach}
-<tr>
-    <td></td><td>Totals</td><td></td>
-    {if not $result.totals['combined']}
-        <td>N/A</t>
-    {else}
-        <td>{print round($result.totals['combined'], 5)}</td>
-    {/if}
-    {foreach $source in $result.sources}
-        {if not $result.totals[$source]}
-            <td>N/A</t>
-        {else}
-            <td>{print round($result.totals[$source], 5)}</td>
-        {/if}
-    {/foreach}
-    <td colspan="4"></td>
-</tr>
-</table>
-{else}
+{if length($result.resultTables) <= 0}
 <p>No suggested equivalences</p>
 {/if}
+{foreach $resultTable in $result.resultTables}
+    {if length($resultTable.equivalences) > 0}
+    <table>
+        <tr>
+            <td></td>
+            <th>Suggested</th>
+            <th></th>
+            <th>Combined</th>
+            {foreach $source in $resultTable.sources}
+            <th>{$source}</th>
+            {/foreach}
+            <th>Expected</th>
+            <th>Not Expected</th>
+            <th>Neither</th>
+            <td></td>
+        </tr>
+    {foreach $equivalence in $resultTable.equivalences}
+      <tr id="{$equivalence.id}"{if $equivalence.strong} class="strong"{/if}>
+        <td>{if $equivalence.strong}✔{else}✘{/if}</td>
+        <td><a href="?uri={$equivalence.encodedId}">{$equivalence.title} ({$equivalence.publisher})</a></td>
+        <td><a href="{$equivalence.id}"><img src="/static/images/external.png"></a></td>
+        {if $equivalence.scores['combined'] == false}
+            <td>N/A</td>
+        {else}
+            <td {if $equivalence.scores['combined'] > 0} title="{print round($equivalence.scores['combined']/$resultTable.totals['combined']*100) }%"{/if}>
+                {round($equivalence.scores['combined'], 5)}
+            </td>
+        {/if}
+        {foreach $source in $resultTable.sources}
+            {if $equivalence.scores[$source] == false}
+                <td>N/A</td>
+            {else}
+                <td {if $equivalence.scores[$source] > 0} title="{print round($equivalence.scores[$source]/$resultTable.totals[$source]*100) }%"{/if}>
+                    {round($equivalence.scores[$source], 5)}
+                </td>
+            {/if}
+        {/foreach}
+        <td><input type="radio" name="{$equivalence.encodedId}" value="expect" {if $equivalence.expected == 'expected'}checked{/if}></td>
+        <td><input type="radio" name="{$equivalence.encodedId}" value="notExpect" {if $equivalence.expected == 'notexpected'}checked{/if}></td>
+        <td><input type="radio" name="{$equivalence.encodedId}" value="unknown" {if $equivalence.expected == 'unknown'}checked{/if}></td>
+        {if isFirst($equivalence)}
+            <td rowspan="{print length($resultTable.equivalences)}"><input id={$result.encodedId} class="resultProbeUpdate" type="submit" value="Update Probe" style="font-size:12px"/></td>
+        {/if}
+      </tr>
+    {/foreach}
+    <tr>
+        <td></td><td>Totals</td><td></td>
+        {if not $resultTable.totals['combined']}
+            <td>N/A</t>
+        {else}
+            <td>{print round($resultTable.totals['combined'], 5)}</td>
+        {/if}
+        {foreach $source in $resultTable.sources}
+            {if not $resultTable.totals[$source]}
+                <td>N/A</t>
+            {else}
+                <td>{print round($resultTable.totals[$source], 5)}</td>
+            {/if}
+        {/foreach}
+        <td colspan="4"></td>
+    </tr>
+    </table>
+    {else}
+    <p>No suggested equivalences</p>
+    {/if}
+    {if $resultTable.desc}
+        <div id="desc">
+            {call atlas.templates.equivalence.widgets.description}
+                {param descList: $resultTable.desc /}
+            {/call}
+        </div>
+    {/if}
+{/foreach}
 <p class="time">{$result.time}</p>
 {if $result.desc}
     <div id="desc">
-	    {call atlas.templates.equivalence.widgets.description}
-	        {param descList: $result.desc /}
-	    {/call}
+        {call atlas.templates.equivalence.widgets.description}
+            {param descList: $result.desc /}
+        {/call}
     </div>
 {/if}
 {/template}

--- a/src/main/webapp/WEB-INF/templates/equivalence/equivalence-widgets-js.soy
+++ b/src/main/webapp/WEB-INF/templates/equivalence/equivalence-widgets-js.soy
@@ -44,7 +44,7 @@
         <tr>
             <td>✔/✘</td>
             <th>Suggested</th>
-            <th>id</th>
+            <th>ID</th>
             <th>Combined</th>
             {foreach $source in $resultTable.sources}
             <th>{$source}</th>

--- a/src/main/webapp/WEB-INF/templates/equivalence/equivalence-widgets-js.soy
+++ b/src/main/webapp/WEB-INF/templates/equivalence/equivalence-widgets-js.soy
@@ -24,8 +24,8 @@
 {template .tableResult}
 <tr>
     <td>{$result.time}</td>
-    <td title="{$result.id}"><a href="/system/equivalence/result?uri={$result.encodedId}">{$result.title}</a></td>
-    <td>{length($result.equivalences)}</td>
+    <td title="{$result.id}"><a href="/system/equivalence/result?id={$result.encodedId}">{$result.title}</a></td>
+    <td>"{$result.equivalences}"</td>
     <td>{if $result.hasStrong}✔{else}✘{/if}</td>
 </tr>
 {/template}
@@ -34,7 +34,7 @@
  * @param result
  */
 {template .result}
-<h2>{$result.title} - <span class="target-uri">{$result.id}</span> <a style="margin-left:5px;vertical-align:middle" href="{$result.id}"><img src="/static/images/external.png"></a></h2>
+<h2>{$result.title} - <span class="target-uri">{$result.id}</span> <a style="margin-left:5px;vertical-align:middle" href="{$result.aid}"><img src="/static/images/external.png"></a></h2>
 {if length($result.resultTables) <= 0}
 <p>No suggested equivalences</p>
 {/if}
@@ -57,7 +57,7 @@
     {foreach $equivalence in $resultTable.equivalences}
       <tr id="{$equivalence.id}"{if $equivalence.strong} class="strong"{/if}>
         <td>{if $equivalence.strong}✔{else}✘{/if}</td>
-        <td><a href="?uri={$equivalence.encodedId}">{$equivalence.title} ({$equivalence.publisher})</a></td>
+        <td><a href="?id={$equivalence.encodedId}">{$equivalence.title} ({$equivalence.publisher})</a></td>
         <td><a href="{$equivalence.id}"><img src="/static/images/external.png"></a></td>
         {if $equivalence.scores['combined'] == false}
             <td>N/A</td>

--- a/src/main/webapp/WEB-INF/templates/equivalence/equivalence-widgets-js.soy
+++ b/src/main/webapp/WEB-INF/templates/equivalence/equivalence-widgets-js.soy
@@ -39,6 +39,15 @@
 <p>No suggested equivalences</p>
 {/if}
 {foreach $resultTable in $result.resultTables}
+    {if length($result.resultTables) > 1}
+        <p class="resultTableLinks">
+            {for $i in range(length($result.resultTables))}
+              <a href="#{$i + 1}">{$i + 1}</a>
+            {/for}
+            <br>
+            <a name="index($resultTable) + 1"></a>
+        </p>
+    {/if}
     {if length($resultTable.equivalences) > 0}
     <table>
         <tr>

--- a/src/main/webapp/WEB-INF/templates/equivalence/equivalence-widgets-js.soy
+++ b/src/main/webapp/WEB-INF/templates/equivalence/equivalence-widgets-js.soy
@@ -24,7 +24,7 @@
 {template .tableResult}
 <tr>
     <td>{$result.time}</td>
-    <td title="{$result.id}"><a href="/system/equivalence/result?id={$result.encodedId}">{$result.title}</a></td>
+    <td title="{$result.id}"><a href="/system/equivalence/result?id={$result.aid}">{$result.title}</a></td>
     <td>{$result.equivalences}</td>
     <td>{if $result.hasStrong}✔{else}✘{/if}</td>
 </tr>
@@ -34,7 +34,7 @@
  * @param result
  */
 {template .result}
-<h2>{$result.title} - <span class="target-uri">{$result.id}</span> <a style="margin-left:5px;vertical-align:middle" href="{$result.aid}"><img src="/static/images/external.png"></a></h2>
+<h2>{$result.title} ({$result.publisher}) - <span class="target-uri">{$result.id}</span> <span class="target-id">({$result.aid})</span></h2>
 {if length($result.resultTables) <= 0}
 <p>No suggested equivalences</p>
 {/if}
@@ -42,9 +42,9 @@
     {if length($resultTable.equivalences) > 0}
     <table>
         <tr>
-            <td></td>
+            <td>✔/✘</td>
             <th>Suggested</th>
-            <th></th>
+            <th>id</th>
             <th>Combined</th>
             {foreach $source in $resultTable.sources}
             <th>{$source}</th>
@@ -58,7 +58,7 @@
       <tr id="{$equivalence.id}"{if $equivalence.strong} class="strong"{/if}>
         <td>{if $equivalence.strong}✔{else}✘{/if}</td>
         <td><a href="?id={$equivalence.encodedId}">{$equivalence.title} ({$equivalence.publisher})</a></td>
-        <td><a href="{$equivalence.id}"><img src="/static/images/external.png"></a></td>
+        <td>{$equivalence.id}</td>
         {if $equivalence.scores['combined'] == false}
             <td>N/A</td>
         {else}

--- a/src/main/webapp/WEB-INF/templates/equivalence/equivalence-widgets-js.soy
+++ b/src/main/webapp/WEB-INF/templates/equivalence/equivalence-widgets-js.soy
@@ -43,7 +43,7 @@
         <p class="resultTableLinks">
             {for $i in range(length($result.resultTables))}
               <a href="#{$i + 1}">{$i + 1}</a>
-              {if {$i + 1} < length($result.resultTables)}}<span> | </span>{/if}
+              {if ($i + 1) < length($result.resultTables)}}<span> | </span>{/if}
             {/for}
             <br>
             <a name="{index($resultTable) + 1}"></a>

--- a/src/main/webapp/WEB-INF/templates/equivalence/equivalence-widgets-js.soy
+++ b/src/main/webapp/WEB-INF/templates/equivalence/equivalence-widgets-js.soy
@@ -42,7 +42,6 @@
     {if length($result.resultTables) > 1}
         <p class="resultTableLinks">
             <a name="{index($resultTable) + 1}"></a>
-            <br>
             {for $i in range(length($result.resultTables))}
               <a href="#{$i + 1}">{$i + 1}</a>
               {if ($i + 1) < length($result.resultTables)}<span> | </span>{/if}

--- a/src/main/webapp/WEB-INF/templates/equivalence/equivalence-widgets-js.soy
+++ b/src/main/webapp/WEB-INF/templates/equivalence/equivalence-widgets-js.soy
@@ -25,7 +25,7 @@
 <tr>
     <td>{$result.time}</td>
     <td title="{$result.id}"><a href="/system/equivalence/result?id={$result.encodedId}">{$result.title}</a></td>
-    <td>"{$result.equivalences}"</td>
+    <td>{$result.equivalences}</td>
     <td>{if $result.hasStrong}✔{else}✘{/if}</td>
 </tr>
 {/template}

--- a/src/main/webapp/WEB-INF/templates/equivalence/equivalence-widgets-js.soy
+++ b/src/main/webapp/WEB-INF/templates/equivalence/equivalence-widgets-js.soy
@@ -41,12 +41,12 @@
 {foreach $resultTable in $result.resultTables}
     {if length($result.resultTables) > 1}
         <p class="resultTableLinks">
+            <a name="{index($resultTable) + 1}"></a>
+            <br>
             {for $i in range(length($result.resultTables))}
               <a href="#{$i + 1}">{$i + 1}</a>
               {if ($i + 1) < length($result.resultTables)}<span> | </span>{/if}
             {/for}
-            <br>
-            <a name="{index($resultTable) + 1}"></a>
         </p>
     {/if}
     {if length($resultTable.equivalences) > 0}

--- a/src/main/webapp/WEB-INF/templates/equivalence/equivalence.soy
+++ b/src/main/webapp/WEB-INF/templates/equivalence/equivalence.soy
@@ -41,7 +41,7 @@
 {call atlas.templates.equivalence.widgets.result}
     {param result: $result /}
 {/call}
-<p style="margin: 10px;"><a href="./results?uri={$result.encodedId}">Child Results</a></p>
+<p style="margin: 10px;"><a href="./results?id={$result.aid}">Child Results</a></p>
 </body>
 </html>
 {/template}

--- a/src/test/java/org/atlasapi/equiv/EquivalenceUpdatingWorkerTest.java
+++ b/src/test/java/org/atlasapi/equiv/EquivalenceUpdatingWorkerTest.java
@@ -154,7 +154,7 @@ public class EquivalenceUpdatingWorkerTest {
         when(resolver.findByCanonicalUris(ImmutableSet.of(eid)))
             .thenReturn(ResolvedContent.builder().put(eid, item).build());
         when(resultStore.forId(eid))
-                .thenReturn(new StoredEquivalenceResults(eid, "title",
+                .thenReturn(new StoredEquivalenceResults(eid, eid, "title",
                         ImmutableList.of(
                                 new StoredEquivalenceResultTable(
 

--- a/src/test/java/org/atlasapi/equiv/EquivalenceUpdatingWorkerTest.java
+++ b/src/test/java/org/atlasapi/equiv/EquivalenceUpdatingWorkerTest.java
@@ -1,16 +1,17 @@
 package org.atlasapi.equiv;
 
-import static org.atlasapi.media.entity.Publisher.BBC;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.metabroadcast.common.time.DateTimeZones;
+import com.metabroadcast.common.time.Timestamp;
 import org.atlasapi.equiv.results.persistence.CombinedEquivalenceScore;
 import org.atlasapi.equiv.results.persistence.EquivalenceResultStore;
-import org.atlasapi.equiv.results.persistence.StoredEquivalenceResult;
+import org.atlasapi.equiv.results.persistence.StoredEquivalenceResultTable;
+import org.atlasapi.equiv.results.persistence.StoredEquivalenceResults;
 import org.atlasapi.equiv.update.EquivalenceUpdater;
 import org.atlasapi.media.entity.Brand;
 import org.atlasapi.media.entity.Content;
@@ -22,7 +23,6 @@ import org.atlasapi.persistence.content.ResolvedContent;
 import org.atlasapi.persistence.lookup.entry.LookupEntry;
 import org.atlasapi.persistence.lookup.entry.LookupEntryStore;
 import org.atlasapi.reporting.telescope.OwlTelescopeReporter;
-
 import org.joda.time.DateTime;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -30,14 +30,13 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
-import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
-import com.metabroadcast.common.time.DateTimeZones;
-import com.metabroadcast.common.time.Timestamp;
+import static org.atlasapi.media.entity.Publisher.BBC;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EquivalenceUpdatingWorkerTest {
@@ -155,10 +154,16 @@ public class EquivalenceUpdatingWorkerTest {
         when(resolver.findByCanonicalUris(ImmutableSet.of(eid)))
             .thenReturn(ResolvedContent.builder().put(eid, item).build());
         when(resultStore.forId(eid))
-            .thenReturn(new StoredEquivalenceResult(eid, "title", 
-                    HashBasedTable.<String, String, Double>create(), 
-                    Lists.<CombinedEquivalenceScore>newArrayList(), 
-                    new DateTime(DateTimeZones.UTC), Lists.newArrayList()));
+                .thenReturn(new StoredEquivalenceResults(eid, "title",
+                        ImmutableList.of(
+                                new StoredEquivalenceResultTable(
+
+                                        HashBasedTable.<String, String, Double>create(),
+                                        Lists.<CombinedEquivalenceScore>newArrayList(),
+                                        ImmutableList.of()
+                                )
+                        ),
+                        new DateTime(DateTimeZones.UTC), Lists.newArrayList()));
         
         EntityUpdatedMessage msg = new EntityUpdatedMessage("1", Timestamp.of(1L), eid, "item", "bbc.co.uk");
         workerThatOnlyUpdatesItems.process(msg);

--- a/src/test/java/org/atlasapi/equiv/EquivalenceUpdatingWorkerTest.java
+++ b/src/test/java/org/atlasapi/equiv/EquivalenceUpdatingWorkerTest.java
@@ -154,7 +154,7 @@ public class EquivalenceUpdatingWorkerTest {
         when(resolver.findByCanonicalUris(ImmutableSet.of(eid)))
             .thenReturn(ResolvedContent.builder().put(eid, item).build());
         when(resultStore.forId(eid))
-                .thenReturn(new StoredEquivalenceResults(eid, eid, "title",
+                .thenReturn(new StoredEquivalenceResults(eid, eid, "title", BBC.title(),
                         ImmutableList.of(
                                 new StoredEquivalenceResultTable(
 

--- a/src/test/java/org/atlasapi/equiv/generators/BarbAliasEquivalenceGeneratorAndScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/generators/BarbAliasEquivalenceGeneratorAndScorerTest.java
@@ -11,7 +11,7 @@ import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Alias;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Item;
@@ -177,7 +177,7 @@ public class BarbAliasEquivalenceGeneratorAndScorerTest {
         ScoredCandidates scoredCandidates = generator.generate(
                 subject,
                 desc,
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
 
         Content identified = new Item();
@@ -208,7 +208,7 @@ public class BarbAliasEquivalenceGeneratorAndScorerTest {
         ScoredCandidates scoredCandidates = aliasGenerator.generate(
                 aliasIdentified2,
                 desc,
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
 
         System.out.println(desc.toString());
@@ -335,7 +335,7 @@ public class BarbAliasEquivalenceGeneratorAndScorerTest {
         ScoredCandidates<Content> scoredCandidates = aliasGenerator.generate(
                 bgItem,
                 desc,
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
         assertTrue(!scoredCandidates.candidates().containsKey(bgItem));
         assertTrue(scoredCandidates.candidates().get(oobgItem) == SCORE_ON_MATCH);
@@ -354,7 +354,7 @@ public class BarbAliasEquivalenceGeneratorAndScorerTest {
         ScoredCandidates<Content> scoredCandidates = aliasGenerator.generate(
                 oobgItem,
                 desc,
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
         assertTrue(scoredCandidates.candidates().get(bgItem) == SCORE_ON_MATCH);
         assertTrue(!scoredCandidates.candidates().containsKey(oobgItem));
@@ -373,7 +373,7 @@ public class BarbAliasEquivalenceGeneratorAndScorerTest {
         ScoredCandidates<Content> scoredCandidates = aliasGenerator.generate(
                 parentBcidItem,
                 desc,
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
         assertTrue(scoredCandidates.candidates().get(bgItem) == SCORE_ON_MATCH);
         assertTrue(scoredCandidates.candidates().get(oobgItem) == SCORE_ON_MATCH);
@@ -392,7 +392,7 @@ public class BarbAliasEquivalenceGeneratorAndScorerTest {
         ScoredCandidates<Content> scoredCandidates = aliasGenerator.generate(
                 cmsItem,
                 desc,
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
         assertTrue(scoredCandidates.candidates().get(bgItem) == SCORE_ON_MATCH);
         assertTrue(scoredCandidates.candidates().get(oobgItem) == SCORE_ON_MATCH);
@@ -424,7 +424,7 @@ public class BarbAliasEquivalenceGeneratorAndScorerTest {
         scoredCandidates = aliasGenerator.generate(
                 stvOobgItem,
                 desc,
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
         assertTrue(scoredCandidates.candidates().get(stvBgItem) == SCORE_ON_MATCH);
         assertTrue(!scoredCandidates.candidates().containsKey(stvOobgItem));
@@ -437,7 +437,7 @@ public class BarbAliasEquivalenceGeneratorAndScorerTest {
         scoredCandidates = aliasGenerator.generate(
                 stvBgItem,
                 desc,
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
         assertTrue(!scoredCandidates.candidates().containsKey(stvBgItem));
         assertTrue(scoredCandidates.candidates().get(stvOobgItem) == SCORE_ON_MATCH);
@@ -450,7 +450,7 @@ public class BarbAliasEquivalenceGeneratorAndScorerTest {
         scoredCandidates = aliasGenerator.generate(
                 stvParentBcidItem,
                 desc,
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
         assertTrue(scoredCandidates.candidates().get(stvBgItem) == SCORE_ON_MATCH);
         assertTrue(scoredCandidates.candidates().get(stvOobgItem) == SCORE_ON_MATCH);
@@ -485,7 +485,7 @@ public class BarbAliasEquivalenceGeneratorAndScorerTest {
         scoredCandidates = aliasGenerator.generate(
                 itvBgItem,
                 desc,
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
         assertTrue(scoredCandidates.candidates().get(stvBgItem) == SCORE_ON_MATCH);
         assertTrue(scoredCandidates.candidates().get(stvOobgItem) == SCORE_ON_MATCH);
@@ -498,7 +498,7 @@ public class BarbAliasEquivalenceGeneratorAndScorerTest {
         scoredCandidates = aliasGenerator.generate(
                 itvOobgItem,
                 desc,
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
         assertTrue(scoredCandidates.candidates().get(stvBgItem) == SCORE_ON_MATCH);
         assertTrue(scoredCandidates.candidates().get(stvOobgItem) == SCORE_ON_MATCH);
@@ -511,7 +511,7 @@ public class BarbAliasEquivalenceGeneratorAndScorerTest {
         scoredCandidates = aliasGenerator.generate(
                 itvParentBcidItem,
                 desc,
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
         assertTrue(scoredCandidates.candidates().get(stvBgItem) == SCORE_ON_MATCH);
         assertTrue(scoredCandidates.candidates().get(stvOobgItem) == SCORE_ON_MATCH);
@@ -524,7 +524,7 @@ public class BarbAliasEquivalenceGeneratorAndScorerTest {
         scoredCandidates = aliasGenerator.generate(
                 itvCmsItem,
                 desc,
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
         assertTrue(scoredCandidates.candidates().get(stvBgItem) == SCORE_ON_MATCH);
         assertTrue(scoredCandidates.candidates().get(stvOobgItem) == SCORE_ON_MATCH);
@@ -548,7 +548,7 @@ public class BarbAliasEquivalenceGeneratorAndScorerTest {
         scoredCandidates = aliasGenerator.generate(
                 bgItem,
                 desc,
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
         assertTrue(!scoredCandidates.candidates().containsKey(bgItem));
         assertTrue(scoredCandidates.candidates().get(oobgItem) == SCORE_ON_MATCH);
@@ -558,7 +558,7 @@ public class BarbAliasEquivalenceGeneratorAndScorerTest {
         scoredCandidates = aliasGenerator.generate(
                 oobgItem,
                 desc,
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
         assertTrue(scoredCandidates.candidates().get(bgItem) == SCORE_ON_MATCH);
         assertTrue(!scoredCandidates.candidates().containsKey(oobgItem));
@@ -568,7 +568,7 @@ public class BarbAliasEquivalenceGeneratorAndScorerTest {
         scoredCandidates = aliasGenerator.generate(
                 parentBcidItem,
                 desc,
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
         assertTrue(scoredCandidates.candidates().get(bgItem) == SCORE_ON_MATCH);
         assertTrue(scoredCandidates.candidates().get(oobgItem) == SCORE_ON_MATCH);
@@ -578,7 +578,7 @@ public class BarbAliasEquivalenceGeneratorAndScorerTest {
         scoredCandidates = aliasGenerator.generate(
                 cmsItem,
                 desc,
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
         assertTrue(scoredCandidates.candidates().get(bgItem) == SCORE_ON_MATCH);
         assertTrue(scoredCandidates.candidates().get(oobgItem) == SCORE_ON_MATCH);
@@ -620,7 +620,7 @@ public class BarbAliasEquivalenceGeneratorAndScorerTest {
         scoredCandidates = aliasGenerator.generate(
                 subject,
                 desc,
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
         assertTrue(!scoredCandidates.candidates().containsKey(differentItem));
         assertThat(scoredCandidates.candidates().get(item), is(SCORE_ON_MATCH));

--- a/src/test/java/org/atlasapi/equiv/generators/BroadcastMatchingItemEquivalenceGeneratorAndScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/generators/BroadcastMatchingItemEquivalenceGeneratorAndScorerTest.java
@@ -1,22 +1,15 @@
 package org.atlasapi.equiv.generators;
 
-import static org.atlasapi.media.entity.Publisher.BBC;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.joda.time.Duration.standardMinutes;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.util.List;
-import java.util.Map;
-
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.metabroadcast.common.base.Maybe;
+import com.metabroadcast.common.time.DateTimeZones;
 import junit.framework.TestCase;
-
 import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.channel.Channel;
 import org.atlasapi.media.channel.ChannelResolver;
 import org.atlasapi.media.entity.Broadcast;
@@ -32,13 +25,18 @@ import org.joda.time.Interval;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.metabroadcast.common.base.Maybe;
-import com.metabroadcast.common.time.DateTimeZones;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.atlasapi.media.entity.Publisher.BBC;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.joda.time.Duration.standardMinutes;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class BroadcastMatchingItemEquivalenceGeneratorAndScorerTest extends TestCase {
@@ -73,7 +71,7 @@ public class BroadcastMatchingItemEquivalenceGeneratorAndScorerTest extends Test
         ScoredCandidates<Item> equivalents = generator.generate(
                 item1,
                 new DefaultDescription(),
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
         
         Map<Item, Score> scoreMap = equivalents.candidates();
@@ -100,7 +98,7 @@ public class BroadcastMatchingItemEquivalenceGeneratorAndScorerTest extends Test
         ScoredCandidates<Item> equivalents = generator.generate(
                 item1,
                 new DefaultDescription(),
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
         
         Map<Item, Score> scoreMap = equivalents.candidates();
@@ -132,7 +130,7 @@ public class BroadcastMatchingItemEquivalenceGeneratorAndScorerTest extends Test
         ScoredCandidates<Item> equivalents = generator.generate(
                 item1,
                 new DefaultDescription(),
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
         
         Map<Item, Score> scoreMap = equivalents.candidates();
@@ -178,7 +176,7 @@ public class BroadcastMatchingItemEquivalenceGeneratorAndScorerTest extends Test
         ScoredCandidates<Item> equivalents = generator.generate(
                 item1,
                 new DefaultDescription(),
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
 
         Map<Item, Score> scoreMap = equivalents.candidates();

--- a/src/test/java/org/atlasapi/equiv/generators/ContainerChildEquivalenceGeneratorTest.java
+++ b/src/test/java/org/atlasapi/equiv/generators/ContainerChildEquivalenceGeneratorTest.java
@@ -1,22 +1,17 @@
 package org.atlasapi.equiv.generators;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasItems;
-import static org.mockito.Matchers.argThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.metabroadcast.common.collect.ImmutableOptionalMap;
 import junit.framework.TestCase;
-
 import org.atlasapi.equiv.ContentRef;
 import org.atlasapi.equiv.EquivalenceSummary;
 import org.atlasapi.equiv.EquivalenceSummaryStore;
 import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Episode;
 import org.atlasapi.media.entity.Publisher;
@@ -26,9 +21,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.metabroadcast.common.collect.ImmutableOptionalMap;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasItems;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ContainerChildEquivalenceGeneratorTest extends TestCase {
@@ -77,7 +75,7 @@ public class ContainerChildEquivalenceGeneratorTest extends TestCase {
         ScoredCandidates<Container> scores = generator.generate(
                 subject,
                 new DefaultDescription(),
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
 
         assertThat(scores.candidates(), hasEntry(equiv1, Score.ONE));

--- a/src/test/java/org/atlasapi/equiv/generators/ContentTitleScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/generators/ContentTitleScorerTest.java
@@ -1,25 +1,23 @@
 package org.atlasapi.equiv.generators;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.lessThan;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
+import com.google.common.base.Functions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeComponent;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
 import org.atlasapi.media.entity.Brand;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Publisher;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import com.google.common.base.Functions;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ContentTitleScorerTest {
 

--- a/src/test/java/org/atlasapi/equiv/generators/EquivalenceGeneratorsTest.java
+++ b/src/test/java/org/atlasapi/equiv/generators/EquivalenceGeneratorsTest.java
@@ -1,28 +1,25 @@
 package org.atlasapi.equiv.generators;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-
+import com.google.common.collect.ImmutableSet;
+import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Item;
-
-import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
-
-import com.google.common.collect.ImmutableSet;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.verify;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -35,7 +32,7 @@ public class EquivalenceGeneratorsTest {
     private ScoredCandidates candidates;
 
     private EquivalenceGenerators<Content> generators;
-    private EquivToTelescopeResults equivToTelescopeResults;
+    private EquivToTelescopeResult equivToTelescopeResult;
 
     @Before
     public void setUp() {
@@ -51,10 +48,10 @@ public class EquivalenceGeneratorsTest {
         when(generator.generate(
                 any(Content.class),
                 any(ResultDescription.class),
-                any(EquivToTelescopeResults.class))
+                any(EquivToTelescopeResult.class))
         ).thenReturn(candidates);
 
-        equivToTelescopeResults = EquivToTelescopeResults.create(
+        equivToTelescopeResult = EquivToTelescopeResult.create(
                 "id",
                 "publisher"
         );
@@ -67,7 +64,7 @@ public class EquivalenceGeneratorsTest {
         List<ScoredCandidates<Content>> generated = generators.generate(
                 item,
                 resultDescription,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         assertTrue(generated.isEmpty());
     }
@@ -82,7 +79,7 @@ public class EquivalenceGeneratorsTest {
         List<ScoredCandidates<Content>> generated = generators.generate(
                 item,
                 resultDescription,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         assertTrue(generated.isEmpty());
     }
@@ -91,15 +88,15 @@ public class EquivalenceGeneratorsTest {
     public void generatorCreatesCandidatesForNonExcludedUri() {
         Item item = new Item();
         item.setCanonicalUri("notexcluded");
-        generators.generate(item, resultDescription, equivToTelescopeResults);
-        verify(generator).generate(item, resultDescription, equivToTelescopeResults);
+        generators.generate(item, resultDescription, equivToTelescopeResult);
+        verify(generator).generate(item, resultDescription, equivToTelescopeResult);
     }
 
     @Test
     public void generatorCreatesCandidatesForNonExcludedId() {
         Item item = new Item();
         item.setId(12345678L);
-        generators.generate(item, resultDescription, equivToTelescopeResults);
-        verify(generator).generate(item, resultDescription, equivToTelescopeResults);
+        generators.generate(item, resultDescription, equivToTelescopeResult);
+        verify(generator).generate(item, resultDescription, equivToTelescopeResult);
     }
 }

--- a/src/test/java/org/atlasapi/equiv/generators/ExactTitleGeneratorTest.java
+++ b/src/test/java/org/atlasapi/equiv/generators/ExactTitleGeneratorTest.java
@@ -4,7 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.metabroadcast.applications.client.model.internal.Application;
 import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Identified;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
@@ -54,7 +54,7 @@ public class ExactTitleGeneratorTest {
         ScoredCandidates<Item> candidates = generator.generate(
                 subject,
                 new DefaultDescription(),
-                EquivToTelescopeResults.create("c", "unbox.amazon.co.uk")
+                EquivToTelescopeResult.create("c", "unbox.amazon.co.uk")
         );
 
         Set<Item> candMap = candidates.candidates().keySet();
@@ -80,7 +80,7 @@ public class ExactTitleGeneratorTest {
         ScoredCandidates<Item> candidates = generator.generate(
                 subject,
                 new DefaultDescription(),
-                EquivToTelescopeResults.create("c", "unbox.amazon.co.uk")
+                EquivToTelescopeResult.create("c", "unbox.amazon.co.uk")
         );
 
         Set<Item> candMap = candidates.candidates().keySet();
@@ -106,7 +106,7 @@ public class ExactTitleGeneratorTest {
         ScoredCandidates<Item> candidates = generator.generate(
                 subject,
                 new DefaultDescription(),
-                EquivToTelescopeResults.create("c", "unbox.amazon.co.uk")
+                EquivToTelescopeResult.create("c", "unbox.amazon.co.uk")
         );
 
         Set<Item> candMap = candidates.candidates().keySet();
@@ -123,7 +123,7 @@ public class ExactTitleGeneratorTest {
         ScoredCandidates<Item> candidates = generator.generate(
                 subject,
                 new DefaultDescription(),
-                EquivToTelescopeResults.create("c", "unbox.amazon.co.uk")
+                EquivToTelescopeResult.create("c", "unbox.amazon.co.uk")
         );
 
         assertThat(candidates.candidates().isEmpty(), is(true));
@@ -137,7 +137,7 @@ public class ExactTitleGeneratorTest {
         ScoredCandidates<Item> candidates = generator.generate(
                 subject,
                 new DefaultDescription(),
-                EquivToTelescopeResults.create("c", "unbox.amazon.co.uk")
+                EquivToTelescopeResult.create("c", "unbox.amazon.co.uk")
         );
 
         assertThat(candidates.candidates().isEmpty(), is(true));

--- a/src/test/java/org/atlasapi/equiv/generators/FilmEquivalenceGeneratorTest.java
+++ b/src/test/java/org/atlasapi/equiv/generators/FilmEquivalenceGeneratorTest.java
@@ -1,19 +1,13 @@
 package org.atlasapi.equiv.generators;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.mock;
-
-import java.util.Map;
-
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.metabroadcast.applications.client.model.internal.Application;
 import junit.framework.TestCase;
-
 import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Film;
 import org.atlasapi.media.entity.Identified;
 import org.atlasapi.media.entity.Item;
@@ -29,8 +23,12 @@ import org.jmock.integration.junit4.JMock;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
 
 @RunWith(JMock.class)
 public class FilmEquivalenceGeneratorTest extends TestCase {
@@ -75,7 +73,7 @@ public class FilmEquivalenceGeneratorTest extends TestCase {
         ScoredCandidates<Item> scoredEquivalents = generator.generate(
                 subjectFilm,
                 new DefaultDescription(),
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
         Map<Item, Score> equivalentsScores = scoredEquivalents.candidates();
         assertThat(equivalentsScores.get(anotherFilm), is(equalTo(score)));

--- a/src/test/java/org/atlasapi/equiv/generators/RadioTimesFilmEquivalenceGeneratorTest.java
+++ b/src/test/java/org/atlasapi/equiv/generators/RadioTimesFilmEquivalenceGeneratorTest.java
@@ -1,18 +1,16 @@
 package org.atlasapi.equiv.generators;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.metabroadcast.common.base.Maybe;
 import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Film;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.persistence.content.ContentResolver;
 import org.atlasapi.persistence.content.ResolvedContent;
-
-import com.metabroadcast.common.base.Maybe;
-
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -48,7 +46,7 @@ public class RadioTimesFilmEquivalenceGeneratorTest {
         ScoredCandidates<Item> scoredCandidates = rtFilmEquivalenceGenerator.generate(
                 film,
                 new DefaultDescription(),
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
         Item onlyElement = Iterables.getOnlyElement(scoredCandidates.candidates().keySet());
         assertTrue(onlyElement instanceof Film);
@@ -62,7 +60,7 @@ public class RadioTimesFilmEquivalenceGeneratorTest {
         ScoredCandidates<Item> scoredCandidates = rtFilmEquivalenceGenerator.generate(
                 film,
                 new DefaultDescription(),
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
         assertTrue(scoredCandidates.candidates().isEmpty());
     }

--- a/src/test/java/org/atlasapi/equiv/generators/TitleSearchGeneratorTest.java
+++ b/src/test/java/org/atlasapi/equiv/generators/TitleSearchGeneratorTest.java
@@ -1,18 +1,17 @@
 package org.atlasapi.equiv.generators;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
+import com.google.common.collect.ImmutableList;
 import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Brand;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.persistence.content.SearchResolver;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableList;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class TitleSearchGeneratorTest {
 
@@ -41,7 +40,7 @@ public class TitleSearchGeneratorTest {
         ScoredCandidates<Container> generated = generator.generate(
                 subject,
                 new DefaultDescription(),
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
         
         assertTrue(generated.candidates().keySet().size() == 1);

--- a/src/test/java/org/atlasapi/equiv/handlers/DelegatingEquivalenceResultHandlerTest.java
+++ b/src/test/java/org/atlasapi/equiv/handlers/DelegatingEquivalenceResultHandlerTest.java
@@ -1,9 +1,8 @@
 package org.atlasapi.equiv.handlers;
 
-import org.atlasapi.equiv.results.EquivalenceResult;
-import org.atlasapi.media.entity.Item;
-
 import com.google.common.collect.ImmutableList;
+import org.atlasapi.equiv.results.EquivalenceResults;
+import org.atlasapi.media.entity.Item;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -19,7 +18,7 @@ public class DelegatingEquivalenceResultHandlerTest {
 
     @Mock private EquivalenceResultHandler<Item> firstDelegate;
     @Mock private EquivalenceResultHandler<Item> secondDelegate;
-    @Mock private EquivalenceResult<Item> result;
+    @Mock private EquivalenceResults<Item> result;
 
     private DelegatingEquivalenceResultHandler<Item> handler;
 

--- a/src/test/java/org/atlasapi/equiv/handlers/EpisodeFilteringEquivalenceResultHandlerTest.java
+++ b/src/test/java/org/atlasapi/equiv/handlers/EpisodeFilteringEquivalenceResultHandlerTest.java
@@ -1,11 +1,16 @@
 package org.atlasapi.equiv.handlers;
 
-import java.util.List;
-
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+import com.metabroadcast.common.collect.ImmutableOptionalMap;
 import org.atlasapi.equiv.ContentRef;
 import org.atlasapi.equiv.EquivalenceSummary;
 import org.atlasapi.equiv.EquivalenceSummaryStore;
 import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.equiv.results.EquivalenceResults;
 import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.results.scores.Score;
@@ -17,14 +22,6 @@ import org.atlasapi.media.entity.Episode;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.ParentRef;
 import org.atlasapi.media.entity.Publisher;
-
-import com.metabroadcast.common.collect.ImmutableOptionalMap;
-
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.Multimap;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -33,6 +30,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.List;
 
 import static junit.framework.TestCase.fail;
 import static org.hamcrest.Matchers.hasItem;
@@ -69,7 +68,7 @@ public class EpisodeFilteringEquivalenceResultHandlerTest {
     @Test
     public void testFiltersItemFromNonStrongBrand() {
         //noinspection unchecked
-        when(delegate.handle(Matchers.any(EquivalenceResult.class)))
+        when(delegate.handle(Matchers.any(EquivalenceResults.class)))
                 .thenReturn(true);
 
         Container strongContainer = new Brand("pabrand", "pabrandCurie", Publisher.PA);
@@ -98,12 +97,18 @@ public class EpisodeFilteringEquivalenceResultHandlerTest {
                 new DefaultDescription()
         );
 
+        EquivalenceResults<Item> results = new EquivalenceResults<>(
+                subject,
+                ImmutableList.of(result),
+                new DefaultDescription()
+        );
+
         EquivalenceResultHandler<Item> handler = EpisodeFilteringEquivalenceResultHandler.relaxed(
                 delegate,
                 summaryStore
         );
 
-        handler.handle(result);
+        handler.handle(results);
 
         verify(delegate).handle(argThat(resultWithNoStrongEquivalents()));
     }
@@ -111,7 +116,7 @@ public class EpisodeFilteringEquivalenceResultHandlerTest {
     @Test
     public void testDoesntFilterItemFromStrongBrand() {
         //noinspection unchecked
-        when(delegate.handle(Matchers.any(EquivalenceResult.class)))
+        when(delegate.handle(Matchers.any(EquivalenceResults.class)))
                 .thenReturn(true);
 
         Container strongContainer = new Brand("bbcbrand", "bbcbrandCurie", Publisher.BBC);
@@ -140,12 +145,18 @@ public class EpisodeFilteringEquivalenceResultHandlerTest {
                 new DefaultDescription()
         );
 
+        EquivalenceResults<Item> results = new EquivalenceResults<>(
+                subject,
+                ImmutableList.of(result),
+                new DefaultDescription()
+        );
+
         EquivalenceResultHandler<Item> handler = EpisodeFilteringEquivalenceResultHandler.relaxed(
                 delegate,
                 summaryStore
         );
 
-        handler.handle(result);
+        handler.handle(results);
 
         verify(delegate).handle(argThat(resultWithStrongEquiv(Publisher.BBC, "gequiv")));
     }
@@ -153,7 +164,7 @@ public class EpisodeFilteringEquivalenceResultHandlerTest {
     @Test
     public void testDoesntFilterItemFromSourceWithNoStrongBrandsWhenRelaxed() {
         //noinspection unchecked
-        when(delegate.handle(Matchers.any(EquivalenceResult.class)))
+        when(delegate.handle(Matchers.any(EquivalenceResults.class)))
                 .thenReturn(true);
 
         EquivalenceSummary equivSummary = new EquivalenceSummary(
@@ -181,12 +192,18 @@ public class EpisodeFilteringEquivalenceResultHandlerTest {
                 new DefaultDescription()
         );
 
+        EquivalenceResults<Item> results = new EquivalenceResults<>(
+                subject,
+                ImmutableList.of(result),
+                new DefaultDescription()
+        );
+
         EquivalenceResultHandler<Item> handler = EpisodeFilteringEquivalenceResultHandler.relaxed(
                 delegate,
                 summaryStore
         );
 
-        handler.handle(result);
+        handler.handle(results);
 
         verify(delegate).handle(argThat(resultWithStrongEquiv(Publisher.C4, "ignoredequiv")));
     }
@@ -194,7 +211,7 @@ public class EpisodeFilteringEquivalenceResultHandlerTest {
     @Test
     public void testDoesntFilterItemWithNoBrand() {
         //noinspection unchecked
-        when(delegate.handle(Matchers.any(EquivalenceResult.class)))
+        when(delegate.handle(Matchers.any(EquivalenceResults.class)))
                 .thenReturn(true);
 
         EquivalenceSummary equivSummary = new EquivalenceSummary(
@@ -221,12 +238,18 @@ public class EpisodeFilteringEquivalenceResultHandlerTest {
                 new DefaultDescription()
         );
 
+        EquivalenceResults<Item> results = new EquivalenceResults<>(
+                subject,
+                ImmutableList.of(result),
+                new DefaultDescription()
+        );
+
         EquivalenceResultHandler<Item> handler = EpisodeFilteringEquivalenceResultHandler.relaxed(
                 delegate,
                 summaryStore
         );
 
-        handler.handle(result);
+        handler.handle(results);
 
         verify(delegate).handle(argThat(resultWithStrongEquiv(Publisher.FIVE, "nobrand")));
     }
@@ -234,7 +257,7 @@ public class EpisodeFilteringEquivalenceResultHandlerTest {
     @Test
     public void testFiltersItemFromSourceWithNoStrongBrandsWhenStrict() {
         //noinspection unchecked
-        when(delegate.handle(Matchers.any(EquivalenceResult.class)))
+        when(delegate.handle(Matchers.any(EquivalenceResults.class)))
                 .thenReturn(true);
 
         EquivalenceSummary equivSummary = new EquivalenceSummary(
@@ -259,12 +282,18 @@ public class EpisodeFilteringEquivalenceResultHandlerTest {
                 subject, noScores, emptyCombined, strong, new DefaultDescription()
         );
 
+        EquivalenceResults<Item> results = new EquivalenceResults<>(
+                subject,
+                ImmutableList.of(result),
+                new DefaultDescription()
+        );
+
         EquivalenceResultHandler<Item> handler = EpisodeFilteringEquivalenceResultHandler.strict(
                 delegate,
                 summaryStore
         );
 
-        handler.handle(result);
+        handler.handle(results);
 
         verify(delegate).handle(argThat(resultWithNoStrongEquivalents()));
     }
@@ -272,7 +301,7 @@ public class EpisodeFilteringEquivalenceResultHandlerTest {
     @Test
     public void whenContainerIsNullReturnTrueWhenDelegateReturnsTrue() {
         //noinspection unchecked
-        when(delegate.handle(Matchers.any(EquivalenceResult.class)))
+        when(delegate.handle(Matchers.any(EquivalenceResults.class)))
                 .thenReturn(true);
 
         subject.setParentRef(null);
@@ -285,13 +314,19 @@ public class EpisodeFilteringEquivalenceResultHandlerTest {
                 new DefaultDescription()
         );
 
+        EquivalenceResults<Item> results = new EquivalenceResults<>(
+                subject,
+                ImmutableList.of(result),
+                new DefaultDescription()
+        );
+
         EquivalenceResultHandler<Item> handler = EpisodeFilteringEquivalenceResultHandler.relaxed(
                 delegate,
                 summaryStore
         );
 
         assertThat(
-                handler.handle(result),
+                handler.handle(results),
                 is(true)
         );
     }
@@ -299,7 +334,7 @@ public class EpisodeFilteringEquivalenceResultHandlerTest {
     @Test
     public void whenContainerIsNullReturnFalseWhenDelegateReturnsFalse() {
         //noinspection unchecked
-        when(delegate.handle(Matchers.any(EquivalenceResult.class)))
+        when(delegate.handle(Matchers.any(EquivalenceResults.class)))
                 .thenReturn(false);
 
         subject.setParentRef(null);
@@ -312,13 +347,19 @@ public class EpisodeFilteringEquivalenceResultHandlerTest {
                 new DefaultDescription()
         );
 
+        EquivalenceResults<Item> results = new EquivalenceResults<>(
+                subject,
+                ImmutableList.of(result),
+                new DefaultDescription()
+        );
+
         EquivalenceResultHandler<Item> handler = EpisodeFilteringEquivalenceResultHandler.relaxed(
                 delegate,
                 summaryStore
         );
 
         assertThat(
-                handler.handle(result),
+                handler.handle(results),
                 is(false)
         );
     }
@@ -336,13 +377,19 @@ public class EpisodeFilteringEquivalenceResultHandlerTest {
                 new DefaultDescription()
         );
 
+        EquivalenceResults<Item> results = new EquivalenceResults<>(
+                subject,
+                ImmutableList.of(result),
+                new DefaultDescription()
+        );
+
         EquivalenceResultHandler<Item> handler = EpisodeFilteringEquivalenceResultHandler.relaxed(
                 delegate,
                 summaryStore
         );
 
         try {
-            handler.handle(result);
+            handler.handle(results);
             fail("Item with missing container summary failed to throw exception");
         } catch (ContainerSummaryRequiredException e) {
             assertThat(e.getItem(), is(subject));
@@ -352,7 +399,7 @@ public class EpisodeFilteringEquivalenceResultHandlerTest {
     @Test
     public void returnTrueWhenTheDelegateReturnsTrue() {
         //noinspection unchecked
-        when(delegate.handle(Matchers.any(EquivalenceResult.class)))
+        when(delegate.handle(Matchers.any(EquivalenceResults.class)))
                 .thenReturn(true);
 
         EquivalenceSummary equivSummary = summary(
@@ -379,13 +426,19 @@ public class EpisodeFilteringEquivalenceResultHandlerTest {
                 new DefaultDescription()
         );
 
+        EquivalenceResults<Item> results = new EquivalenceResults<>(
+                subject,
+                ImmutableList.of(result),
+                new DefaultDescription()
+        );
+
         EquivalenceResultHandler<Item> handler = EpisodeFilteringEquivalenceResultHandler.relaxed(
                 delegate,
                 summaryStore
         );
 
         assertThat(
-                handler.handle(result),
+                handler.handle(results),
                 is(true)
         );
     }
@@ -393,7 +446,7 @@ public class EpisodeFilteringEquivalenceResultHandlerTest {
     @Test
     public void returnFalseWhenTheDelegateReturnsFalse() {
         //noinspection unchecked
-        when(delegate.handle(Matchers.any(EquivalenceResult.class)))
+        when(delegate.handle(Matchers.any(EquivalenceResults.class)))
                 .thenReturn(false);
 
         EquivalenceSummary equivSummary = summary(
@@ -420,13 +473,19 @@ public class EpisodeFilteringEquivalenceResultHandlerTest {
                 new DefaultDescription()
         );
 
+        EquivalenceResults<Item> results = new EquivalenceResults<>(
+                subject,
+                ImmutableList.of(result),
+                new DefaultDescription()
+        );
+
         EquivalenceResultHandler<Item> handler = EpisodeFilteringEquivalenceResultHandler.relaxed(
                 delegate,
                 summaryStore
         );
 
         assertThat(
-                handler.handle(result),
+                handler.handle(results),
                 is(false)
         );
     }
@@ -441,11 +500,11 @@ public class EpisodeFilteringEquivalenceResultHandlerTest {
         return equivSummary;
     }
 
-    private Matcher<EquivalenceResult<Item>> resultWithStrongEquiv(
+    private Matcher<EquivalenceResults<Item>> resultWithStrongEquiv(
             final Publisher publisher,
             final String uri
     ) {
-        return new TypeSafeMatcher<EquivalenceResult<Item>>() {
+        return new TypeSafeMatcher<EquivalenceResults<Item>>() {
 
             @Override
             public void describeTo(Description desc) {
@@ -456,17 +515,16 @@ public class EpisodeFilteringEquivalenceResultHandlerTest {
             }
 
             @Override
-            public boolean matchesSafely(EquivalenceResult<Item> result) {
-                return result.strongEquivalences().get(publisher).stream().anyMatch(strong -> strong
-                        .candidate()
+            public boolean matchesSafely(EquivalenceResults<Item> result) {
+                return result.strongEquivalences().stream().anyMatch(strong -> strong
                         .getCanonicalUri()
                         .equals(uri));
             }
         };
     }
 
-    private Matcher<EquivalenceResult<Item>> resultWithNoStrongEquivalents() {
-        return new TypeSafeMatcher<EquivalenceResult<Item>>() {
+    private Matcher<EquivalenceResults<Item>> resultWithNoStrongEquivalents() {
+        return new TypeSafeMatcher<EquivalenceResults<Item>>() {
 
             @Override
             public void describeTo(Description desc) {
@@ -474,8 +532,8 @@ public class EpisodeFilteringEquivalenceResultHandlerTest {
             }
 
             @Override
-            public boolean matchesSafely(EquivalenceResult<Item> result) {
-                return result.strongEquivalences().isEmpty();
+            public boolean matchesSafely(EquivalenceResults<Item> results) {
+                return results.strongEquivalences().isEmpty();
             }
         };
     }

--- a/src/test/java/org/atlasapi/equiv/handlers/LookupWritingEquivalenceHandlerTest.java
+++ b/src/test/java/org/atlasapi/equiv/handlers/LookupWritingEquivalenceHandlerTest.java
@@ -1,17 +1,5 @@
 package org.atlasapi.equiv.handlers;
 
-import java.util.Set;
-
-import org.atlasapi.equiv.ContentRef;
-import org.atlasapi.equiv.results.EquivalenceResult;
-import org.atlasapi.equiv.results.scores.Score;
-import org.atlasapi.equiv.results.scores.ScoredCandidate;
-import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.media.entity.Described;
-import org.atlasapi.media.entity.Item;
-import org.atlasapi.media.entity.Publisher;
-import org.atlasapi.persistence.lookup.LookupWriter;
-
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
@@ -19,11 +7,23 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import junit.framework.TestCase;
+import org.atlasapi.equiv.ContentRef;
+import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.equiv.results.EquivalenceResults;
+import org.atlasapi.equiv.results.scores.Score;
+import org.atlasapi.equiv.results.scores.ScoredCandidate;
+import org.atlasapi.equiv.results.scores.ScoredCandidates;
+import org.atlasapi.media.entity.Described;
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Publisher;
+import org.atlasapi.persistence.lookup.LookupWriter;
 import org.joda.time.Duration;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Set;
 
 import static org.hamcrest.Matchers.any;
 import static org.hamcrest.Matchers.hasItems;
@@ -77,7 +77,7 @@ public class LookupWritingEquivalenceHandlerTest extends TestCase {
         ))
                 .thenReturn(Optional.of(ImmutableSet.of()));
 
-        updater.handle(equivResultFor(content, ImmutableList.of(equiv1, equiv2)));
+        updater.handle(equivResultsFor(content, ImmutableList.of(equiv1, equiv2)));
 
         verify(lookupWriter).writeLookup(
                 argThat(is(contentRef)),
@@ -95,7 +95,7 @@ public class LookupWritingEquivalenceHandlerTest extends TestCase {
         ))
                 .thenReturn(Optional.of(ImmutableSet.of()));
 
-        boolean handled = updater.handle(equivResultFor(content, ImmutableList.of(equiv1, equiv2)));
+        boolean handled = updater.handle(equivResultsFor(content, ImmutableList.of(equiv1, equiv2)));
 
         assertThat(handled, is(true));
     }
@@ -109,7 +109,7 @@ public class LookupWritingEquivalenceHandlerTest extends TestCase {
         ))
                 .thenReturn(Optional.absent());
 
-        boolean handled = updater.handle(equivResultFor(content, ImmutableList.of(equiv1, equiv2)));
+        boolean handled = updater.handle(equivResultsFor(content, ImmutableList.of(equiv1, equiv2)));
 
         assertThat(handled, is(false));
     }
@@ -125,11 +125,11 @@ public class LookupWritingEquivalenceHandlerTest extends TestCase {
         ))
                 .thenReturn(Optional.of(ImmutableSet.of()));
 
-        EquivalenceResult<Item> equivResult = equivResultFor(
+        EquivalenceResults<Item> equivResult = equivResultsFor(
                 content,
                 ImmutableList.of(equiv1, equiv2)
         );
-        EquivalenceResult<Item> noEquivalences = equivResultFor(
+        EquivalenceResults<Item> noEquivalences = equivResultsFor(
                 equiv1,
                 ImmutableList.<Item>of()
         );
@@ -167,12 +167,12 @@ public class LookupWritingEquivalenceHandlerTest extends TestCase {
         ))
                 .thenReturn(Optional.of(ImmutableSet.of()));
 
-        EquivalenceResult<Item> equivResult1 = equivResultFor(
+        EquivalenceResults<Item> equivResult1 = equivResultsFor(
                 content,
                 ImmutableList.of(equiv1, equiv2)
         );
 
-        EquivalenceResult<Item> equivResult2 = equivResultFor(
+        EquivalenceResults<Item> equivResult2 = equivResultsFor(
                 equiv1,
                 ImmutableList.<Item>of(content)
         );
@@ -194,17 +194,22 @@ public class LookupWritingEquivalenceHandlerTest extends TestCase {
 
     }
 
-    private EquivalenceResult<Item> equivResultFor(Item content, Iterable<Item> equivalents) {
+    private EquivalenceResults<Item> equivResultsFor(Item content, Iterable<Item> equivalents) {
         Multimap<Publisher, ScoredCandidate<Item>> strong = Multimaps.transformValues(Multimaps
                 .index(
                 equivalents,
                         Described::getPublisher
         ), RANDOM_SCORE);
-        return new EquivalenceResult<Item>(
+        EquivalenceResult<Item> result = new EquivalenceResult<Item>(
                 content,
                 ImmutableList.<ScoredCandidates<Item>>of(),
                 null,
                 strong,
+                null
+        );
+        return new EquivalenceResults<>(
+                content,
+                ImmutableList.of(result),
                 null
         );
     }

--- a/src/test/java/org/atlasapi/equiv/messengers/QueueingEquivalenceResultMessengerTest.java
+++ b/src/test/java/org/atlasapi/equiv/messengers/QueueingEquivalenceResultMessengerTest.java
@@ -1,6 +1,14 @@
 package org.atlasapi.equiv.messengers;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.primitives.Longs;
+import com.metabroadcast.common.queue.MessageSender;
+import com.metabroadcast.common.time.Timestamp;
+import com.metabroadcast.common.time.Timestamper;
 import org.atlasapi.equiv.results.EquivalenceResult;
+import org.atlasapi.equiv.results.EquivalenceResults;
 import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.media.entity.Item;
@@ -9,15 +17,6 @@ import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.messaging.v3.ContentEquivalenceAssertionMessage;
 import org.atlasapi.persistence.lookup.entry.LookupEntry;
 import org.atlasapi.persistence.lookup.entry.LookupEntryStore;
-
-import com.metabroadcast.common.queue.MessageSender;
-import com.metabroadcast.common.time.Timestamp;
-import com.metabroadcast.common.time.Timestamper;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.primitives.Longs;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
@@ -67,6 +66,12 @@ public class QueueingEquivalenceResultMessengerTest {
                 new DefaultDescription()
         );
 
+        EquivalenceResults<Item> results = new EquivalenceResults<>(
+                subject,
+                ImmutableList.of(result),
+                new DefaultDescription()
+        );
+
         when(lookupEntryStore.entriesForIds(ImmutableSet.of(subject.getId())))
                 .thenReturn(ImmutableList.of(
                         LookupEntry.lookupEntryFrom(graphItemWithLowestId)
@@ -75,7 +80,7 @@ public class QueueingEquivalenceResultMessengerTest {
                                 ))
                 ));
 
-        resultHandler.sendMessage(result);
+        resultHandler.sendMessage(results);
 
         verify(sender).sendMessage(
                 any(ContentEquivalenceAssertionMessage.class),
@@ -94,10 +99,16 @@ public class QueueingEquivalenceResultMessengerTest {
                 new DefaultDescription()
         );
 
+        EquivalenceResults<Item> results = new EquivalenceResults<>(
+                subject,
+                ImmutableList.of(result),
+                new DefaultDescription()
+        );
+
         when(lookupEntryStore.entriesForIds(ImmutableSet.of(subject.getId())))
                 .thenReturn(ImmutableList.of());
 
-        resultHandler.sendMessage(result);
+        resultHandler.sendMessage(results);
 
         verify(sender).sendMessage(
                 any(ContentEquivalenceAssertionMessage.class),

--- a/src/test/java/org/atlasapi/equiv/results/DefaultEquivalenceResultBuilderTest.java
+++ b/src/test/java/org/atlasapi/equiv/results/DefaultEquivalenceResultBuilderTest.java
@@ -1,7 +1,7 @@
 package org.atlasapi.equiv.results;
 
-import java.util.List;
-
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.results.combining.AddingEquivalenceCombiner;
 import org.atlasapi.equiv.results.combining.ScoreCombiner;
 import org.atlasapi.equiv.results.description.DefaultDescription;
@@ -13,7 +13,7 @@ import org.atlasapi.equiv.results.filters.EquivalenceFilter;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Brand;
 import org.atlasapi.media.entity.Broadcast;
 import org.atlasapi.media.entity.Identified;
@@ -21,11 +21,10 @@ import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.media.entity.Series;
 import org.atlasapi.media.entity.Version;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import org.joda.time.DateTime;
 import org.junit.Test;
+
+import java.util.List;
 
 import static org.junit.Assert.assertTrue;
 
@@ -40,7 +39,7 @@ public class DefaultEquivalenceResultBuilderTest {
                     extractor1,
                     extractor2
             ));
-    private final EquivToTelescopeResults equivToTelescopeResults = EquivToTelescopeResults.create("id", "publisher");
+    private final EquivToTelescopeResult equivToTelescopeResult = EquivToTelescopeResult.create("id", "publisher");
 
     @Test
     public void checkDoesNotEquivalateToSeveralPaWithoutBroadcasts() {
@@ -52,7 +51,7 @@ public class DefaultEquivalenceResultBuilderTest {
                 item,
                 equivalents,
                 new DefaultDescription(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
 
         assertTrue(equivalenceResult.strongEquivalences().values().size() == 1);
@@ -92,7 +91,7 @@ public class DefaultEquivalenceResultBuilderTest {
                 item,
                 equivalents,
                 new DefaultDescription(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         assertTrue(equivalenceResult.strongEquivalences().values().size() == 1);
     }
@@ -194,7 +193,7 @@ public class DefaultEquivalenceResultBuilderTest {
                 item,
                 equivalents,
                 new DefaultDescription(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         assertTrue(equivalenceResult.strongEquivalences().values().size() == 1);
     }
@@ -231,7 +230,7 @@ public class DefaultEquivalenceResultBuilderTest {
                 item,
                 equivalents,
                 new DefaultDescription(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         assertTrue(equivalenceResult.strongEquivalences().values().size() == 1);
     }
@@ -296,7 +295,7 @@ public class DefaultEquivalenceResultBuilderTest {
                 item,
                 equivalents,
                 new DefaultDescription(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         return equivalenceResult;
     }
@@ -335,7 +334,7 @@ public class DefaultEquivalenceResultBuilderTest {
                 item,
                 equivalents,
                 new DefaultDescription(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         return equivalenceResult;
     }
@@ -377,7 +376,7 @@ public class DefaultEquivalenceResultBuilderTest {
                 item,
                 equivalents,
                 new DefaultDescription(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
 
         assertTrue(equivalenceResult.strongEquivalences().values().size() == 0);
@@ -398,7 +397,7 @@ public class DefaultEquivalenceResultBuilderTest {
                 item,
                 equivalents,
                 new DefaultDescription(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
 
         assertTrue(equivalenceResult.strongEquivalences().values().size() == 1);
@@ -414,7 +413,7 @@ public class DefaultEquivalenceResultBuilderTest {
                 item,
                 equivalents,
                 new DefaultDescription(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
 
         assertTrue(equivalenceResult.strongEquivalences().values().size() == 1);
@@ -439,7 +438,7 @@ public class DefaultEquivalenceResultBuilderTest {
                 item,
                 equivalents,
                 new DefaultDescription(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
 
         assertTrue(equivalenceResult.strongEquivalences().values().size() == 1);
@@ -463,7 +462,7 @@ public class DefaultEquivalenceResultBuilderTest {
                 item,
                 equivalents,
                 new DefaultDescription(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
 
         assertTrue(equivalenceResult.strongEquivalences().values().size() == 1);
@@ -480,7 +479,7 @@ public class DefaultEquivalenceResultBuilderTest {
                 item,
                 equivalents,
                 new DefaultDescription(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
 
         assertTrue(equivalenceResult.strongEquivalences().values().size() == 1);

--- a/src/test/java/org/atlasapi/equiv/results/EquivalenceResultBuilderTest.java
+++ b/src/test/java/org/atlasapi/equiv/results/EquivalenceResultBuilderTest.java
@@ -1,10 +1,9 @@
 package org.atlasapi.equiv.results;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.List;
-import java.util.Map;
-
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
 import org.atlasapi.equiv.results.combining.AddingEquivalenceCombiner;
 import org.atlasapi.equiv.results.combining.ScoreCombiner;
 import org.atlasapi.equiv.results.description.DefaultDescription;
@@ -16,17 +15,14 @@ import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
-
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Multimap;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
 
 public class EquivalenceResultBuilderTest {
 
@@ -58,7 +54,7 @@ public class EquivalenceResultBuilderTest {
                 item,
                 equivalents,
                 new DefaultDescription(),
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
 
         ScoredCandidates<Item> equivalences = result.combinedEquivalences();

--- a/src/test/java/org/atlasapi/equiv/results/extractors/AllOverOrEqHighestNonEmptyThresholdExtractorTest.java
+++ b/src/test/java/org/atlasapi/equiv/results/extractors/AllOverOrEqHighestNonEmptyThresholdExtractorTest.java
@@ -6,7 +6,7 @@ import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
@@ -24,8 +24,8 @@ public class AllOverOrEqHighestNonEmptyThresholdExtractorTest {
             );
 
     private final ResultDescription desc = new DefaultDescription();
-    private final EquivToTelescopeResults equivToTelescopeResults =
-            EquivToTelescopeResults.create("id", "publisher");
+    private final EquivToTelescopeResult equivToTelescopeResult =
+            EquivToTelescopeResult.create("id", "publisher");
 
 
     @Test
@@ -45,7 +45,7 @@ public class AllOverOrEqHighestNonEmptyThresholdExtractorTest {
                 ImmutableList.<ScoredCandidate<Content>>builder().addAll(expected).addAll(notExpected).build(),
                 new Item(),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         assertThat(scoredCandidates, is(expected));
     }
@@ -67,7 +67,7 @@ public class AllOverOrEqHighestNonEmptyThresholdExtractorTest {
                 ImmutableList.<ScoredCandidate<Content>>builder().addAll(expected).addAll(notExpected).build(),
                 new Item(),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         assertThat(scoredCandidates, is(expected));
     }
@@ -85,7 +85,7 @@ public class AllOverOrEqHighestNonEmptyThresholdExtractorTest {
                 ImmutableList.<ScoredCandidate<Content>>builder().addAll(expected).addAll(notExpected).build(),
                 new Item(),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         assertThat(scoredCandidates, is(expected));
     }
@@ -106,7 +106,7 @@ public class AllOverOrEqHighestNonEmptyThresholdExtractorTest {
                 ImmutableList.<ScoredCandidate<Content>>builder().addAll(expected).addAll(notExpected).build(),
                 new Item(),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         assertThat(scoredCandidates, is(expected));
     }

--- a/src/test/java/org/atlasapi/equiv/results/extractors/PercentThresholdAboveNextBestMatchEquivalenceExtractorTest.java
+++ b/src/test/java/org/atlasapi/equiv/results/extractors/PercentThresholdAboveNextBestMatchEquivalenceExtractorTest.java
@@ -1,29 +1,25 @@
 package org.atlasapi.equiv.results.extractors;
 
+import com.google.common.collect.ImmutableList;
+import org.atlasapi.equiv.results.description.DefaultDescription;
+import org.atlasapi.equiv.results.scores.Score;
+import org.atlasapi.equiv.results.scores.ScoredCandidate;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Publisher;
+import org.junit.Test;
+
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import org.atlasapi.equiv.results.description.DefaultDescription;
-import org.atlasapi.equiv.results.scores.Score;
-import org.atlasapi.equiv.results.scores.ScoredCandidate;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
-import org.atlasapi.media.entity.Item;
-import org.atlasapi.media.entity.Publisher;
-
-import com.google.common.collect.ImmutableSet;
-import org.junit.Test;
-
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
-
 
 public class PercentThresholdAboveNextBestMatchEquivalenceExtractorTest {
 
-    private final EquivToTelescopeResults equivToTelescopeResults =
-            EquivToTelescopeResults.create("id", "publisher");
+    private final EquivToTelescopeResult equivToTelescopeResult =
+            EquivToTelescopeResult.create("id", "publisher");
 
     @Test
     public void testExtractsWhenStrongBeatsNextBestByThreshold() {
@@ -35,7 +31,7 @@ public class PercentThresholdAboveNextBestMatchEquivalenceExtractorTest {
                 strong,
                 ScoredCandidate.valueOf(new Item("test2","cur2",Publisher.BBC), Score.valueOf(0.5))
         ), null, new DefaultDescription(),
-                equivToTelescopeResults);
+                equivToTelescopeResult);
         ScoredCandidate<Item> extract = extractSet.iterator().next();
 
         assertTrue("Strong extracted", !extractSet.isEmpty());
@@ -58,7 +54,7 @@ public class PercentThresholdAboveNextBestMatchEquivalenceExtractorTest {
                 ),
                 null,
                 new DefaultDescription(),
-                equivToTelescopeResults);
+                equivToTelescopeResult);
         assertFalse("Strong should not be extracted", !extractSet.isEmpty());
     } 
     
@@ -72,7 +68,7 @@ public class PercentThresholdAboveNextBestMatchEquivalenceExtractorTest {
                 ImmutableList.<ScoredCandidate<Item>>of(strong),
                 null,
                 new DefaultDescription(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
 
         ScoredCandidate<Item> extract = extractSet.iterator().next();

--- a/src/test/java/org/atlasapi/equiv/results/extractors/PercentThresholdEquivalenceExtractorTest.java
+++ b/src/test/java/org/atlasapi/equiv/results/extractors/PercentThresholdEquivalenceExtractorTest.java
@@ -1,24 +1,21 @@
 package org.atlasapi.equiv.results.extractors;
 
-import java.util.Set;
-
+import com.google.common.collect.ImmutableList;
 import junit.framework.TestCase;
-
 import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
 import org.junit.Test;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
+import java.util.Set;
 
 public class PercentThresholdEquivalenceExtractorTest extends TestCase {
 
-    private final EquivToTelescopeResults equivToTelescopeResults =
-            EquivToTelescopeResults.create("id", "publisher");
+    private final EquivToTelescopeResult equivToTelescopeResult =
+            EquivToTelescopeResult.create("id", "publisher");
 
     @Test
     public void testExtractsItemWith90PercentOfTotalWithNegatives() {
@@ -31,7 +28,7 @@ public class PercentThresholdEquivalenceExtractorTest extends TestCase {
                 ScoredCandidate.valueOf(new Item("test2","cur2",Publisher.BBC), Score.valueOf(-0.5)),
                 ScoredCandidate.valueOf(new Item("test3","cur3",Publisher.BBC), Score.valueOf(-0.5)),
                 ScoredCandidate.valueOf(new Item("test4","cur4",Publisher.BBC), Score.valueOf(-0.5))
-        ), null, new DefaultDescription(), equivToTelescopeResults);
+        ), null, new DefaultDescription(), equivToTelescopeResult);
 
         ScoredCandidate<Item> extract = extractSet.iterator().next();
 
@@ -50,7 +47,7 @@ public class PercentThresholdEquivalenceExtractorTest extends TestCase {
                 ScoredCandidate.valueOf(new Item("test2","cur2",Publisher.BBC), Score.valueOf(-0.5)),
                 ScoredCandidate.valueOf(new Item("test3","cur3",Publisher.BBC), Score.valueOf(-0.5)),
                 ScoredCandidate.valueOf(new Item("test4","cur4",Publisher.BBC), Score.valueOf(-0.5))
-        ), null, new DefaultDescription(), equivToTelescopeResults);
+        ), null, new DefaultDescription(), equivToTelescopeResult);
         
         assertTrue("Something strong extracted", extractSet.isEmpty());
     }

--- a/src/test/java/org/atlasapi/equiv/results/extractors/PublisherFilteringExtractorTest.java
+++ b/src/test/java/org/atlasapi/equiv/results/extractors/PublisherFilteringExtractorTest.java
@@ -1,28 +1,27 @@
 package org.atlasapi.equiv.results.extractors;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import java.util.List;
-
+import com.google.common.collect.ImmutableList;
 import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.filters.PublisherFilter;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableList;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class PublisherFilteringExtractorTest {
 
     @Test
     public void testFiltersUnacceptablePublishers() {
 
-        EquivToTelescopeResults equivToTelescopeResults =
-                EquivToTelescopeResults.create("id", "publisher");
+        EquivToTelescopeResult equivToTelescopeResult =
+                EquivToTelescopeResult.create("id", "publisher");
         
         PublisherFilter<Item> filter = new PublisherFilter<Item>();
         
@@ -32,21 +31,21 @@ public class PublisherFilteringExtractorTest {
                 paScore,
                 itemWithPublisher(Publisher.PA),
                 new DefaultDescription(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         ).iterator().hasNext());
 
         assertTrue(filter.apply(
                 paScore,
                 itemWithPublisher(Publisher.BBC),
                 new DefaultDescription(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         ).iterator().hasNext());
 
         assertTrue(filter.apply(
                 paScore,
                 itemWithPublisher(Publisher.C4_PMLSD),
                 new DefaultDescription(),
-                equivToTelescopeResults).iterator().hasNext()
+                equivToTelescopeResult).iterator().hasNext()
         );
         
         List<ScoredCandidate<Item>> BbcScore = ImmutableList.of(scoreOneFor(Publisher.BBC));
@@ -54,14 +53,14 @@ public class PublisherFilteringExtractorTest {
                 BbcScore,
                 itemWithPublisher(Publisher.C4_PMLSD),
                 new DefaultDescription(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         ).iterator().hasNext());
 
         assertTrue(filter.apply(
                 BbcScore,
                 itemWithPublisher(Publisher.SEESAW),
                 new DefaultDescription(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         ).iterator().hasNext());
         
         List<ScoredCandidate<Item>> dmScore = ImmutableList.of(scoreOneFor(Publisher.DAILYMOTION));
@@ -69,7 +68,7 @@ public class PublisherFilteringExtractorTest {
                 dmScore,
                 itemWithPublisher(Publisher.C4_PMLSD),
                 new DefaultDescription(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         ).iterator().hasNext());
     }
 

--- a/src/test/java/org/atlasapi/equiv/results/filters/ConjunctiveFilterTest.java
+++ b/src/test/java/org/atlasapi/equiv/results/filters/ConjunctiveFilterTest.java
@@ -1,21 +1,5 @@
 package org.atlasapi.equiv.results.filters;
 
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-
-import java.util.List;
-
-import javax.annotation.Nullable;
-
-import org.atlasapi.equiv.results.description.DefaultDescription;
-import org.atlasapi.equiv.results.description.ResultDescription;
-import org.atlasapi.equiv.results.scores.Score;
-import org.atlasapi.equiv.results.scores.ScoredCandidate;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
-
-import org.junit.Test;
-
 import com.google.common.base.Function;
 import com.google.common.collect.ContiguousSet;
 import com.google.common.collect.DiscreteDomain;
@@ -23,6 +7,19 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
+import org.atlasapi.equiv.results.description.DefaultDescription;
+import org.atlasapi.equiv.results.description.ResultDescription;
+import org.atlasapi.equiv.results.scores.Score;
+import org.atlasapi.equiv.results.scores.ScoredCandidate;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 public class ConjunctiveFilterTest {
 
@@ -40,7 +37,7 @@ public class ConjunctiveFilterTest {
                 candidates,
                 null,
                 desc,
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
         
         assertThat(Lists.transform(filtered, ScoredCandidate.<Integer>toCandidate()), is(hasItems(6,12,18)));
@@ -72,7 +69,7 @@ public class ConjunctiveFilterTest {
                 ScoredCandidate<Integer> input,
                 Integer subject,
                 ResultDescription desc,
-                EquivToTelescopeResults equivToTelescopeResults
+                EquivToTelescopeResult equivToTelescopeResult
         ) {
             return input.candidate() % factor == 0;
         }

--- a/src/test/java/org/atlasapi/equiv/results/filters/ContainerHierarchyFilterTest.java
+++ b/src/test/java/org/atlasapi/equiv/results/filters/ContainerHierarchyFilterTest.java
@@ -1,23 +1,22 @@
 package org.atlasapi.equiv.results.filters;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.List;
-
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Brand;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.media.entity.Series;
 import org.junit.Test;
 
-import com.google.common.base.Function;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
 
 public class ContainerHierarchyFilterTest {
 
@@ -36,19 +35,19 @@ public class ContainerHierarchyFilterTest {
                 candidates,
                 brand,
                 new DefaultDescription(),
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         ), brand, topLevelSeries);
         checkFiltered(filter.apply(
                 candidates,
                 topLevelSeries,
                 new DefaultDescription(),
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         ), brand, topLevelSeries);
         checkFiltered(filter.apply(
                 candidates,
                 nonTopLevelSeries,
                 new DefaultDescription(),
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         ), nonTopLevelSeries);
         
     }

--- a/src/test/java/org/atlasapi/equiv/results/filters/DummyContainerFilterTest.java
+++ b/src/test/java/org/atlasapi/equiv/results/filters/DummyContainerFilterTest.java
@@ -1,10 +1,12 @@
 package org.atlasapi.equiv.results.filters;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Brand;
 import org.atlasapi.media.entity.ChildRef;
 import org.atlasapi.media.entity.Container;
@@ -12,20 +14,17 @@ import org.atlasapi.media.entity.CrewMember;
 import org.atlasapi.media.entity.EntityType;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Series;
+import org.joda.time.DateTime;
+import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import org.joda.time.DateTime;
-import org.junit.Test;
-
 public class DummyContainerFilterTest {
 
     private DummyContainerFilter dummyContainerFilter = new DummyContainerFilter();
-    private final EquivToTelescopeResults equivToTelescopeResults =
-            EquivToTelescopeResults.create("id", "publisher");
+    private final EquivToTelescopeResult equivToTelescopeResult =
+            EquivToTelescopeResult.create("id", "publisher");
 
     @Test
     public void testDoesntFilterNonContainers() {
@@ -39,7 +38,7 @@ public class DummyContainerFilterTest {
                         ScoredCandidate.valueOf(candidate, Score.ONE),
                         subject,
                         result,
-                        equivToTelescopeResults
+                        equivToTelescopeResult
                 )
         );
         assertTrue(
@@ -47,7 +46,7 @@ public class DummyContainerFilterTest {
                         ScoredCandidate.valueOf(candidate, Score.ONE),
                         candidate,
                         result,
-                        equivToTelescopeResults
+                        equivToTelescopeResult
                 )
         );
     }
@@ -69,7 +68,7 @@ public class DummyContainerFilterTest {
                         ScoredCandidate.valueOf(candidate, Score.ONE),
                         subject,
                         result,
-                        equivToTelescopeResults
+                        equivToTelescopeResult
                 )
         );
     }
@@ -85,7 +84,7 @@ public class DummyContainerFilterTest {
                         ScoredCandidate.valueOf(candidate, Score.ONE),
                         subject,
                         result,
-                        equivToTelescopeResults
+                        equivToTelescopeResult
                 )
         );
     }
@@ -102,7 +101,7 @@ public class DummyContainerFilterTest {
                         ScoredCandidate.valueOf(candidate, Score.ONE),
                         subject,
                         result,
-                        equivToTelescopeResults
+                        equivToTelescopeResult
                 )
         );
     }

--- a/src/test/java/org/atlasapi/equiv/results/filters/FilmYearFilterTest.java
+++ b/src/test/java/org/atlasapi/equiv/results/filters/FilmYearFilterTest.java
@@ -4,7 +4,7 @@ import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Film;
 import org.atlasapi.media.entity.Item;
 import org.junit.Test;
@@ -15,8 +15,8 @@ import static org.junit.Assert.assertTrue;
 public class FilmYearFilterTest {
 
     private final FilmYearFilter underTest = new FilmYearFilter();
-    private final EquivToTelescopeResults equivToTelescopeResults =
-            EquivToTelescopeResults.create("id", "publisher");
+    private final EquivToTelescopeResult equivToTelescopeResult =
+            EquivToTelescopeResult.create("id", "publisher");
 
     @Test
     public void testDoesntFilterNonFilms() {
@@ -30,7 +30,7 @@ public class FilmYearFilterTest {
                         ScoredCandidate.valueOf(candidate, Score.ONE),
                         subject,
                         result,
-                        equivToTelescopeResults
+                        equivToTelescopeResult
                 )
         );
     }
@@ -47,7 +47,7 @@ public class FilmYearFilterTest {
                         ScoredCandidate.valueOf(candidate, Score.ONE),
                         subject,
                         result,
-                        equivToTelescopeResults
+                        equivToTelescopeResult
                 )
         );
     }
@@ -67,19 +67,19 @@ public class FilmYearFilterTest {
                 ScoredCandidate.valueOf(candidate2015, Score.ONE),
                 subject,
                 result,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         assertTrue(underTest.doFilter(
                 ScoredCandidate.valueOf(candidate2016, Score.ONE),
                 subject,
                 result,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         assertTrue(underTest.doFilter(
                 ScoredCandidate.valueOf(candidate2017, Score.ONE),
                 subject,
                 result,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
     }
 
@@ -93,7 +93,7 @@ public class FilmYearFilterTest {
                 ScoredCandidate.valueOf(candidate, Score.ONE),
                 subject,
                 result,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
 
     }

--- a/src/test/java/org/atlasapi/equiv/results/filters/UnpublishedContentFilterTest.java
+++ b/src/test/java/org/atlasapi/equiv/results/filters/UnpublishedContentFilterTest.java
@@ -3,9 +3,8 @@ package org.atlasapi.equiv.results.filters;
 import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidate;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Item;
-
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
@@ -27,7 +26,7 @@ public class UnpublishedContentFilterTest {
                 itemScoredCandidate,
                 subject,
                 new DefaultDescription(),
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         ));
     }
 
@@ -43,7 +42,7 @@ public class UnpublishedContentFilterTest {
                 itemScoredCandidate,
                 subject,
                 new DefaultDescription(),
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         ));
     }
 }

--- a/src/test/java/org/atlasapi/equiv/results/persistence/EquivalenceResultTranslatorTest.java
+++ b/src/test/java/org/atlasapi/equiv/results/persistence/EquivalenceResultTranslatorTest.java
@@ -1,13 +1,12 @@
 package org.atlasapi.equiv.results.persistence;
 
-import java.util.List;
-import java.util.Set;
-
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Table.Cell;
+import com.mongodb.DBObject;
 import junit.framework.TestCase;
-
-import org.atlasapi.equiv.results.EquivalenceResult;
 import org.atlasapi.equiv.results.DefaultEquivalenceResultBuilder;
+import org.atlasapi.equiv.results.EquivalenceResult;
 import org.atlasapi.equiv.results.EquivalenceResultBuilder;
 import org.atlasapi.equiv.results.combining.AddingEquivalenceCombiner;
 import org.atlasapi.equiv.results.combining.ScoreCombiner;
@@ -19,15 +18,13 @@ import org.atlasapi.equiv.results.filters.EquivalenceFilter;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Table.Cell;
-import com.mongodb.DBObject;
+import java.util.List;
+import java.util.Set;
 
 public class EquivalenceResultTranslatorTest extends TestCase {
 
@@ -43,8 +40,8 @@ public class EquivalenceResultTranslatorTest extends TestCase {
     public final Item equivalent2 = target("equivalent2", "Equivalent2", Publisher.BBC);
     public final Item equivalent3 = target("equivalent3", "Equivalent3", Publisher.C4);
     private static final DefaultDescription desc = new DefaultDescription();
-    private final EquivToTelescopeResults equivToTelescopeResults =
-            EquivToTelescopeResults.create("id", "publisher");
+    private final EquivToTelescopeResult equivToTelescopeResult =
+            EquivToTelescopeResult.create("id", "publisher");
     
     private Item target(String name, String title, Publisher publisher) {
         Item target = new Item(name+"Uri", name+"Curie", publisher);
@@ -60,7 +57,7 @@ public class EquivalenceResultTranslatorTest extends TestCase {
                 target,
                 scores,
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         
         DBObject dbo = translator.toDBObject(itemResult);
@@ -84,7 +81,7 @@ public class EquivalenceResultTranslatorTest extends TestCase {
                 target,
                 scores,
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         
         DBObject dbo = translator.toDBObject(itemResult);
@@ -124,7 +121,7 @@ public class EquivalenceResultTranslatorTest extends TestCase {
                 target,
                 scores,
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         
         DBObject dbo = translator.toDBObject(itemResult);
@@ -162,7 +159,7 @@ public class EquivalenceResultTranslatorTest extends TestCase {
                 target,
                 scores,
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         
         DBObject dbo = translator.toDBObject(itemResult);

--- a/src/test/java/org/atlasapi/equiv/results/persistence/StoredEquivalenceResultTranslatorTest.java
+++ b/src/test/java/org/atlasapi/equiv/results/persistence/StoredEquivalenceResultTranslatorTest.java
@@ -1,11 +1,9 @@
 package org.atlasapi.equiv.results.persistence;
 
-import java.util.List;
-import java.util.Set;
-
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Table.Cell;
 import junit.framework.TestCase;
-
 import org.atlasapi.equiv.results.DefaultEquivalenceResultBuilder;
 import org.atlasapi.equiv.results.EquivalenceResult;
 import org.atlasapi.equiv.results.EquivalenceResultBuilder;
@@ -19,14 +17,13 @@ import org.atlasapi.equiv.results.filters.EquivalenceFilter;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Table.Cell;
+import java.util.List;
+import java.util.Set;
 
 public class StoredEquivalenceResultTranslatorTest extends TestCase {
 
@@ -36,8 +33,8 @@ public class StoredEquivalenceResultTranslatorTest extends TestCase {
     private final EquivalenceExtractor<Item> extractor = TopEquivalenceExtractor.create();
     private final EquivalenceResultBuilder<Item> resultBuilder =
             DefaultEquivalenceResultBuilder.<Item>create(combiner, filter, ImmutableList.of(extractor));
-    private final EquivToTelescopeResults equivToTelescopeResults =
-            EquivToTelescopeResults.create("id", "publisher");
+    private final EquivToTelescopeResult equivToTelescopeResult =
+            EquivToTelescopeResult.create("id", "publisher");
 
     public final Item target = target("target", "Target", Publisher.BBC);
     public final Item equivalent1 = target("equivalent1", "Equivalent1", Publisher.BBC);
@@ -59,7 +56,7 @@ public class StoredEquivalenceResultTranslatorTest extends TestCase {
                 target,
                 scores,
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         
         StoredEquivalenceResult storedResult = translator.toStoredEquivalenceResult(itemResult);
@@ -82,7 +79,7 @@ public class StoredEquivalenceResultTranslatorTest extends TestCase {
                 target,
                 scores,
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         
         StoredEquivalenceResult restoredResult = translator.toStoredEquivalenceResult(itemResult);
@@ -117,7 +114,7 @@ public class StoredEquivalenceResultTranslatorTest extends TestCase {
                 target,
                 scores,
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         
         StoredEquivalenceResult restoredResult = translator.toStoredEquivalenceResult(itemResult);
@@ -154,7 +151,7 @@ public class StoredEquivalenceResultTranslatorTest extends TestCase {
                 target,
                 scores,
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         
         StoredEquivalenceResult restoredResult = translator.toStoredEquivalenceResult(itemResult);

--- a/src/test/java/org/atlasapi/equiv/scorers/BroadcastItemTitleScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/scorers/BroadcastItemTitleScorerTest.java
@@ -1,5 +1,19 @@
 package org.atlasapi.equiv.scorers;
 
+import com.google.common.collect.ImmutableSet;
+import org.atlasapi.equiv.results.description.DefaultDescription;
+import org.atlasapi.equiv.results.scores.Score;
+import org.atlasapi.equiv.results.scores.ScoredCandidates;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
+import org.atlasapi.media.entity.Brand;
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Publisher;
+import org.atlasapi.persistence.content.ContentResolver;
+import org.atlasapi.persistence.content.ResolvedContent;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -10,21 +24,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.atlasapi.equiv.results.description.DefaultDescription;
-import org.atlasapi.equiv.results.scores.Score;
-import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
-import org.atlasapi.media.entity.Brand;
-import org.atlasapi.media.entity.Item;
-import org.atlasapi.media.entity.Publisher;
-import org.atlasapi.persistence.content.ContentResolver;
-import org.atlasapi.persistence.content.ResolvedContent;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
-
-import com.google.common.collect.ImmutableSet;
-
 @RunWith(MockitoJUnitRunner.class)
 public class BroadcastItemTitleScorerTest {
 
@@ -32,8 +31,8 @@ public class BroadcastItemTitleScorerTest {
     private final ContentResolver resolver = mock(ContentResolver.class);
     private final BroadcastItemTitleScorer scorer
         = new BroadcastItemTitleScorer(resolver, mismatchScore);
-    private final EquivToTelescopeResults equivToTelescopeResults =
-            EquivToTelescopeResults.create("id", "publisher");
+    private final EquivToTelescopeResult equivToTelescopeResult =
+            EquivToTelescopeResult.create("id", "publisher");
     
     @Test
     public void testScoresOneIfBrandTitleMatchesWhenCandidateHasContainer() {
@@ -55,7 +54,7 @@ public class BroadcastItemTitleScorerTest {
                 subject,
                 ImmutableSet.of(candidate),
                 new DefaultDescription(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         
         assertThat(results.candidates().get(candidate), is(Score.ONE));
@@ -82,7 +81,7 @@ public class BroadcastItemTitleScorerTest {
                 subject,
                 ImmutableSet.of(candidate),
                 new DefaultDescription(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         
         assertThat(results.candidates().get(candidate), is(Score.ONE));
@@ -106,7 +105,7 @@ public class BroadcastItemTitleScorerTest {
                 subject,
                 ImmutableSet.of(candidate),
                 new DefaultDescription(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         
         assertThat(results.candidates().get(candidate), is(Score.ONE));
@@ -136,7 +135,7 @@ public class BroadcastItemTitleScorerTest {
                 subject,
                 ImmutableSet.of(candidate),
                 new DefaultDescription(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         
         assertThat(results.candidates().get(candidate), is(mismatchScore));

--- a/src/test/java/org/atlasapi/equiv/scorers/ContainerHierarchyMatchingScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/scorers/ContainerHierarchyMatchingScorerTest.java
@@ -1,6 +1,34 @@
 package org.atlasapi.equiv.scorers;
 
-import static org.hamcrest.Matchers.equalTo;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.metabroadcast.common.time.DateTimeZones;
+import org.atlasapi.equiv.results.description.DefaultDescription;
+import org.atlasapi.equiv.results.description.ResultDescription;
+import org.atlasapi.equiv.results.scores.Score;
+import org.atlasapi.equiv.results.scores.ScoredCandidates;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
+import org.atlasapi.media.entity.Brand;
+import org.atlasapi.media.entity.ChildRef;
+import org.atlasapi.media.entity.Container;
+import org.atlasapi.media.entity.EntityType;
+import org.atlasapi.media.entity.Identified;
+import org.atlasapi.media.entity.Publisher;
+import org.atlasapi.media.entity.Series;
+import org.atlasapi.media.entity.SeriesRef;
+import org.atlasapi.persistence.content.ContentResolver;
+import org.atlasapi.persistence.content.ResolvedContent;
+import org.joda.time.DateTime;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.List;
+import java.util.Map;
+
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
@@ -9,40 +37,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
-import java.util.Map;
-
-import org.atlasapi.equiv.results.description.DefaultDescription;
-import org.atlasapi.equiv.results.description.ResultDescription;
-import org.atlasapi.equiv.results.scores.Score;
-import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
-import org.atlasapi.media.entity.Brand;
-import org.atlasapi.media.entity.ChildRef;
-import org.atlasapi.media.entity.Container;
-import org.atlasapi.media.entity.Content;
-import org.atlasapi.media.entity.EntityType;
-import org.atlasapi.media.entity.Episode;
-import org.atlasapi.media.entity.Identified;
-import org.atlasapi.media.entity.Publisher;
-import org.atlasapi.media.entity.Series;
-import org.atlasapi.media.entity.SeriesRef;
-import org.atlasapi.persistence.content.ContentResolver;
-import org.atlasapi.persistence.content.ResolvedContent;
-import org.atlasapi.persistence.content.ResolvedContent.ResolvedContentBuilder;
-import org.hamcrest.core.IsNull;
-import org.joda.time.DateTime;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMap.Builder;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.metabroadcast.common.time.DateTimeZones;
-
 @RunWith(MockitoJUnitRunner.class)
 public class ContainerHierarchyMatchingScorerTest {
 
@@ -50,8 +44,8 @@ public class ContainerHierarchyMatchingScorerTest {
     private SubscriptionCatchupBrandDetector subscriptionCatchupBrandDetector = mock(SubscriptionCatchupBrandDetector.class);
     
     private final ContainerHierarchyMatchingScorer scorer = new ContainerHierarchyMatchingScorer(contentResolver, Score.negativeOne(), subscriptionCatchupBrandDetector);
-    private final EquivToTelescopeResults equivToTelescopeResults =
-            EquivToTelescopeResults.create("id", "publisher");
+    private final EquivToTelescopeResult equivToTelescopeResult =
+            EquivToTelescopeResult.create("id", "publisher");
 
     @Test
     @SuppressWarnings("unchecked")
@@ -61,7 +55,7 @@ public class ContainerHierarchyMatchingScorerTest {
                 brandWithChildren(5),
                 ImmutableSet.<Container>of(brandWithChildren(7)),
                 desc(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         
         assertThat(Iterables.getOnlyElement(score.candidates().values()), is(Score.nullScore()));
@@ -76,7 +70,7 @@ public class ContainerHierarchyMatchingScorerTest {
                 brandWithChildren(7),
                 ImmutableSet.<Container>of(brandWithChildren(7)),
                 desc(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         
         assertThat(Iterables.getOnlyElement(score.candidates().values()), is(Score.ONE));
@@ -99,7 +93,7 @@ public class ContainerHierarchyMatchingScorerTest {
                 subject,
                 ImmutableSet.<Container>of(candidate),
                 desc(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         
         assertThat(Iterables.getOnlyElement(score.candidates().values()), is(Score.nullScore()));
@@ -120,7 +114,7 @@ public class ContainerHierarchyMatchingScorerTest {
                 subject,
                 ImmutableSet.<Container>of(candidate),
                 desc(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         
         assertThat(Iterables.getOnlyElement(score.candidates().values()), is(Score.ONE));
@@ -157,7 +151,7 @@ public class ContainerHierarchyMatchingScorerTest {
                 subject,
                 ImmutableSet.of(candidate),
                 desc(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         
         assertThat(Iterables.getOnlyElement(score.candidates().values()), is(Score.negativeOne()));
@@ -176,7 +170,7 @@ public class ContainerHierarchyMatchingScorerTest {
                 subject,
                 ImmutableSet.of(candidate),
                 desc(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         
         assertThat(Iterables.getOnlyElement(score.candidates().values()), is(Score.nullScore()));
@@ -195,7 +189,7 @@ public class ContainerHierarchyMatchingScorerTest {
                 subject,
                 ImmutableSet.of(candidate),
                 desc(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         
         assertThat(Iterables.getOnlyElement(score.candidates().values()), is(Score.nullScore()));
@@ -214,7 +208,7 @@ public class ContainerHierarchyMatchingScorerTest {
                 subject,
                 ImmutableSet.of(candidate),
                 desc(),
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         
         assertThat(Iterables.getOnlyElement(score.candidates().values()), is(Score.nullScore()));

--- a/src/test/java/org/atlasapi/equiv/scorers/ContentAliasScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/scorers/ContentAliasScorerTest.java
@@ -4,7 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Alias;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
@@ -31,7 +31,7 @@ public class ContentAliasScorerTest {
                 subject,
                 ImmutableSet.of(candidate),
                 new DefaultDescription(),
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
 
         assertThat(results.candidates().get(candidate), is(mismatchScore));
@@ -50,7 +50,7 @@ public class ContentAliasScorerTest {
                 subject,
                 ImmutableSet.of(candidate),
                 new DefaultDescription(),
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
 
         assertThat(results.candidates().get(candidate), is(Score.ONE));
@@ -71,7 +71,7 @@ public class ContentAliasScorerTest {
                 subject,
                 ImmutableSet.of(candidate),
                 new DefaultDescription(),
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
 
         assertThat(results.candidates().get(candidate), is(mismatchScore));
@@ -92,7 +92,7 @@ public class ContentAliasScorerTest {
                 subject,
                 ImmutableSet.of(candidate),
                 new DefaultDescription(),
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
 
         assertThat(results.candidates().get(candidate), is(Score.ONE));

--- a/src/test/java/org/atlasapi/equiv/scorers/CrewMemberScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/scorers/CrewMemberScorerTest.java
@@ -1,21 +1,5 @@
 package org.atlasapi.equiv.scorers;
 
-import static com.google.common.collect.DiscreteDomain.integers;
-import static org.hamcrest.Matchers.closeTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-
-import java.util.List;
-
-import org.atlasapi.equiv.results.description.DefaultDescription;
-import org.atlasapi.equiv.results.description.ResultDescription;
-import org.atlasapi.equiv.results.scores.Score;
-import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
-import org.atlasapi.media.entity.CrewMember;
-import org.atlasapi.media.entity.Item;
-import org.junit.Test;
-
 import com.google.common.base.Function;
 import com.google.common.collect.ContiguousSet;
 import com.google.common.collect.ImmutableList;
@@ -23,6 +7,21 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
+import org.atlasapi.equiv.results.description.DefaultDescription;
+import org.atlasapi.equiv.results.description.ResultDescription;
+import org.atlasapi.equiv.results.scores.Score;
+import org.atlasapi.equiv.results.scores.ScoredCandidates;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
+import org.atlasapi.media.entity.CrewMember;
+import org.atlasapi.media.entity.Item;
+import org.junit.Test;
+
+import java.util.List;
+
+import static com.google.common.collect.DiscreteDomain.integers;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 public class CrewMemberScorerTest {
 
@@ -100,7 +99,7 @@ public class CrewMemberScorerTest {
                 subject,
                 ImmutableSet.of(candidate),
                 desc,
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
     }
 

--- a/src/test/java/org/atlasapi/equiv/scorers/DescriptionMatchingScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/scorers/DescriptionMatchingScorerTest.java
@@ -1,12 +1,11 @@
 package org.atlasapi.equiv.scorers;
 
+import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Item;
-
-import com.google.common.collect.ImmutableSet;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -27,7 +26,7 @@ public class DescriptionMatchingScorerTest {
                 subject,
                 ImmutableSet.of(candidate),
                 desc,
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
         return scores.candidates().get(candidate);
     }

--- a/src/test/java/org/atlasapi/equiv/scorers/DescriptionTitleMatchingScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/scorers/DescriptionTitleMatchingScorerTest.java
@@ -1,20 +1,12 @@
 package org.atlasapi.equiv.scorers;
 
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
-
+import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.scorers.DescriptionTitleMatchingScorer;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Item;
-
-import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
-import scala.actors.threadpool.Arrays;
 
 import static org.junit.Assert.assertEquals;
 
@@ -138,7 +130,7 @@ public class DescriptionTitleMatchingScorerTest {
                 subject,
                 ImmutableSet.of(candidate),
                 desc,
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
         return scores.candidates().get(candidate);
     }

--- a/src/test/java/org/atlasapi/equiv/scorers/SequenceItemScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/scorers/SequenceItemScorerTest.java
@@ -1,30 +1,29 @@
 package org.atlasapi.equiv.scorers;
 
-import static org.atlasapi.equiv.results.scores.Score.NULL_SCORE;
-import static org.atlasapi.equiv.results.scores.Score.ONE;
-import static org.junit.Assert.assertEquals;
-
-import java.util.Set;
-
+import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Episode;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.ParentRef;
 import org.atlasapi.media.entity.Publisher;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+
+import static org.atlasapi.equiv.results.scores.Score.NULL_SCORE;
+import static org.atlasapi.equiv.results.scores.Score.ONE;
+import static org.junit.Assert.assertEquals;
 
 public class SequenceItemScorerTest {
 
     private final SequenceItemScorer scorer = new SequenceItemScorer(Score.ONE);
     private final ResultDescription desc = new DefaultDescription();
-    private final EquivToTelescopeResults equivToTelescopeResults =
-            EquivToTelescopeResults.create("id", "publisher");
+    private final EquivToTelescopeResult equivToTelescopeResult =
+            EquivToTelescopeResult.create("id", "publisher");
 
     @Test
     public void testScoresNullWhenSubjectNotEpisode() {
@@ -34,7 +33,7 @@ public class SequenceItemScorerTest {
         ScoredCandidates<Item> scores = scorer.score(
                 subject, set(candidate),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
 
         assertEquals("should score null if subject not episode",
@@ -50,7 +49,7 @@ public class SequenceItemScorerTest {
                 subject,
                 set(candidate),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
 
         assertEquals("should score null if candidate not episode",
@@ -66,7 +65,7 @@ public class SequenceItemScorerTest {
                 subject,
                 set(candidate),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         
         assertEquals("should score null if episode and series number absent",
@@ -82,7 +81,7 @@ public class SequenceItemScorerTest {
                 subject,
                 set(candidate),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         
         assertEquals("should score null if episode number absent and series number match",
@@ -98,7 +97,7 @@ public class SequenceItemScorerTest {
                 subject,
                 set(candidate),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         
         assertEquals("should score null if episode number absent and series number differs",
@@ -114,7 +113,7 @@ public class SequenceItemScorerTest {
                 subject,
                 set(candidate),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
 
         assertEquals("should score null if series number differs",
@@ -130,7 +129,7 @@ public class SequenceItemScorerTest {
                 subject,
                 set(candidate),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
 
         assertEquals("should score null if episode number differs",
@@ -147,7 +146,7 @@ public class SequenceItemScorerTest {
                 subject,
                 set(candidate),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         
         assertEquals("should score null if series number absent and episode numbers differ",
@@ -163,7 +162,7 @@ public class SequenceItemScorerTest {
                 subject,
                 set(candidate),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         
         assertEquals("should score null if series number and episode numbers differ",
@@ -179,7 +178,7 @@ public class SequenceItemScorerTest {
                 subject,
                 set(candidate),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         
         assertEquals("should score one if series number absent and episode numbers match",
@@ -195,7 +194,7 @@ public class SequenceItemScorerTest {
                 subject,
                 set(candidate),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         
         assertEquals("should score one if series number absent and episode numbers match",
@@ -212,7 +211,7 @@ public class SequenceItemScorerTest {
                 subject,
                 set(candidate),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         
         assertEquals("should score null if subject child of top-level series and candidate not",
@@ -230,7 +229,7 @@ public class SequenceItemScorerTest {
                 subject,
                 set(candidate),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         
         assertEquals("should score null if candidate child of top-level series and subject not",

--- a/src/test/java/org/atlasapi/equiv/scorers/SeriesSequenceItemScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/scorers/SeriesSequenceItemScorerTest.java
@@ -1,22 +1,21 @@
 package org.atlasapi.equiv.scorers;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
-
-import java.util.Set;
-
+import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Episode;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.ParentRef;
 import org.atlasapi.media.entity.Publisher;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 
 public class SeriesSequenceItemScorerTest {
@@ -64,7 +63,7 @@ public class SeriesSequenceItemScorerTest {
                 subject,
                 set(candidate),
                 desc,
-                EquivToTelescopeResults.create("id", "publisher")
+                EquivToTelescopeResult.create("id", "publisher")
         );
         assertThat(scores.candidates().get(candidate), is(expectedScore));
     }

--- a/src/test/java/org/atlasapi/equiv/scorers/TitleMatchingItemScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/scorers/TitleMatchingItemScorerTest.java
@@ -1,19 +1,17 @@
 package org.atlasapi.equiv.scorers;
 
-import static com.google.common.collect.ImmutableSet.of;
+import com.google.common.collect.Iterables;
 import junit.framework.TestCase;
-
 import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
 import org.atlasapi.equiv.scorers.TitleMatchingItemScorer.TitleType;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
-
 import org.junit.Test;
 
-import com.google.common.collect.Iterables;
+import static com.google.common.collect.ImmutableSet.of;
 
 public class TitleMatchingItemScorerTest extends TestCase {
 
@@ -44,20 +42,20 @@ public class TitleMatchingItemScorerTest extends TestCase {
     public void testGenerateEquivalences() {
 
         DefaultDescription desc = new DefaultDescription();
-        EquivToTelescopeResults equivToTelescopeResults = EquivToTelescopeResults.create(
+        EquivToTelescopeResult equivToTelescopeResult = EquivToTelescopeResult.create(
                 "id",
                 "publisher"
         );
 
-        score(2.0, scorer.score(itemWithTitle("09/10/2011"), of(itemWithTitle("09/10/2011")), desc, equivToTelescopeResults));
+        score(2.0, scorer.score(itemWithTitle("09/10/2011"), of(itemWithTitle("09/10/2011")), desc, equivToTelescopeResult));
         
-        score(0, scorer.score(itemWithTitle("19/10/2011"), of(itemWithTitle("09/10/2011")), desc, equivToTelescopeResults));
-        score(0, scorer.score(itemWithTitle("Countdown"), of(itemWithTitle("Out of Time")), desc, equivToTelescopeResults));
-        score(0, scorer.score(itemWithTitle("Episode: 3"), of(itemWithTitle("Episode 5")), desc, equivToTelescopeResults));
+        score(0, scorer.score(itemWithTitle("19/10/2011"), of(itemWithTitle("09/10/2011")), desc, equivToTelescopeResult));
+        score(0, scorer.score(itemWithTitle("Countdown"), of(itemWithTitle("Out of Time")), desc, equivToTelescopeResult));
+        score(0, scorer.score(itemWithTitle("Episode: 3"), of(itemWithTitle("Episode 5")), desc, equivToTelescopeResult));
         
-        score(0, scorer.score(itemWithTitle("19/10/2011"), of(itemWithTitle("Different")), desc, equivToTelescopeResults));
-        score(0, scorer.score(itemWithTitle("Episode 1"), of(itemWithTitle("19/10/2011")), desc, equivToTelescopeResults));
-        score(0, scorer.score(itemWithTitle("Episode 1"), of(itemWithTitle("Different")), desc, equivToTelescopeResults));
+        score(0, scorer.score(itemWithTitle("19/10/2011"), of(itemWithTitle("Different")), desc, equivToTelescopeResult));
+        score(0, scorer.score(itemWithTitle("Episode 1"), of(itemWithTitle("19/10/2011")), desc, equivToTelescopeResult));
+        score(0, scorer.score(itemWithTitle("Episode 1"), of(itemWithTitle("Different")), desc, equivToTelescopeResult));
         
     }
 
@@ -65,15 +63,15 @@ public class TitleMatchingItemScorerTest extends TestCase {
     public void testSeqTitleTypes() {
 
         DefaultDescription desc = new DefaultDescription();
-        EquivToTelescopeResults equivToTelescopeResults = EquivToTelescopeResults.create(
+        EquivToTelescopeResult equivToTelescopeResult = EquivToTelescopeResult.create(
                 "id",
                 "publisher"
         );
         
-        score(2, scorer.score(itemWithTitle("Kinross"), of(itemWithTitle("2. Kinross")), desc, equivToTelescopeResults));
-        score(2, scorer.score(itemWithTitle("Kinross"), of(itemWithTitle("2: Kinross")), desc, equivToTelescopeResults));
-        score(2, scorer.score(itemWithTitle("Kinross"), of(itemWithTitle("2 - Kinross")), desc, equivToTelescopeResults));
-        score(0, scorer.score(itemWithTitle("Kinross"), of(itemWithTitle("2. Different")), desc, equivToTelescopeResults));
+        score(2, scorer.score(itemWithTitle("Kinross"), of(itemWithTitle("2. Kinross")), desc, equivToTelescopeResult));
+        score(2, scorer.score(itemWithTitle("Kinross"), of(itemWithTitle("2: Kinross")), desc, equivToTelescopeResult));
+        score(2, scorer.score(itemWithTitle("Kinross"), of(itemWithTitle("2 - Kinross")), desc, equivToTelescopeResult));
+        score(0, scorer.score(itemWithTitle("Kinross"), of(itemWithTitle("2. Different")), desc, equivToTelescopeResult));
         
     }
 
@@ -85,7 +83,7 @@ public class TitleMatchingItemScorerTest extends TestCase {
                 itemWithTitle("Gabriel Iglesias vs. Randy Couture"),
                 of(itemWithTitle("Gabriel Iglesias v Randy Couture")
 
-                        ), desc, EquivToTelescopeResults.create(
+                        ), desc, EquivToTelescopeResult.create(
                         "id",
                         "publisher"
                 )));
@@ -95,14 +93,14 @@ public class TitleMatchingItemScorerTest extends TestCase {
     public void testMatchingWithAmpersands() {
         
         DefaultDescription desc = new DefaultDescription();
-        EquivToTelescopeResults equivToTelescopeResults = EquivToTelescopeResults.create(
+        EquivToTelescopeResult equivToTelescopeResult = EquivToTelescopeResult.create(
                 "id",
                 "publisher"
         );
 
-        score(2, scorer.score(itemWithTitle("Rosencrantz & Guildenstern Are Dead"), of(itemWithTitle("Rosencrantz and Guildenstern Are Dead")), desc, equivToTelescopeResults));
-        score(2, scorer.score(itemWithTitle("Bill & Ben"), of(itemWithTitle("2. Bill and Ben")), desc, equivToTelescopeResults));
-        score(0, scorer.score(itemWithTitle("B&Q"), of(itemWithTitle("BandQ")), desc, equivToTelescopeResults));
+        score(2, scorer.score(itemWithTitle("Rosencrantz & Guildenstern Are Dead"), of(itemWithTitle("Rosencrantz and Guildenstern Are Dead")), desc, equivToTelescopeResult));
+        score(2, scorer.score(itemWithTitle("Bill & Ben"), of(itemWithTitle("2. Bill and Ben")), desc, equivToTelescopeResult));
+        score(0, scorer.score(itemWithTitle("B&Q"), of(itemWithTitle("BandQ")), desc, equivToTelescopeResult));
 
     }
 
@@ -115,14 +113,14 @@ public class TitleMatchingItemScorerTest extends TestCase {
                 itemWithTitle("Foo / Bar"),
                 of(itemWithTitle("Foo/Bar")),
                 desc,
-                EquivToTelescopeResults.create("id", "publisher"))
+                EquivToTelescopeResult.create("id", "publisher"))
         );
     }
     
     @Test
     public void testMatchingWithThePrefix() {
         DefaultDescription desc = new DefaultDescription();
-        EquivToTelescopeResults equivToTelescopeResults = EquivToTelescopeResults.create(
+        EquivToTelescopeResult equivToTelescopeResult = EquivToTelescopeResult.create(
                 "id",
                 "publisher"
         );
@@ -131,62 +129,62 @@ public class TitleMatchingItemScorerTest extends TestCase {
                 itemWithTitle("Funny People"),
                 of(itemWithTitle("Funny People (Unrated)")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("Unrated People"),
                 of(itemWithTitle("Unrated People")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("Sports"),
                 of(itemWithTitle("Live Sports")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("The Great Escape"),
                 of(itemWithTitle("Great Escape")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("the Great Escape"),
                 of(itemWithTitle("Great Escape")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(0, scorer.score(
                 itemWithTitle("Theatreland"),
                 of(itemWithTitle("The atreland")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(0, scorer.score(
                 itemWithTitle("theatreland"),
                 of(itemWithTitle("the atreland")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(0, scorer.score(
                 itemWithTitle("liveandnotlive live"),
                 of(itemWithTitle("live")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(0, scorer.score(
                 itemWithTitle("Funny People"),
                 of(itemWithTitle("Funny People Unrated")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
     }
     
     @Test
     public void testMatchingSports() {
         DefaultDescription desc = new DefaultDescription();
-        EquivToTelescopeResults equivToTelescopeResults = EquivToTelescopeResults.create(
+        EquivToTelescopeResult equivToTelescopeResult = EquivToTelescopeResult.create(
                 "id",
                 "publisher"
         );
@@ -197,25 +195,25 @@ public class TitleMatchingItemScorerTest extends TestCase {
                 itemWithTitle("Live Porto v Chelsea"),
                 of(itemWithTitle("FC Porto v Chelsea")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("Live Maccabi Tel-Aviv v D' Kiev"),
                 of(itemWithTitle("Maccabi Tel Aviv v Dynamo Kiev")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("Live Maccabi Tel-Aviv v D' Kiev"),
                 of(itemWithTitle("Maccabi Tel Aviv v D' Kiev")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("Live Maccabi Tel-Aviv v Dynamo Kiev"),
                 of(itemWithTitle("Maccabi Tel Aviv v D' Kiev")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
     }
 
@@ -224,7 +222,7 @@ public class TitleMatchingItemScorerTest extends TestCase {
         //This test case covers cases when non-abbrivating apostrophe is used in the end of the word
         // like "Girls' Night In" with "Girls' Night In"
         DefaultDescription desc = new DefaultDescription();
-        EquivToTelescopeResults equivToTelescopeResults = EquivToTelescopeResults.create(
+        EquivToTelescopeResult equivToTelescopeResult = EquivToTelescopeResult.create(
                 "id",
                 "publisher"
         );
@@ -233,32 +231,32 @@ public class TitleMatchingItemScorerTest extends TestCase {
                 itemWithTitle("Girls' Night In"),
                 of(itemWithTitle("Girls' Night In")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("Girls Night In"),
                 of(itemWithTitle("Girls' Night In")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("Girls' Night In"),
                 of(itemWithTitle("Girls Night In")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("Girls Night In"),
                 of(itemWithTitle("Girls Night In")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
     }
 
     @Test
     public void testMatchingWithPunctuation() {
         DefaultDescription desc = new DefaultDescription();
-        EquivToTelescopeResults equivToTelescopeResults = EquivToTelescopeResults.create(
+        EquivToTelescopeResult equivToTelescopeResult = EquivToTelescopeResult.create(
                 "id",
                 "publisher"
         );
@@ -267,44 +265,44 @@ public class TitleMatchingItemScorerTest extends TestCase {
                 itemWithTitle("48 hrs"),
                 of(itemWithTitle("48 HRS.")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("The 7:51"),
                 of(itemWithTitle("The 7.51")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("Mr. & Mrs. Smith"),
                 of(itemWithTitle("Mr & Mrs Smith")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("The way, way back"),
                 of(itemWithTitle("The way way back")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("The weekend"),
                 of(itemWithTitle("The week-end")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("'Allo 'Allo!"),
                 of(itemWithTitle("Allo Allo")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
     }
 
     @Test
     public void testMatchingTitlesWithYearsInTitles() {
         DefaultDescription desc = new DefaultDescription();
-        EquivToTelescopeResults equivToTelescopeResults = EquivToTelescopeResults.create(
+        EquivToTelescopeResult equivToTelescopeResult = EquivToTelescopeResult.create(
                 "id",
                 "publisher"
         );
@@ -313,19 +311,19 @@ public class TitleMatchingItemScorerTest extends TestCase {
                 itemWithTitle("Cold Comes the Night (2013)"),
                 of(itemWithTitle("Cold Comes the Night")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("Get Carter (2013)"),
                 of(itemWithTitle("Get Carter")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(0, scorer.score(
                 itemWithTitle("Space Odessey 2013"),
                 of(itemWithTitle("Space Odessey")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
     }
 
@@ -336,7 +334,7 @@ public class TitleMatchingItemScorerTest extends TestCase {
         //This test case covers cases when non-abbrivating apostrophe is used within a word
         // like Charlies Big Catch" with "Charlie's Big Catch"
 
-        EquivToTelescopeResults equivToTelescopeResults = EquivToTelescopeResults.create(
+        EquivToTelescopeResult equivToTelescopeResult = EquivToTelescopeResult.create(
                 "id",
                 "publisher"
         );
@@ -345,56 +343,56 @@ public class TitleMatchingItemScorerTest extends TestCase {
                 itemWithTitle("Charlies Big Catch"),
                 of(itemWithTitle("Charlie's Big Catch")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("Charlie's Big Catch"),
                 of(itemWithTitle("Charlie's Big Catch")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("Charlie's Big Catch"),
                 of(itemWithTitle("Charlies Big Catch")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("Charlies Big Catch"),
                 of(itemWithTitle("Charlies Big Catch")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("C'harlies Big Catch"),
                 of(itemWithTitle("Charlies Big Catch")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("Charlies Big Catch"),
                 of(itemWithTitle("C'harlies Big Catch")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("C'harlies Big Catch"),
                 of(itemWithTitle("C'harlies Big Catch")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(0, scorer.score(
                 itemWithTitle("C'harlie Big Catch"),
                 of(itemWithTitle("C'harlies Big Catch")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
     }
 
     @Test
     public void testMatchingWithDifferentSpacing() {
         DefaultDescription desc = new DefaultDescription();
-        EquivToTelescopeResults equivToTelescopeResults = EquivToTelescopeResults.create(
+        EquivToTelescopeResult equivToTelescopeResult = EquivToTelescopeResult.create(
                 "id",
                 "publisher"
         );
@@ -403,19 +401,19 @@ public class TitleMatchingItemScorerTest extends TestCase {
                 itemWithTitle("HouseBusters"),
                 of(itemWithTitle("House Busters")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("House  Busters  "),
                 of(itemWithTitle("  House Busters")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("Iron Man 3"),
                 of(itemWithTitle("IronMan 3")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
     }
     
@@ -423,7 +421,7 @@ public class TitleMatchingItemScorerTest extends TestCase {
     public void testMachingWithDifferentNumberingSystem(){
         //do not change romans anywhere but the end of a sentence
         DefaultDescription desc = new DefaultDescription();
-        EquivToTelescopeResults equivToTelescopeResults = EquivToTelescopeResults.create(
+        EquivToTelescopeResult equivToTelescopeResult = EquivToTelescopeResult.create(
                 "id",
                 "publisher"
         );
@@ -432,25 +430,25 @@ public class TitleMatchingItemScorerTest extends TestCase {
                 itemWithTitle("Iron Man 3"),
                 of(itemWithTitle("Iron Man III")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("The world and I"),
                 of(itemWithTitle("The world and one")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         )); //sideeffect
         score(0, scorer.score(
                 itemWithTitle("V for vendetta"),
                 of(itemWithTitle("Five for Vendetta")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(0, scorer.score(
                 itemWithTitle("Three v Five"),
                 of(itemWithTitle("Three Five Five")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
     }
     
@@ -462,14 +460,14 @@ public class TitleMatchingItemScorerTest extends TestCase {
                 itemWithTitle("British Harbor"),
                 of(itemWithTitle("British Harbour")),
                 desc,
-                EquivToTelescopeResults.create("id", "publisher"))
+                EquivToTelescopeResult.create("id", "publisher"))
         );
     }
 
     @Test
     public void testMatchingWithDifferentAccents() {
         DefaultDescription desc = new DefaultDescription();
-        EquivToTelescopeResults equivToTelescopeResults = EquivToTelescopeResults.create(
+        EquivToTelescopeResult equivToTelescopeResult = EquivToTelescopeResult.create(
                 "id",
                 "publisher"
         );
@@ -478,26 +476,26 @@ public class TitleMatchingItemScorerTest extends TestCase {
                 itemWithTitle("En Equilibre"),
                 of(itemWithTitle("En équilibre")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("Vie héroïque"),
                 of(itemWithTitle("Vie heroique")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("François Cluzet"),
                 of(itemWithTitle("Francois Cluzet")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
     }
 
     @Test
     public void testPartialMatchAfterSemicolon() {
         DefaultDescription desc = new DefaultDescription();
-        EquivToTelescopeResults equivToTelescopeResults = EquivToTelescopeResults.create(
+        EquivToTelescopeResult equivToTelescopeResult = EquivToTelescopeResult.create(
                 "id",
                 "publisher"
         );
@@ -506,32 +504,32 @@ public class TitleMatchingItemScorerTest extends TestCase {
                 itemWithTitle("Storage Hunters"),
                 of(itemWithTitle("Storage Hunters: UK")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(1, scorer.score(
                 itemWithTitle("Storage Hunters: UK"),
                 of(itemWithTitle("Storage Hunters")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(1, scorer.score(
                 itemWithTitle("CSI: NY"),
                 of(itemWithTitle("CSI: New York")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(1, scorer.score(
                 itemWithTitle("CSI: NY"),
                 of(itemWithTitle("CSI")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
     }
 
     @Test
     public void testForOutOfBoundsException() {
         DefaultDescription desc = new DefaultDescription();
-        EquivToTelescopeResults equivToTelescopeResults = EquivToTelescopeResults.create(
+        EquivToTelescopeResult equivToTelescopeResult = EquivToTelescopeResult.create(
                 "id",
                 "publisher"
         );
@@ -540,20 +538,20 @@ public class TitleMatchingItemScorerTest extends TestCase {
                 itemWithTitle("Storage Hunters"),
                 of(itemWithTitle(":Storage Hunters: UK")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("Storage Hunters"),
                 of(itemWithTitle(":Storage Hunters:")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
     }
 
     @Test
     public void testForMultipleColonsToStart() {
         DefaultDescription desc = new DefaultDescription();
-        EquivToTelescopeResults equivToTelescopeResults = EquivToTelescopeResults.create(
+        EquivToTelescopeResult equivToTelescopeResult = EquivToTelescopeResult.create(
                 "id",
                 "publisher"
         );
@@ -562,20 +560,20 @@ public class TitleMatchingItemScorerTest extends TestCase {
                 itemWithTitle("Storage Hunters"),
                 of(itemWithTitle("::::Storage Hunters: UK")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("Storage Hunters"),
                 of(itemWithTitle("::::Storage Hunters")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
     }
 
     @Test
     public void testForPrefixRemovalBug() {
         DefaultDescription desc = new DefaultDescription();
-        EquivToTelescopeResults equivToTelescopeResults = EquivToTelescopeResults.create(
+        EquivToTelescopeResult equivToTelescopeResult = EquivToTelescopeResult.create(
                 "id",
                 "publisher"
         );
@@ -584,13 +582,13 @@ public class TitleMatchingItemScorerTest extends TestCase {
                 itemWithTitle("Storage: Bunters"),
                 of(itemWithTitle(" 5 : Storage Hunters")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
         score(2, scorer.score(
                 itemWithTitle("Storage: Hunters"),
                 of(itemWithTitle(" 5 : Storage Hunters")),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         ));
     }
     

--- a/src/test/java/org/atlasapi/equiv/scorers/TitleSubsetBroadcastItemScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/scorers/TitleSubsetBroadcastItemScorerTest.java
@@ -1,23 +1,21 @@
 package org.atlasapi.equiv.scorers;
 
-import static org.junit.Assert.assertEquals;
-
+import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
-import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
+import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.entity.Broadcast;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.media.entity.Version;
 import org.atlasapi.persistence.testing.StubContentResolver;
-
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableSet;
+import static org.junit.Assert.assertEquals;
 
 public class TitleSubsetBroadcastItemScorerTest {
 
@@ -122,14 +120,14 @@ public class TitleSubsetBroadcastItemScorerTest {
 
     private Score score(Item subject, Item candidate) {
         DefaultDescription desc = new DefaultDescription();
-        EquivToTelescopeResults equivToTelescopeResults =
-                EquivToTelescopeResults.create("id", "publisher");
+        EquivToTelescopeResult equivToTelescopeResult =
+                EquivToTelescopeResult.create("id", "publisher");
 
         ScoredCandidates<Item> scores = scorer.score(
                 subject,
                 ImmutableSet.of(candidate),
                 desc,
-                equivToTelescopeResults
+                equivToTelescopeResult
         );
         return scores.candidates().get(candidate);
     }

--- a/src/test/java/org/atlasapi/equiv/update/metadata/EquivToTelescopeResultTest.java
+++ b/src/test/java/org/atlasapi/equiv/update/metadata/EquivToTelescopeResultTest.java
@@ -1,19 +1,17 @@
 package org.atlasapi.equiv.update.metadata;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonElement;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class EquivToTelescopeResultsTest {
+public class EquivToTelescopeResultTest {
 
-    private EquivToTelescopeResults equivToTelescopeResults;
+    private EquivToTelescopeResult equivToTelescopeResult;
 
     @Before
     public void setUp() {
-        equivToTelescopeResults = EquivToTelescopeResults.create("id", "publisher");
+        equivToTelescopeResult = EquivToTelescopeResult.create("id", "publisher");
     }
 
     @Test
@@ -21,23 +19,23 @@ public class EquivToTelescopeResultsTest {
         EquivToTelescopeComponent generator = EquivToTelescopeComponent.create();
         generator.addComponentResult("id", "5.0");
         generator.addComponentResult(23848, "0.0");
-        equivToTelescopeResults.addGeneratorResult(generator);
+        equivToTelescopeResult.addGeneratorResult(generator);
 
         EquivToTelescopeComponent scorer1 = EquivToTelescopeComponent.create();
         scorer1.addComponentResult("scorer1id", "2");
         scorer1.addComponentResult(28238, "3");
         scorer1.addComponentResult("scorer1id2", "22");
         scorer1.addComponentResult(282382, "32");
-        equivToTelescopeResults.addScorerResult(scorer1);
+        equivToTelescopeResult.addScorerResult(scorer1);
 
         EquivToTelescopeComponent scorer2 = EquivToTelescopeComponent.create();
         scorer2.addComponentResult("scorer2id", "4");
         scorer2.addComponentResult(23232, "4");
-        equivToTelescopeResults.addScorerResult(scorer2);
+        equivToTelescopeResult.addScorerResult(scorer2);
 
 
-        assertEquals(equivToTelescopeResults.getGenerators().get(0), generator);
-        assertEquals(equivToTelescopeResults.getScorers().size(), 2);
+        assertEquals(equivToTelescopeResult.getGenerators().get(0), generator);
+        assertEquals(equivToTelescopeResult.getScorers().size(), 2);
     }
 
 }


### PR DESCRIPTION
The motivation for this change is because we might want source A to equiv to source B with one set
of logic, but to equiv to source C with another. This can be managed somewhat with specific generators, scorers, extractors etc which filter out certain publishers but it isn't ideal.

This change allows a given publisher to have multiple equiv update providers which can take a different list of target publishers to equiv to.

Since the handler and messenger steps should only happen once per equiv run these have been moved out of the update provider classes. These now also need to handle multiple equivalence result objects and so the handler code has been modified to be consistent with existing behaviour.

Telescope equiv reporting has also been changed to accommodate multiple equiv updaters each with their own generators etc.

Some QoL changes are included to improve the equivalence results html to aid debugging.