### PR TITLE
Sky bcid equiv

### DIFF
--- a/src/main/java/org/atlasapi/equiv/generators/BarbAliasEquivalenceGeneratorAndScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/BarbAliasEquivalenceGeneratorAndScorer.java
@@ -65,6 +65,7 @@ public class BarbAliasEquivalenceGeneratorAndScorer<T extends Content> implement
     private static final String STV_OOBG_PREFIX = "gb:barb:originatingOwner:broadcastGroup:111";
     private static final String SKY_BG_PREFIX = "gb:barb:broadcastGroup:5";
     private static final String SKY_OOBG_PREFIX = "gb:barb:originatingOwner:broadcastGroup:5";
+    private static final String SKY_PARENT_BCID_SUFFIX = "5:parentVersionBcid";
     private static final String BARB_CONTENT_ID_NAMESPACE = "gb:barb:contentid";
     
     private static final Set<String> C4_NAMESPACES = ImmutableSet.of(
@@ -284,10 +285,10 @@ public class BarbAliasEquivalenceGeneratorAndScorer<T extends Content> implement
 
         // sky has bad data so ignore the parents in favour of the originating broadcaster if exists and isnt sky
         if (aliases.stream().anyMatch(alias -> alias.getNamespace().startsWith(SKY_BG_PREFIX)) &&
-                expandedAliases.stream()
+                aliases.stream()
                         .map(Alias::getNamespace)
                         .anyMatch(ns -> ns.startsWith(OOBG_PREFIX) && !ns.startsWith(SKY_OOBG_PREFIX))) {
-            expandedAliases.removeIf(alias -> alias.getNamespace().endsWith(PARENT_VERSION_BCID_NAMESPACE_SUFFIX));
+            expandedAliases.removeIf(alias -> alias.getNamespace().endsWith(SKY_PARENT_BCID_SUFFIX));
         }
         
         return expandedAliases;

--- a/src/main/java/org/atlasapi/equiv/generators/BarbAliasEquivalenceGeneratorAndScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/BarbAliasEquivalenceGeneratorAndScorer.java
@@ -66,6 +66,7 @@ public class BarbAliasEquivalenceGeneratorAndScorer<T extends Content> implement
     private static final String STV_BG_PREFIX = "gb:barb:broadcastGroup:111";
     private static final String STV_OOBG_PREFIX = "gb:barb:originatingOwner:broadcastGroup:111";
     private static final String SKY_BG_PREFIX = "gb:barb:broadcastGroup:5";
+    private static final String SKY_OOBG_PREFIX = "gb:barb:originatingOwner:broadcastGroup:5";
     private static final String SKY_OOBCID_NAMESPACE = "gb:barb:originatingOwner:broadcastGroup:5:bcid";
     private static final String SKY_BCID_NAMESPACE = "gb:barb:broadcastGroup:5:bcid";
     private static final String SKY_PARENT_BCID_NAMESPACE = "gb:barb:broadcastGroup:5:parentVersionBcid";
@@ -279,7 +280,7 @@ public class BarbAliasEquivalenceGeneratorAndScorer<T extends Content> implement
         for(Alias alias : subject.getAliases()) {
             if(alias.getNamespace().startsWith(SKY_BG_PREFIX)) {
                 isSky = true;
-            } else if(alias.getNamespace().startsWith(OOBG_PREFIX) && !alias.getNamespace().equals(SKY_OOBCID_NAMESPACE)) {
+            } else if(alias.getNamespace().startsWith(OOBG_PREFIX) && !alias.getNamespace().startsWith(SKY_OOBG_PREFIX)) {
                 isNonSkyOobgid = true;
             }
             if(isSky && isNonSkyOobgid) {

--- a/src/main/java/org/atlasapi/equiv/generators/BarbAliasEquivalenceGeneratorAndScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/BarbAliasEquivalenceGeneratorAndScorer.java
@@ -23,11 +23,9 @@ import org.atlasapi.persistence.lookup.mongo.MongoLookupEntryStore;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 import static com.google.gdata.util.common.base.Preconditions.checkArgument;
+import static java.lang.String.format;
 
 /**
  * Query for each alias. For each alias get a list of candidates, and score them as well (?).
@@ -66,6 +64,8 @@ public class BarbAliasEquivalenceGeneratorAndScorer<T extends Content> implement
     private static final String ITV_OOBG_PREFIX = "gb:barb:originatingOwner:broadcastGroup:2";
     private static final String STV_BG_PREFIX = "gb:barb:broadcastGroup:111";
     private static final String STV_OOBG_PREFIX = "gb:barb:originatingOwner:broadcastGroup:111";
+    private static final String SKY_BG_PREFIX = "gb:barb:broadcastGroup:5";
+    private static final String SKY_OOBG_PREFIX = "gb:barb:originatingOwner:broadcastGroup:5";
     private static final String BARB_CONTENT_ID_NAMESPACE = "gb:barb:contentid";
     
     private static final Set<String> C4_NAMESPACES = ImmutableSet.of(
@@ -281,6 +281,14 @@ public class BarbAliasEquivalenceGeneratorAndScorer<T extends Content> implement
             }
             
             addPrefixedC4Aliases(expandedAliases, alias.getNamespace(), value);
+        }
+
+        // sky has bad data so ignore the parents in favour of the originating broadcaster if exists and isnt sky
+        if (expandedAliases.stream().anyMatch(alias -> alias.getNamespace().startsWith(SKY_BG_PREFIX)) &&
+                expandedAliases.stream()
+                        .map(Alias::getNamespace)
+                        .anyMatch(ns -> ns.startsWith(OOBG_PREFIX) && !ns.startsWith(SKY_OOBG_PREFIX))) {
+            expandedAliases.removeIf(alias -> alias.getNamespace().endsWith(PARENT_VERSION_BCID_NAMESPACE_SUFFIX));
         }
         
         return expandedAliases;

--- a/src/main/java/org/atlasapi/equiv/generators/BarbAliasEquivalenceGeneratorAndScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/BarbAliasEquivalenceGeneratorAndScorer.java
@@ -283,7 +283,7 @@ public class BarbAliasEquivalenceGeneratorAndScorer<T extends Content> implement
         }
 
         // sky has bad data so ignore the parents in favour of the originating broadcaster if exists and isnt sky
-        if (expandedAliases.stream().anyMatch(alias -> alias.getNamespace().startsWith(SKY_BG_PREFIX)) &&
+        if (aliases.stream().anyMatch(alias -> alias.getNamespace().startsWith(SKY_BG_PREFIX)) &&
                 expandedAliases.stream()
                         .map(Alias::getNamespace)
                         .anyMatch(ns -> ns.startsWith(OOBG_PREFIX) && !ns.startsWith(SKY_OOBG_PREFIX))) {

--- a/src/main/java/org/atlasapi/equiv/generators/BarbAliasEquivalenceGeneratorAndScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/BarbAliasEquivalenceGeneratorAndScorer.java
@@ -25,7 +25,6 @@ import java.util.Objects;
 import java.util.Set;
 
 import static com.google.gdata.util.common.base.Preconditions.checkArgument;
-import static java.lang.String.format;
 
 /**
  * Query for each alias. For each alias get a list of candidates, and score them as well (?).

--- a/src/main/java/org/atlasapi/equiv/generators/BarbAliasEquivalenceGeneratorAndScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/BarbAliasEquivalenceGeneratorAndScorer.java
@@ -65,7 +65,7 @@ public class BarbAliasEquivalenceGeneratorAndScorer<T extends Content> implement
     private static final String STV_OOBG_PREFIX = "gb:barb:originatingOwner:broadcastGroup:111";
     private static final String SKY_BG_PREFIX = "gb:barb:broadcastGroup:5";
     private static final String SKY_OOBG_PREFIX = "gb:barb:originatingOwner:broadcastGroup:5";
-    private static final String SKY_PARENT_BCID_SUFFIX = "5:parentVersionBcid";
+    private static final String SKY_PARENT_BCID_NAMESPACE = "gb:barb:broadcastGroup:5:parentVersionBcid";
     private static final String BARB_CONTENT_ID_NAMESPACE = "gb:barb:contentid";
     
     private static final Set<String> C4_NAMESPACES = ImmutableSet.of(
@@ -288,7 +288,7 @@ public class BarbAliasEquivalenceGeneratorAndScorer<T extends Content> implement
                 aliases.stream()
                         .map(Alias::getNamespace)
                         .anyMatch(ns -> ns.startsWith(OOBG_PREFIX) && !ns.startsWith(SKY_OOBG_PREFIX))) {
-            expandedAliases.removeIf(alias -> alias.getNamespace().endsWith(SKY_PARENT_BCID_SUFFIX));
+            expandedAliases.removeIf(alias -> alias.getNamespace().equals(SKY_PARENT_BCID_NAMESPACE));
         }
         
         return expandedAliases;

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BarbItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BarbItemUpdaterProvider.java
@@ -58,6 +58,7 @@ public class BarbItemUpdaterProvider implements EquivalenceResultUpdaterProvider
                                         dependencies.getContentResolver(),
                                         targetPublishers,
                                         Score.valueOf(10.0),
+                                        Score.ZERO,
                                         false
                                 ),
                                 new BroadcastMatchingItemEquivalenceGeneratorAndScorer(

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BarbXItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BarbXItemUpdaterProvider.java
@@ -50,6 +50,7 @@ public class BarbXItemUpdaterProvider implements EquivalenceResultUpdaterProvide
                                         dependencies.getContentResolver(),
                                         targetPublishers,
                                         Score.valueOf(10.0),
+                                        Score.ZERO,
                                         false
                                 )
                         )

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/TxlogsItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/TxlogsItemUpdaterProvider.java
@@ -54,6 +54,7 @@ public class TxlogsItemUpdaterProvider implements EquivalenceResultUpdaterProvid
                                         dependencies.getContentResolver(),
                                         targetPublishers,
                                         Score.valueOf(10.0),
+                                        Score.ZERO,
                                         false
                                 ),
                                 new BroadcastMatchingItemEquivalenceGeneratorAndScorer(

--- a/src/test/java/org/atlasapi/equiv/generators/BarbAliasEquivalenceGeneratorAndScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/generators/BarbAliasEquivalenceGeneratorAndScorerTest.java
@@ -725,25 +725,54 @@ public class BarbAliasEquivalenceGeneratorAndScorerTest {
         String bcid = "1234";
         Alias oobgidBcid = new Alias(format(OOBG_BCID_NAMESPACE_FORMAT, 5), bcid);
 
-        Item c4Item = bgItemForBgid(1, bcid);
-        c4Item.addAlias(oobgidBcid);
+        Item bbcItem = bgItemForBgid(1, bcid);
+        bbcItem.addAlias(oobgidBcid);
 
         Item oobgItem = oobgItemForBgid(5, bcid);
         Item parentBcidItem = parentBcidItemForBgid(1, bcid);
         Item cmsItem = cmsItemForBgid(1, bcid);
 
-        setUpContentResolving(ImmutableSet.of(c4Item, oobgItem, parentBcidItem, cmsItem));
+        setUpContentResolving(ImmutableSet.of(bbcItem, oobgItem, parentBcidItem, cmsItem));
         ScoredCandidates<Content> scoredCandidates;
         scoredCandidates = aliasGenerator.generate(
-                c4Item,
+                bbcItem,
                 desc,
                 EquivToTelescopeResult.create("id", "publisher")
         );
 
-        assertTrue(!scoredCandidates.candidates().containsKey(c4Item));
+        assertTrue(!scoredCandidates.candidates().containsKey(bbcItem));
         assertTrue(scoredCandidates.candidates().get(parentBcidItem) == SCORE_ON_MATCH);
         assertTrue(scoredCandidates.candidates().get(oobgItem) == SCORE_ON_MATCH);
         assertTrue(scoredCandidates.candidates().get(cmsItem) == SCORE_ON_MATCH);
+    }
+
+    @Test
+    public void skyItemWithNonSkyOobgidMatchesNonSkyParent() throws Exception {
+        String bcidOne = "1234";
+        String bcidTwo = "6789";
+        String bcidThree = "9999";
+        String bcidFour = "1111";
+        
+        Item skyItem = bgItemForBgid(5, bcidOne);
+        Alias oobgidBcid = new Alias(format(OOBG_BCID_NAMESPACE_FORMAT, 1), bcidTwo);
+        Alias parentBgid = new Alias(format(BG_PARENT_VERSION_BCID_NAMESPACE_FORMAT, 5), bcidThree);
+        skyItem.addAlias(oobgidBcid);
+        skyItem.addAlias(parentBgid);
+
+        Item parentBcidItem = parentBcidItemForBgid(1, bcidTwo);
+        Alias bbcBgid = new Alias(format(BG_BCID_NAMESPACE_FORMAT, 1), bcidFour);
+        parentBcidItem.addAlias(bbcBgid);
+
+        setUpContentResolving(ImmutableSet.of(skyItem, parentBcidItem));
+        ScoredCandidates<Content> scoredCandidates;
+        scoredCandidates = aliasGenerator.generate(
+                skyItem,
+                desc,
+                EquivToTelescopeResult.create("id", "publisher")
+        );
+
+        assertTrue(!scoredCandidates.candidates().containsKey(skyItem));
+        assertTrue(scoredCandidates.candidates().get(parentBcidItem) == SCORE_ON_MATCH);
     }
 
 }

--- a/src/test/java/org/atlasapi/equiv/generators/BarbAliasEquivalenceGeneratorAndScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/generators/BarbAliasEquivalenceGeneratorAndScorerTest.java
@@ -1010,4 +1010,92 @@ public class BarbAliasEquivalenceGeneratorAndScorerTest {
         assertThat(scoredCandidates.candidates().get(item2), is(SCORE_ON_MISMATCH));
     }
 
+    @Test
+    public void testSkyOobcidOnlyMatchesSkyWithNonSkyOobgidParentVersionBcid() {
+        Item item1 = item(
+                "1",
+                "Correct Title",
+                1, "A", null,
+                5, "X"
+        );
+        Item item2 = item(
+                "2",
+                "Wrong Title",
+                5, "B", "X",
+                2, "Y"
+        );
+        Item item3 = item(
+                "3",
+                "Correct Title",
+                5, "C", "X",
+                null, null
+        );
+        Item item4 = item(
+                "4",
+                "Correct Title",
+                5, "X", null,
+                null, null
+        );
+        setUpContentResolving(ImmutableSet.of(item1, item2, item3, item4));
+        //item1 and item3 should not equiv unless we factor in titles
+
+        ScoredCandidates<Content> scoredCandidates;
+        scoredCandidates = aliasGenerator.generate(
+                item1,
+                desc,
+                EquivToTelescopeResult.create("id", "publisher")
+        );
+
+        assertThat(scoredCandidates.candidates().containsKey(item1), is(false));
+        assertThat(scoredCandidates.candidates().containsKey(item2), is(true));
+        assertThat(scoredCandidates.candidates().containsKey(item3), is(true));
+        assertThat(scoredCandidates.candidates().containsKey(item4), is(true));
+        assertThat(scoredCandidates.candidates().get(item2), is(SCORE_ON_MISMATCH));
+        assertThat(scoredCandidates.candidates().get(item3), is(SCORE_ON_MATCH));
+        assertThat(scoredCandidates.candidates().get(item4), is(SCORE_ON_MATCH));
+
+        scoredCandidates = aliasGenerator.generate(
+                item2,
+                desc,
+                EquivToTelescopeResult.create("id", "publisher")
+        );
+
+        assertThat(scoredCandidates.candidates().containsKey(item1), is(true));
+        assertThat(scoredCandidates.candidates().containsKey(item2), is(false));
+        assertThat(scoredCandidates.candidates().containsKey(item3), is(true));
+        assertThat(scoredCandidates.candidates().containsKey(item4), is(true));
+        assertThat(scoredCandidates.candidates().get(item1), is(SCORE_ON_MISMATCH));
+        assertThat(scoredCandidates.candidates().get(item3), is(SCORE_ON_MISMATCH));
+        assertThat(scoredCandidates.candidates().get(item4), is(SCORE_ON_MISMATCH));
+
+
+        scoredCandidates = aliasGenerator.generate(
+                item3,
+                desc,
+                EquivToTelescopeResult.create("id", "publisher")
+        );
+
+        assertThat(scoredCandidates.candidates().containsKey(item1), is(true));
+        assertThat(scoredCandidates.candidates().containsKey(item2), is(true));
+        assertThat(scoredCandidates.candidates().containsKey(item3), is(false));
+        assertThat(scoredCandidates.candidates().containsKey(item4), is(true));
+        assertThat(scoredCandidates.candidates().get(item1), is(SCORE_ON_MATCH));
+        assertThat(scoredCandidates.candidates().get(item2), is(SCORE_ON_MISMATCH));
+        assertThat(scoredCandidates.candidates().get(item4), is(SCORE_ON_MATCH));
+
+        scoredCandidates = aliasGenerator.generate(
+                item4,
+                desc,
+                EquivToTelescopeResult.create("id", "publisher")
+        );
+
+        assertThat(scoredCandidates.candidates().containsKey(item1), is(true));
+        assertThat(scoredCandidates.candidates().containsKey(item2), is(true));
+        assertThat(scoredCandidates.candidates().containsKey(item3), is(true));
+        assertThat(scoredCandidates.candidates().containsKey(item4), is(false));
+        assertThat(scoredCandidates.candidates().get(item1), is(SCORE_ON_MATCH));
+        assertThat(scoredCandidates.candidates().get(item2), is(SCORE_ON_MISMATCH));
+        assertThat(scoredCandidates.candidates().get(item3), is(SCORE_ON_MATCH));
+    }
+
 }

--- a/src/test/java/org/atlasapi/equiv/generators/BarbAliasEquivalenceGeneratorAndScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/generators/BarbAliasEquivalenceGeneratorAndScorerTest.java
@@ -234,7 +234,6 @@ public class BarbAliasEquivalenceGeneratorAndScorerTest {
                 aliasContentMultimap.put(alias, content);
             }
         }
-        ImmutableList.copyOf(aliasContentMultimap.get(null));
         for (Alias alias : aliasContentMultimap.keySet()) {
             when(aliasLookupEntryStore.entriesForAliases(
                     Optional.of(alias.getNamespace()),

--- a/src/test/java/org/atlasapi/equiv/generators/BarbAliasEquivalenceGeneratorAndScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/generators/BarbAliasEquivalenceGeneratorAndScorerTest.java
@@ -718,7 +718,6 @@ public class BarbAliasEquivalenceGeneratorAndScorerTest {
         assertTrue(!scoredCandidates.candidates().containsKey(parentBcidItem));
         assertTrue(scoredCandidates.candidates().get(oobgItem) == SCORE_ON_MATCH);
         assertTrue(scoredCandidates.candidates().get(cmsItem) == SCORE_ON_MATCH);
-        
     }
 
 }

--- a/src/test/java/org/atlasapi/equiv/generators/BarbAliasEquivalenceGeneratorAndScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/generators/BarbAliasEquivalenceGeneratorAndScorerTest.java
@@ -720,4 +720,30 @@ public class BarbAliasEquivalenceGeneratorAndScorerTest {
         assertTrue(scoredCandidates.candidates().get(cmsItem) == SCORE_ON_MATCH);
     }
 
+    @Test
+    public void doesNotIgnoreParentsIfContentIsNotSky() throws Exception {
+        String bcid = "1234";
+        Alias oobgidBcid = new Alias(format(OOBG_BCID_NAMESPACE_FORMAT, 5), bcid);
+
+        Item c4Item = bgItemForBgid(1, bcid);
+        c4Item.addAlias(oobgidBcid);
+
+        Item oobgItem = oobgItemForBgid(5, bcid);
+        Item parentBcidItem = parentBcidItemForBgid(1, bcid);
+        Item cmsItem = cmsItemForBgid(1, bcid);
+
+        setUpContentResolving(ImmutableSet.of(c4Item, oobgItem, parentBcidItem, cmsItem));
+        ScoredCandidates<Content> scoredCandidates;
+        scoredCandidates = aliasGenerator.generate(
+                c4Item,
+                desc,
+                EquivToTelescopeResult.create("id", "publisher")
+        );
+
+        assertTrue(!scoredCandidates.candidates().containsKey(c4Item));
+        assertTrue(scoredCandidates.candidates().get(parentBcidItem) == SCORE_ON_MATCH);
+        assertTrue(scoredCandidates.candidates().get(oobgItem) == SCORE_ON_MATCH);
+        assertTrue(scoredCandidates.candidates().get(cmsItem) == SCORE_ON_MATCH);
+    }
+
 }


### PR DESCRIPTION
Sky has bad data so if an originating owner broadcaster exists and isnt sky, don't use the parent bcid aliases to generate equiv candidates.

https://metabroadcast.atlassian.net/browse/ENG-267