### PR TITLE
trim broadcasts in owl-api on amendments

### DIFF
--- a/src/main/java/org/atlasapi/query/QueryExecutorModule.java
+++ b/src/main/java/org/atlasapi/query/QueryExecutorModule.java
@@ -158,7 +158,6 @@ public class QueryExecutorModule {
 
     private BroadcastTrimmer broadcastTrimmer() {
         return new ScheduleResolverBroadcastTrimmer(
-                null,
                 scheduleResolver,
                 contentResolver,
                 contentWriter

--- a/src/main/java/org/atlasapi/query/QueryExecutorModule.java
+++ b/src/main/java/org/atlasapi/query/QueryExecutorModule.java
@@ -1,16 +1,11 @@
 package org.atlasapi.query;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.util.concurrent.Service;
-import com.google.common.util.concurrent.ServiceManager;
-import com.metabroadcast.common.ids.NumberToShortStringCodec;
-import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
-import com.metabroadcast.common.persistence.mongo.DatabasedMongo;
-import com.metabroadcast.common.queue.MessageConsumerFactory;
-import com.metabroadcast.common.queue.MessageSender;
-import com.metabroadcast.common.queue.MessageSenderFactory;
-import com.metabroadcast.common.queue.kafka.KafkaConsumer;
-import com.metabroadcast.common.time.SystemClock;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
 import org.atlasapi.input.BrandModelTransformer;
 import org.atlasapi.input.ClipModelTransformer;
 import org.atlasapi.input.DefaultJacksonModelReader;
@@ -19,7 +14,6 @@ import org.atlasapi.input.ItemModelTransformer;
 import org.atlasapi.input.SegmentModelTransformer;
 import org.atlasapi.input.SeriesModelTransformer;
 import org.atlasapi.media.channel.ChannelResolver;
-import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.media.segment.SegmentWriter;
 import org.atlasapi.messaging.v3.KafkaMessagingModule;
 import org.atlasapi.persistence.content.ContentResolver;
@@ -42,17 +36,24 @@ import org.atlasapi.query.worker.ContentWriteWorker;
 import org.atlasapi.remotesite.channel4.pmlsd.epg.BroadcastTrimmer;
 import org.atlasapi.remotesite.channel4.pmlsd.epg.ScheduleResolverBroadcastTrimmer;
 
+import com.metabroadcast.common.ids.NumberToShortStringCodec;
+import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
+import com.metabroadcast.common.persistence.mongo.DatabasedMongo;
+import com.metabroadcast.common.queue.MessageConsumerFactory;
+import com.metabroadcast.common.queue.MessageSender;
+import com.metabroadcast.common.queue.MessageSenderFactory;
+import com.metabroadcast.common.queue.kafka.KafkaConsumer;
+import com.metabroadcast.common.time.SystemClock;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Service;
+import com.google.common.util.concurrent.ServiceManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static org.atlasapi.persistence.MongoContentPersistenceModule.NON_ID_SETTING_CONTENT_WRITER;
 
@@ -155,10 +156,9 @@ public class QueryExecutorModule {
         );
     }
 
-    @Bean
-    BroadcastTrimmer broadcastTrimmer() {
+    private BroadcastTrimmer broadcastTrimmer() {
         return new ScheduleResolverBroadcastTrimmer(
-                Publisher.BT_SPORT_EBS,
+                null,
                 scheduleResolver,
                 contentResolver,
                 contentWriter

--- a/src/main/java/org/atlasapi/query/content/ContentWriteExecutor.java
+++ b/src/main/java/org/atlasapi/query/content/ContentWriteExecutor.java
@@ -1,10 +1,13 @@
 package org.atlasapi.query.content;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.metabroadcast.common.base.Maybe;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.List;
+import java.util.Set;
+
 import org.atlasapi.input.ModelReader;
 import org.atlasapi.input.ModelTransformer;
 import org.atlasapi.input.ReadException;
@@ -32,17 +35,15 @@ import org.atlasapi.query.content.merge.ContentMerger;
 import org.atlasapi.query.content.merge.VersionMerger;
 import org.atlasapi.remotesite.channel4.pmlsd.epg.BroadcastTrimmer;
 
+import com.metabroadcast.common.base.Maybe;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import org.joda.time.Interval;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.util.List;
-import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/src/main/java/org/atlasapi/query/content/ContentWriteExecutor.java
+++ b/src/main/java/org/atlasapi/query/content/ContentWriteExecutor.java
@@ -41,7 +41,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -159,12 +158,7 @@ public class ContentWriteExecutor {
         if (updatedContent instanceof Item) {
             Item item = (Item) updatedContent;
             writer.createOrUpdate(item);
-
-            if (content.getPublisher().key().equals(Publisher.BT_SPORT_EBS.key())) {
-                updateEbsSchedule(content, item);
-            } else {
-                updateSchedule(item);
-            }
+            updateSchedule(content, item);
         } else {
             writer.createOrUpdate((Container) updatedContent);
         }
@@ -175,7 +169,7 @@ public class ContentWriteExecutor {
         }
     }
 
-    private void updateEbsSchedule(Content content, Item item) {
+    private void updateSchedule(Content content, Item item) {
         for (Broadcast broadcast : content.getVersions()
                 .iterator()
                 .next()
@@ -190,10 +184,10 @@ public class ContentWriteExecutor {
 
             ImmutableMap<String, String> acceptableIds = ImmutableMap.of(
                     broadcast.getSourceId(),
-                    content.getCanonicalUri()
+                    item.getCanonicalUri()
             );
 
-            trimmer.trimBroadcasts(broadcastInterval, channel, acceptableIds);
+            trimmer.trimBroadcasts(item.getPublisher(), broadcastInterval, channel, acceptableIds);
 
             scheduleWriter.replaceScheduleBlock(
                     item.getPublisher(),

--- a/src/main/java/org/atlasapi/remotesite/channel4/pmlsd/epg/ScheduleResolverBroadcastTrimmer.java
+++ b/src/main/java/org/atlasapi/remotesite/channel4/pmlsd/epg/ScheduleResolverBroadcastTrimmer.java
@@ -58,7 +58,7 @@ public class ScheduleResolverBroadcastTrimmer implements BroadcastTrimmer {
             Channel channel,
             Map<String, String> acceptableIds
     ) {
-        trimBroadcasts(defaultPublisher.get(), scheduleInterval, channel, acceptableIds);
+        trimBroadcasts(null, scheduleInterval, channel, acceptableIds);
     }
 
     @Override

--- a/src/main/java/org/atlasapi/remotesite/channel4/pmlsd/epg/ScheduleResolverBroadcastTrimmer.java
+++ b/src/main/java/org/atlasapi/remotesite/channel4/pmlsd/epg/ScheduleResolverBroadcastTrimmer.java
@@ -58,7 +58,7 @@ public class ScheduleResolverBroadcastTrimmer implements BroadcastTrimmer {
             Channel channel,
             Map<String, String> acceptableIds
     ) {
-        trimBroadcasts(null, scheduleInterval, channel, acceptableIds);
+        trimBroadcasts(defaultPublisher.get(), scheduleInterval, channel, acceptableIds);
     }
 
     @Override


### PR DESCRIPTION
Problem is that broadcast amendments done thru owl-api (eg. stuff like txlogs)
make the broadcast that was already there stick around on that piece of content.
This change makes it so that they get trimmed (ie. marked as unpublished).

https://metabroadcast.atlassian.net/browse/ENG-226