### PR TITLE
Avoid cursor timeout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -436,7 +436,7 @@
         <dependency>
             <groupId>org.atlasapi</groupId>
             <artifactId>atlas-persistence</artifactId>
-            <version>${atlas.version}</version>
+            <version>5.5-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>jetty</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -436,7 +436,7 @@
         <dependency>
             <groupId>org.atlasapi</groupId>
             <artifactId>atlas-persistence</artifactId>
-            <version>5.5-SNAPSHOT</version>
+            <version>5.0-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>jetty</artifactId>

--- a/src/main/java/org/atlasapi/equiv/EquivTaskModule.java
+++ b/src/main/java/org/atlasapi/equiv/EquivTaskModule.java
@@ -33,7 +33,6 @@ import org.atlasapi.messaging.v3.JacksonMessageSerializer;
 import org.atlasapi.messaging.v3.KafkaMessagingModule;
 import org.atlasapi.persistence.content.ContentResolver;
 import org.atlasapi.persistence.content.ScheduleResolver;
-import org.atlasapi.persistence.content.listing.ContentLister;
 import org.atlasapi.persistence.content.listing.SelectedContentLister;
 import org.atlasapi.persistence.content.mongo.LastUpdatedContentFinder;
 import org.atlasapi.persistence.lookup.LookupWriter;
@@ -215,7 +214,7 @@ public class EquivTaskModule {
     @Value("${equiv.stream-updater.consumers.max}") private Integer maxStreamedEquivUpdateConsumers;
     @Value("${messaging.destination.content.changes}") private String contentChanges;
 
-    @Autowired private ContentLister contentLister;
+    @Autowired private SelectedContentLister contentLister;
     @Autowired private SimpleScheduler taskScheduler;
     @Autowired private ContentResolver contentResolver;
     @Autowired private LastUpdatedContentFinder contentFinder;
@@ -723,7 +722,7 @@ public class EquivTaskModule {
 
     private ContentEquivalenceUpdateTask publisherUpdateTask(final Publisher... publishers) {
         return new ContentEquivalenceUpdateTask(
-                (SelectedContentLister) contentLister,
+                contentLister,
                 contentResolver,
                 getNewDefaultExecutor(),
                 progressStore(),

--- a/src/main/java/org/atlasapi/equiv/update/tasks/ContentEquivalenceUpdateTask.java
+++ b/src/main/java/org/atlasapi/equiv/update/tasks/ContentEquivalenceUpdateTask.java
@@ -147,9 +147,9 @@ public final class ContentEquivalenceUpdateTask extends ScheduledTask {
                     //ever need to check that result you probably need to refactor the code
                     //using invokeAll instead of the countdown latch.
                     currentContent = resolveUri(currentUri);
+                    executor.submit(handleAsync(currentContent, latch));
+                    submitted++;
                 }
-                executor.submit(handleAsync(currentContent, latch));
-                submitted++;
 
                 //reduce the latch by the difference between the wanted amount,
                 // and the amount we managed to submit. (i.e. manage the last few).

--- a/src/main/java/org/atlasapi/equiv/update/tasks/ContentEquivalenceUpdateTask.java
+++ b/src/main/java/org/atlasapi/equiv/update/tasks/ContentEquivalenceUpdateTask.java
@@ -116,14 +116,14 @@ public final class ContentEquivalenceUpdateTask extends ScheduledTask {
 
         log.info("Running equiv on all content from {}", progress.getPublisher());
         if (executor == null) {
-            runSyncronously(contents);
+            runSynchronously(contents);
         } else {
-            runAsyncronously(contents);
+            runAsynchronously(contents);
         }
     }
 
     //TODO: switch to List<String> (a list of URIs)
-    private void runAsyncronously(List<Content> contents) {
+    private void runAsynchronously(List<Content> contents) {
         Content current = null;
         try {
             while (shouldContinue() && !contents.isEmpty()) {
@@ -162,7 +162,7 @@ public final class ContentEquivalenceUpdateTask extends ScheduledTask {
         onFinish(shouldContinue(), null);
     }
 
-    private void runSyncronously(List<Content> contents) {
+    private void runSynchronously(List<Content> contents) {
         boolean proceed = true;
         Content current = null;
         int processed = 0;

--- a/src/main/java/org/atlasapi/equiv/update/tasks/ContentEquivalenceUpdateTask.java
+++ b/src/main/java/org/atlasapi/equiv/update/tasks/ContentEquivalenceUpdateTask.java
@@ -120,8 +120,9 @@ public final class ContentEquivalenceUpdateTask extends ScheduledTask {
 
         onStart(progress);
 
-        List<String> uriIterator = contentLister.listContentUris(listingCriteria(progress));
-        Queue<String> contentUris = new LinkedList<>(uriIterator);
+        Iterator<String> uriIterator = contentLister.listContentUris(listingCriteria(progress));
+        Queue<String> contentUris = new LinkedList<>();
+        uriIterator.forEachRemaining(contentUris::add);
 
         log.info("Running equiv on all content from {}", progress.getPublisher());
         if (executor == null) {

--- a/src/main/java/org/atlasapi/equiv/update/tasks/ContentEquivalenceUpdateTask.java
+++ b/src/main/java/org/atlasapi/equiv/update/tasks/ContentEquivalenceUpdateTask.java
@@ -120,7 +120,7 @@ public final class ContentEquivalenceUpdateTask extends ScheduledTask {
         onStart(progress);
 
         Iterator<String> uriIterator = contentLister.listContentUris(listingCriteria(progress));
-        List<String> contentUris = new LinkedList<>();
+        LinkedList<String> contentUris = new LinkedList<>();
         uriIterator.forEachRemaining(contentUris::add);
 
         log.info("Running equiv on all content from {}", progress.getPublisher());

--- a/src/main/java/org/atlasapi/equiv/update/tasks/ContentEquivalenceUpdateTask.java
+++ b/src/main/java/org/atlasapi/equiv/update/tasks/ContentEquivalenceUpdateTask.java
@@ -145,7 +145,7 @@ public final class ContentEquivalenceUpdateTask extends ScheduledTask {
                     submitted++;
                 }
                 //reduce the latch by the difference between the wanted amount,
-                // and the amount we maanged to submit. (i.e. manage the last few).
+                // and the amount we managed to submit. (i.e. manage the last few).
                 while (submitted < SAVE_EVERY_BLOCK_SIZE) {
                     latch.countDown();
                     submitted++;

--- a/src/main/java/org/atlasapi/equiv/update/tasks/ContentEquivalenceUpdateTask.java
+++ b/src/main/java/org/atlasapi/equiv/update/tasks/ContentEquivalenceUpdateTask.java
@@ -2,6 +2,7 @@ package org.atlasapi.equiv.update.tasks;
 
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -118,7 +119,9 @@ public final class ContentEquivalenceUpdateTask extends ScheduledTask {
 
         onStart(progress);
 
-        List<String> contentUris = contentLister.listContentUris(listingCriteria(progress));
+        Iterator<String> uriIterator = contentLister.listContentUris(listingCriteria(progress));
+        List<String> contentUris = new LinkedList<>();
+        uriIterator.forEachRemaining(contentUris::add);
 
         log.info("Running equiv on all content from {}", progress.getPublisher());
         if (executor == null) {

--- a/src/main/java/org/atlasapi/equiv/update/tasks/ContentEquivalenceUpdateTask.java
+++ b/src/main/java/org/atlasapi/equiv/update/tasks/ContentEquivalenceUpdateTask.java
@@ -121,7 +121,7 @@ public final class ContentEquivalenceUpdateTask extends ScheduledTask {
         onStart(progress);
 
         Iterator<String> uriIterator = contentLister.listContentUris(listingCriteria(progress));
-        LinkedList<String> contentUris = new LinkedList<>();
+        Queue<String> contentUris = new LinkedList<>();
         uriIterator.forEachRemaining(contentUris::add);
 
         log.info("Running equiv on all content from {}", progress.getPublisher());

--- a/src/main/java/org/atlasapi/equiv/update/tasks/ContentEquivalenceUpdateTask.java
+++ b/src/main/java/org/atlasapi/equiv/update/tasks/ContentEquivalenceUpdateTask.java
@@ -120,9 +120,8 @@ public final class ContentEquivalenceUpdateTask extends ScheduledTask {
 
         onStart(progress);
 
-        Iterator<String> uriIterator = contentLister.listContentUris(listingCriteria(progress));
-        Queue<String> contentUris = new LinkedList<>();
-        uriIterator.forEachRemaining(contentUris::add);
+        List<String> uriIterator = contentLister.listContentUris(listingCriteria(progress));
+        Queue<String> contentUris = new LinkedList<>(uriIterator);
 
         log.info("Running equiv on all content from {}", progress.getPublisher());
         if (executor == null) {

--- a/src/main/java/org/atlasapi/equiv/update/tasks/ContentEquivalenceUpdateTask.java
+++ b/src/main/java/org/atlasapi/equiv/update/tasks/ContentEquivalenceUpdateTask.java
@@ -118,7 +118,7 @@ public final class ContentEquivalenceUpdateTask extends ScheduledTask {
 
         onStart(progress);
 
-        List<String> contentUris = contentLister.listContentUris(listingCriteria(progress), true);
+        List<String> contentUris = contentLister.listContentUris(listingCriteria(progress));
 
         log.info("Running equiv on all content from {}", progress.getPublisher());
         if (executor == null) {

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/LastUpdatedSettingContentWriter.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/LastUpdatedSettingContentWriter.java
@@ -1,19 +1,10 @@
 package org.atlasapi.remotesite.bbc.nitro;
 
-import com.google.common.base.Function;
-import com.google.common.base.Objects;
-import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-import com.metabroadcast.common.base.Maybe;
-import com.metabroadcast.common.time.Clock;
-import com.metabroadcast.common.time.SystemClock;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.atlasapi.media.entity.Broadcast;
 import org.atlasapi.media.entity.Clip;
 import org.atlasapi.media.entity.Container;
@@ -28,14 +19,26 @@ import org.atlasapi.media.entity.Restriction;
 import org.atlasapi.media.entity.Version;
 import org.atlasapi.persistence.content.ContentResolver;
 import org.atlasapi.persistence.content.ContentWriter;
+
+import com.metabroadcast.common.base.Maybe;
+import com.metabroadcast.common.time.Clock;
+import com.metabroadcast.common.time.SystemClock;
+
+import com.google.common.base.Function;
+import com.google.common.base.Objects;
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -349,19 +352,10 @@ public class LastUpdatedSettingContentWriter implements ContentWriter {
     }
 
     private ImmutableMap<String, Broadcast> previousBroadcasts(Set<Version> prevVersions) {
-        Iterable<Broadcast> allBroadcasts = Iterables.concat(Iterables.transform(prevVersions, new Function<Version, Iterable<Broadcast>>() {
-            @Override
-            public Iterable<Broadcast> apply(Version input) {
-                return input.getBroadcasts();
-            }
-        }));
-        return Maps.uniqueIndex(allBroadcasts, new Function<Broadcast, String>() {
-
-            @Override
-            public String apply(Broadcast input) {
-                return input.getSourceId();
-            }
-        });
+        Iterable<Broadcast> allBroadcasts = Iterables.concat(prevVersions.stream()
+                .map(Version::getBroadcasts)
+                .collect(Collectors.toList()));
+        return Maps.uniqueIndex(allBroadcasts, Broadcast::getSourceId);
     }
 
     private boolean itemsEqual(Item prevItem, Item item) {

--- a/src/test/java/org/atlasapi/equiv/update/tasks/ContentEquivalenceUpdateTaskTest.java
+++ b/src/test/java/org/atlasapi/equiv/update/tasks/ContentEquivalenceUpdateTaskTest.java
@@ -26,6 +26,7 @@ import org.atlasapi.equiv.update.EquivalenceUpdater;
 import org.atlasapi.media.entity.Brand;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Episode;
+import org.atlasapi.media.entity.Identified;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.persistence.content.ContentResolver;
@@ -62,10 +63,13 @@ public class ContentEquivalenceUpdateTaskTest extends TestCase {
         return new SelectedContentLister() {
 
             @Override
-            public List<Content> listContent(ContentListingCriteria criteria, boolean b) {
-                Iterator<Content> iterator = listContent(criteria);
-                List<Content> allContent = new ArrayList<>();
-                iterator.forEachRemaining(allContent::add);
+            public List<String> listContentUris(ContentListingCriteria criteria) {
+                Iterator<Content> contentIterator = listContent(criteria);
+                Iterator<String> uriIterator = Iterators.transform(contentIterator,
+                        Identified::getCanonicalUri
+                );
+                List<String> allContent = new ArrayList<>();
+                uriIterator.forEachRemaining(allContent::add);
                 return allContent;
             }
 

--- a/src/test/java/org/atlasapi/equiv/update/tasks/ContentEquivalenceUpdateTaskTest.java
+++ b/src/test/java/org/atlasapi/equiv/update/tasks/ContentEquivalenceUpdateTaskTest.java
@@ -60,11 +60,15 @@ public class ContentEquivalenceUpdateTaskTest extends TestCase {
         return new SelectedContentLister() {
 
             @Override
-            public Iterator<String> listContentUris(ContentListingCriteria criteria) {
+            public List<String> listContentUris(ContentListingCriteria criteria) {
                 Iterator<Content> contentIterator = listContent(criteria);
-                return Iterators.transform(contentIterator,
-                        Identified::getCanonicalUri
-                );
+                List<String> allContent = new ArrayList<>();
+                Content content;
+                while(contentIterator.hasNext()){
+                    content = contentIterator.next();
+                    allContent.add(content.getCanonicalUri());
+                }
+                return allContent;
             }
 
             @Override

--- a/src/test/java/org/atlasapi/equiv/update/tasks/ContentEquivalenceUpdateTaskTest.java
+++ b/src/test/java/org/atlasapi/equiv/update/tasks/ContentEquivalenceUpdateTaskTest.java
@@ -25,11 +25,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Queue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -60,15 +56,11 @@ public class ContentEquivalenceUpdateTaskTest extends TestCase {
         return new SelectedContentLister() {
 
             @Override
-            public List<String> listContentUris(ContentListingCriteria criteria) {
+            public Iterator<String> listContentUris(ContentListingCriteria criteria) {
                 Iterator<Content> contentIterator = listContent(criteria);
-                List<String> allContent = new ArrayList<>();
-                Content content;
-                while(contentIterator.hasNext()){
-                    content = contentIterator.next();
-                    allContent.add(content.getCanonicalUri());
-                }
-                return allContent;
+                return Iterators.transform(contentIterator,
+                        Identified::getCanonicalUri
+                );
             }
 
             @Override

--- a/src/test/java/org/atlasapi/equiv/update/tasks/ContentEquivalenceUpdateTaskTest.java
+++ b/src/test/java/org/atlasapi/equiv/update/tasks/ContentEquivalenceUpdateTaskTest.java
@@ -27,7 +27,9 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Queue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -58,14 +60,11 @@ public class ContentEquivalenceUpdateTaskTest extends TestCase {
         return new SelectedContentLister() {
 
             @Override
-            public List<String> listContentUris(ContentListingCriteria criteria) {
+            public Iterator<String> listContentUris(ContentListingCriteria criteria) {
                 Iterator<Content> contentIterator = listContent(criteria);
-                Iterator<String> uriIterator = Iterators.transform(contentIterator,
+                return Iterators.transform(contentIterator,
                         Identified::getCanonicalUri
                 );
-                List<String> allContent = new ArrayList<>();
-                uriIterator.forEachRemaining(allContent::add);
-                return allContent;
             }
 
             @Override


### PR DESCRIPTION
This is part of a workaround to prevent MongoCursorNotFoundException which stopped equiv from properly rerunning on all content from a publisher. The change is to use a List of content uris instead of an Iterator of Content, and resolving the content afterwards.

https://metabroadcast.atlassian.net/browse/ENG-316