### PR TITLE
Ingest original version pids and actual tx start and end times

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/BaseNitroItemExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/BaseNitroItemExtractor.java
@@ -50,7 +50,7 @@ public abstract class BaseNitroItemExtractor<SOURCE, ITEM extends Item>
     private static final String ORIGINAL_TYPE = "Original";
     private static final String WARNING_TEXT_LONG_LENGTH = "long";
     private static final String VERSION_PID_NAMESPACE = "gb:bbc:nitro:prod:version:pid";
-    private static final String ORIGINAL_VERSION_PID_NAMESPACE = "gb:bbc:nitro:prod:original:version:pid";
+    private static final String ORIGINAL_VERSION_PID_NAMESPACE = "gb:bbc:nitro:prod:version:original:pid";
     private static final String CRID_ALIAS_NAMESPACE = "gb:yv:prod:version:crid";
 
     private final NitroIdGenerator nitroIdGenerator = new NitroIdGenerator(Hashing.md5());
@@ -147,7 +147,6 @@ public abstract class BaseNitroItemExtractor<SOURCE, ITEM extends Item>
         extractAdditionalItemFields(source, item, now);
     }
 
-    //This was moved from NitroEpisodeExtractor and refactored slightly
     private void addVersionAliasesToLocations(Item item, Version version, Alias versionPidAlias) {
         Alias versionCridAlias = new Alias(
                 CRID_ALIAS_NAMESPACE,

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroBroadcastExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroBroadcastExtractor.java
@@ -47,11 +47,17 @@ public class NitroBroadcastExtractor
         }
         DateTime start = NitroUtil.toDateTime(source.getPublishedTime().getStart());
         DateTime end = NitroUtil.toDateTime(source.getPublishedTime().getEnd());
+
+        DateTime actualStart = NitroUtil.toDateTime(source.getTxTime().getStart());
+        DateTime actualEnd = NitroUtil.toDateTime(source.getTxTime().getEnd());
+
         Broadcast broadcast = new Broadcast(channel, start, end)
                 .withId("bbc:" + source.getPid());
         broadcast.setRepeat(source.isIsRepeat());
         broadcast.setAudioDescribed(source.isIsAudioDescribed());
         broadcast.setAliases(extractAliasesFrom(source));
+        broadcast.setActualTransmissionTime(actualStart);
+        broadcast.setActualTransmissionEndTime(actualEnd);
 
         // Adding an alias uri for equivalence between Nitro and YV broadcasts
         Optional<Alias> pcridAlias = Iterables.tryFind(broadcast.getAliases(), PCRID_ALIAS);

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroBroadcastExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroBroadcastExtractor.java
@@ -48,16 +48,18 @@ public class NitroBroadcastExtractor
         DateTime start = NitroUtil.toDateTime(source.getPublishedTime().getStart());
         DateTime end = NitroUtil.toDateTime(source.getPublishedTime().getEnd());
 
-        DateTime actualStart = NitroUtil.toDateTime(source.getTxTime().getStart());
-        DateTime actualEnd = NitroUtil.toDateTime(source.getTxTime().getEnd());
-
         Broadcast broadcast = new Broadcast(channel, start, end)
                 .withId("bbc:" + source.getPid());
         broadcast.setRepeat(source.isIsRepeat());
         broadcast.setAudioDescribed(source.isIsAudioDescribed());
         broadcast.setAliases(extractAliasesFrom(source));
-        broadcast.setActualTransmissionTime(actualStart);
-        broadcast.setActualTransmissionEndTime(actualEnd);
+
+        if(source.getTxTime() != null) {
+            DateTime actualStart = NitroUtil.toDateTime(source.getTxTime().getStart());
+            DateTime actualEnd = NitroUtil.toDateTime(source.getTxTime().getEnd());
+            broadcast.setActualTransmissionTime(actualStart);
+            broadcast.setActualTransmissionEndTime(actualEnd);
+        }
 
         // Adding an alias uri for equivalence between Nitro and YV broadcasts
         Optional<Alias> pcridAlias = Iterables.tryFind(broadcast.getAliases(), PCRID_ALIAS);

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroBroadcastExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroBroadcastExtractor.java
@@ -55,10 +55,14 @@ public class NitroBroadcastExtractor
         broadcast.setAliases(extractAliasesFrom(source));
 
         if(source.getTxTime() != null) {
-            DateTime actualStart = NitroUtil.toDateTime(source.getTxTime().getStart());
-            DateTime actualEnd = NitroUtil.toDateTime(source.getTxTime().getEnd());
-            broadcast.setActualTransmissionTime(actualStart);
-            broadcast.setActualTransmissionEndTime(actualEnd);
+            if(source.getTxTime().getStart() != null) {
+                DateTime actualStart = NitroUtil.toDateTime(source.getTxTime().getStart());
+                broadcast.setActualTransmissionTime(actualStart);
+            }
+            if(source.getTxTime().getEnd() != null) {
+                DateTime actualEnd = NitroUtil.toDateTime(source.getTxTime().getEnd());
+                broadcast.setActualTransmissionEndTime(actualEnd);
+            }
         }
 
         // Adding an alias uri for equivalence between Nitro and YV broadcasts

--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroEpisodeExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/extract/NitroEpisodeExtractor.java
@@ -5,7 +5,6 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
-import com.google.common.hash.Hashing;
 import com.metabroadcast.atlas.glycerin.model.AncestorTitles;
 import com.metabroadcast.atlas.glycerin.model.AvailableVersions;
 import com.metabroadcast.atlas.glycerin.model.Brand.MasterBrand;
@@ -16,17 +15,12 @@ import com.metabroadcast.atlas.glycerin.model.PidReference;
 import com.metabroadcast.atlas.glycerin.model.Synopses;
 import com.metabroadcast.common.intl.Countries;
 import com.metabroadcast.common.time.Clock;
-import org.atlasapi.feeds.youview.nitro.NitroIdGenerator;
-import org.atlasapi.media.entity.Alias;
 import org.atlasapi.media.entity.CrewMember;
-import org.atlasapi.media.entity.Encoding;
 import org.atlasapi.media.entity.Film;
 import org.atlasapi.media.entity.Item;
-import org.atlasapi.media.entity.Location;
 import org.atlasapi.media.entity.ParentRef;
 import org.atlasapi.media.entity.Person;
 import org.atlasapi.media.entity.ReleaseDate;
-import org.atlasapi.media.entity.Version;
 import org.atlasapi.persistence.content.people.QueuingPersonWriter;
 import org.atlasapi.remotesite.ContentExtractor;
 import org.atlasapi.remotesite.bbc.BbcFeeds;
@@ -57,8 +51,6 @@ import static com.metabroadcast.atlas.glycerin.model.Brand.Contributions;
 public final class NitroEpisodeExtractor extends BaseNitroItemExtractor<Episode, Item> {
 
     private static final String FILM_FORMAT_ID = "PT007";
-    private static final String PID_ALIAS_NAMESPACE = "gb:bbc:nitro:prod:version:pid";
-    private static final String CRID_ALIAS_NAMESPACE = "gb:yv:prod:version:crid";
     private static final Predicate<Format> IS_FILM_FORMAT = new Predicate<Format>() {
 
         @Override
@@ -71,7 +63,6 @@ public final class NitroEpisodeExtractor extends BaseNitroItemExtractor<Episode,
 
     private final NitroCrewMemberExtractor crewMemberExtractor = new NitroCrewMemberExtractor();
     private final NitroPersonExtractor personExtractor = new NitroPersonExtractor();
-    private final NitroIdGenerator nitroIdGenerator = new NitroIdGenerator(Hashing.md5());
     private final QueuingPersonWriter personWriter;
 
     public NitroEpisodeExtractor(Clock clock, QueuingPersonWriter personWriter) {
@@ -168,28 +159,7 @@ public final class NitroEpisodeExtractor extends BaseNitroItemExtractor<Episode,
             setReleaseDate(item, source);
         }
         writeAndSetPeople(item, source);
-        for (Version version : item.getVersions()) {
-            addLocationAliasesToItemVersion(item, version);
-        }
     }
-
-        private void addLocationAliasesToItemVersion(Item item, Version version) {
-            for (Encoding encoding : version.getManifestedAs()) {
-                for (Location location : encoding.getAvailableAt()) {
-                    Alias versionAlias = new Alias(
-                            PID_ALIAS_NAMESPACE,
-                            version.getCanonicalUri()
-                                    .replace("http://nitro.bbc.co.uk/programmes/", "")
-                    );
-                    item.addAlias(versionAlias);
-                    location.addAlias(versionAlias);
-                    location.addAlias(new Alias(
-                            CRID_ALIAS_NAMESPACE,
-                            nitroIdGenerator.generateVersionCrid(item, version)
-                    ));
-                }
-            }
-        }
 
     private void writeAndSetPeople(Item item, NitroItemSource<Episode> source) {
         Contributions contributions = source.getProgramme().getContributions();


### PR DESCRIPTION
This is for work for BARB relating to equivalence and filling
in episode and original version PIDs in CCIDSTxLogs.
More information can be found in JIRA ENG-339.

* Refactored some existing logic with version pids and
version crids in NitroEpisodeExtractor into
BaseNitroItemExtractor.