### PR TITLE
Improvements to previous equiv work for Nitro<->Txlogs

### DIFF
--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BbcTxlogsItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BbcTxlogsItemUpdaterProvider.java
@@ -7,7 +7,7 @@ import org.atlasapi.equiv.update.updaters.providers.EquivalenceResultUpdaterProv
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.equiv.update.updaters.providers.item.barb.BarbAliasItemUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.item.barb.BarbBbcActualTransmissionItemUpdaterProvider;
-import org.atlasapi.equiv.update.updaters.providers.item.barb.BarbBroadcastItemUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.item.barb.BarbBbcBroadcastItemUpdaterProvider;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
 
@@ -18,27 +18,27 @@ import static com.google.common.base.Preconditions.checkArgument;
 public class BbcTxlogsItemUpdaterProvider implements EquivalenceResultUpdaterProvider<Item> {
 
     private final BarbAliasItemUpdaterProvider barbAliasItemUpdaterProvider;
-    private final BarbBroadcastItemUpdaterProvider barbBroadcastItemUpdaterProvider;
+    private final BarbBbcBroadcastItemUpdaterProvider barbBbcBroadcastItemUpdaterProvider;
     private final BarbBbcActualTransmissionItemUpdaterProvider barbBbcActualTransmissionItemUpdaterProvider;
 
     private BbcTxlogsItemUpdaterProvider(
             BarbAliasItemUpdaterProvider barbAliasItemUpdaterProvider,
-            BarbBroadcastItemUpdaterProvider barbBroadcastItemUpdaterProvider,
+            BarbBbcBroadcastItemUpdaterProvider barbBbcBroadcastItemUpdaterProvider,
             BarbBbcActualTransmissionItemUpdaterProvider barbBbcActualTransmissionItemUpdaterProvider
     ) {
         this.barbAliasItemUpdaterProvider = barbAliasItemUpdaterProvider;
-        this.barbBroadcastItemUpdaterProvider = barbBroadcastItemUpdaterProvider;
+        this.barbBbcBroadcastItemUpdaterProvider = barbBbcBroadcastItemUpdaterProvider;
         this.barbBbcActualTransmissionItemUpdaterProvider = barbBbcActualTransmissionItemUpdaterProvider;
     }
 
     public static BbcTxlogsItemUpdaterProvider create(
             BarbAliasItemUpdaterProvider barbAliasItemUpdaterProvider,
-            BarbBroadcastItemUpdaterProvider barbBroadcastItemUpdaterProvider,
+            BarbBbcBroadcastItemUpdaterProvider barbBbcBroadcastItemUpdaterProvider,
             BarbBbcActualTransmissionItemUpdaterProvider barbBbcActualTransmissionItemUpdaterProvider
     ) {
         return new BbcTxlogsItemUpdaterProvider(
                 barbAliasItemUpdaterProvider,
-                barbBroadcastItemUpdaterProvider,
+                barbBbcBroadcastItemUpdaterProvider,
                 barbBbcActualTransmissionItemUpdaterProvider
         );
     }
@@ -56,7 +56,7 @@ public class BbcTxlogsItemUpdaterProvider implements EquivalenceResultUpdaterPro
                 targetPublishers
         );
 
-        EquivalenceResultUpdater<Item> broadcastEquivResultUpdater = barbBroadcastItemUpdaterProvider.getUpdater(
+        EquivalenceResultUpdater<Item> broadcastEquivResultUpdater = barbBbcBroadcastItemUpdaterProvider.getUpdater(
                 dependencies,
                 targetPublishers
         );

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/barb/BarbBbcBroadcastItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/barb/BarbBbcBroadcastItemUpdaterProvider.java
@@ -27,15 +27,15 @@ import org.joda.time.Duration;
 
 import java.util.Set;
 
-public class BarbBroadcastItemUpdaterProvider implements EquivalenceResultUpdaterProvider<Item> {
+public class BarbBbcBroadcastItemUpdaterProvider implements EquivalenceResultUpdaterProvider<Item> {
 
 
-    private BarbBroadcastItemUpdaterProvider() {
+    private BarbBbcBroadcastItemUpdaterProvider() {
 
     }
 
-    public static BarbBroadcastItemUpdaterProvider create() {
-        return new BarbBroadcastItemUpdaterProvider();
+    public static BarbBbcBroadcastItemUpdaterProvider create() {
+        return new BarbBbcBroadcastItemUpdaterProvider();
     }
 
     @Override
@@ -50,7 +50,7 @@ public class BarbBroadcastItemUpdaterProvider implements EquivalenceResultUpdate
                                 dependencies.getScheduleResolver(),
                                 dependencies.getChannelResolver(),
                                 targetPublishers,
-                                Duration.standardMinutes(5),
+                                Duration.standardMinutes(10),
                                 Predicates.alwaysTrue(),
                                 3.0
                         )

--- a/src/main/java/org/atlasapi/equiv/update/updaters/types/ItemEquivalenceUpdaterType.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/types/ItemEquivalenceUpdaterType.java
@@ -23,7 +23,7 @@ import org.atlasapi.equiv.update.updaters.providers.item.WikipediaItemUpdateProv
 import org.atlasapi.equiv.update.updaters.providers.item.YouviewItemUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.item.barb.BarbAliasItemUpdaterProvider;
 import org.atlasapi.equiv.update.updaters.providers.item.barb.BarbBbcActualTransmissionItemUpdaterProvider;
-import org.atlasapi.equiv.update.updaters.providers.item.barb.BarbBroadcastItemUpdaterProvider;
+import org.atlasapi.equiv.update.updaters.providers.item.barb.BarbBbcBroadcastItemUpdaterProvider;
 import org.atlasapi.media.entity.Item;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -80,7 +80,7 @@ public enum ItemEquivalenceUpdaterType {
     BBC_TXLOGS_ITEM(
             BbcTxlogsItemUpdaterProvider.create(
                     BarbAliasItemUpdaterProvider.create(),
-                    BarbBroadcastItemUpdaterProvider.create(),
+                    BarbBbcBroadcastItemUpdaterProvider.create(),
                     BarbBbcActualTransmissionItemUpdaterProvider.create()
             )
     ),

--- a/src/test/java/org/atlasapi/equiv/generators/barb/BarbBbcActualTransmissionItemEquivalenceGeneratorAndScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/generators/barb/BarbBbcActualTransmissionItemEquivalenceGeneratorAndScorerTest.java
@@ -40,7 +40,7 @@ public class BarbBbcActualTransmissionItemEquivalenceGeneratorAndScorerTest {
             .withBroadcaster(Publisher.METABROADCAST)
             .withTitle("BBC One")
             .withHighDefinition(false)
-            .withMediaType(MediaType.AUDIO)
+            .withMediaType(MediaType.VIDEO)
             .withUri("http://www.bbc.co.uk/bbcone")
             .build();
 
@@ -48,7 +48,7 @@ public class BarbBbcActualTransmissionItemEquivalenceGeneratorAndScorerTest {
             .withBroadcaster(Publisher.METABROADCAST)
             .withTitle("BBC Two Wales")
             .withHighDefinition(false)
-            .withMediaType(MediaType.AUDIO)
+            .withMediaType(MediaType.VIDEO)
             .withUri("http://www.bbc.co.uk/services/bbctwo/wales")
             .build();
 


### PR DESCRIPTION
Based off feedback from BBC.

* Relaxed the regular broadcast equiv flexibility from
5mins to 10mins

* For BBC Two Wales and Northern Ireland when checking
actual transmission times only check the actual
transmission start time since Nitro is generally
missing the actual transmission end time.