### PR TITLE
Api endpoints to update explicit equiv

### DIFF
--- a/src/main/java/org/atlasapi/query/content/ContentWriteExecutor.java
+++ b/src/main/java/org/atlasapi/query/content/ContentWriteExecutor.java
@@ -1,13 +1,10 @@
 package org.atlasapi.query.content;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.util.List;
-import java.util.Set;
-
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.metabroadcast.common.base.Maybe;
 import org.atlasapi.input.ModelReader;
 import org.atlasapi.input.ModelTransformer;
 import org.atlasapi.input.ReadException;
@@ -34,16 +31,18 @@ import org.atlasapi.query.content.merge.BroadcastMerger;
 import org.atlasapi.query.content.merge.ContentMerger;
 import org.atlasapi.query.content.merge.VersionMerger;
 import org.atlasapi.remotesite.channel4.pmlsd.epg.BroadcastTrimmer;
-
-import com.metabroadcast.common.base.Maybe;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import org.joda.time.Interval;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.List;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -198,9 +197,14 @@ public class ContentWriteExecutor {
         }
     }
 
+    /**
+     * @param publishers the set of publishers whose explicit equivalences will be modified in the lookup table,
+     *                   with any other explicit equivalences to content from other publishers being unaffected.
+     *                   If null will be later set to all publishers present in the explicitEquivRefs.
+     */
     public void updateExplicitEquivalence(
             Content content,
-            Set<Publisher> publishers,
+            @Nullable Set<Publisher> publishers,
             Set<LookupRef> explicitEquivRefs
     ) {
         content.setEquivalentTo(explicitEquivRefs);

--- a/src/main/java/org/atlasapi/query/content/ContentWriteExecutor.java
+++ b/src/main/java/org/atlasapi/query/content/ContentWriteExecutor.java
@@ -201,6 +201,12 @@ public class ContentWriteExecutor {
      * @param publishers the set of publishers whose explicit equivalences will be modified in the lookup table,
      *                   with any other explicit equivalences to content from other publishers being unaffected.
      *                   If null will be later set to all publishers present in the explicitEquivRefs.
+     * e.g. Suppose content A (Publisher X) has explicit equivs to B (Publisher Y), C (Publisher Z)
+     *                   and explicitEquivsRefs is just a single element set of D (Publisher Y)
+     *                   If publishers is just a single element set of Publisher Y then the explicit equivs in the
+     *                   lookup table will become C (Publisher Z), D (Publisher Y)
+     *                   If publishers is Publisher Y and Publisher Z then the explicit equivs in the lookup table will
+     *                   become just D (Publisher Y)
      */
     public void updateExplicitEquivalence(
             Content content,

--- a/src/main/java/org/atlasapi/query/v2/ContentWriteController.java
+++ b/src/main/java/org/atlasapi/query/v2/ContentWriteController.java
@@ -511,9 +511,18 @@ public class ContentWriteController {
      * N.B. this updates the content table since it contains a copy of the explicit set and is used for merging
      * explicit equivalences in the regular content POST endpoint.
      *
-     * In particular this allows an easy way to remove all explicit equivalences on a piece of content since the other
-     * methods do not support updating the explicit equivalences with an empty set.
+     * In particular this allows an easy way to remove all explicit equivalences on a piece of content.
+     * This was needed due to an ingest bug which would fetch content through the api, add broadcasts and write
+     * the content back - which due to the questionable way the api was designed meant that all transitive equivs
+     * were being written as explicit equivs, which was undesired and needed to be undone.
+     *
+     * N.B. Unlike the other explicit endpoints which were added later, this method has no validation on the sources
+     * of content that are being explicitly equived. As a result the endpoint currently allows a piece of content to
+     * be equived to content from a source that the application has neither read nor write access to. If there is ever
+     * a need to use the endpoint beyond the bug mentioned above it should be considered whether this behaviour is
+     * appropriate.
      */
+    @Deprecated
     @Nullable
     public WriteResponse updateExplicitEquivalenceBySource(HttpServletRequest req, HttpServletResponse resp) {
         PossibleApplication possibleApplication = validateApplicationConfiguration(req, resp);

--- a/src/main/java/org/atlasapi/query/v2/ContentWriteController.java
+++ b/src/main/java/org/atlasapi/query/v2/ContentWriteController.java
@@ -763,9 +763,6 @@ public class ContentWriteController {
         } else {
             throw new IllegalArgumentException("No id or uri specified");
         }
-        if (!lookupEntries.iterator().hasNext()) {
-            throw new IllegalArgumentException("No lookup entry found");
-        }
         return Iterables.getOnlyElement(lookupEntries);
     }
 

--- a/src/main/java/org/atlasapi/query/v2/ContentWriteController.java
+++ b/src/main/java/org/atlasapi/query/v2/ContentWriteController.java
@@ -274,7 +274,7 @@ public class ContentWriteController {
             }
             if (!secondContent.getEquivalentTo().contains(LookupRef.from(firstContent))) {
                 Set<LookupRef> newExplicits = new HashSet<>(secondContent.getEquivalentTo());
-                newExplicits.add(LookupRef.from(secondContent));
+                newExplicits.add(LookupRef.from(firstContent));
                 writeExecutor.updateExplicitEquivalence(secondContent, null, newExplicits);
                 updatedIds.add(encodeId(secondContent.getId()));
             }

--- a/src/main/java/org/atlasapi/query/v2/ContentWriteController.java
+++ b/src/main/java/org/atlasapi/query/v2/ContentWriteController.java
@@ -459,7 +459,7 @@ public class ContentWriteController {
 
     private Set<LookupRef> getLookupRefsForIds(Iterable<String> ids, Application application) {
         Iterable<Long> decodedIds = MoreStreams.stream(ids)
-                .map(id -> SubstitutionTableNumberCodec.lowerCaseOnly().decode(id))
+                .map(codec::decode)
                 .map(BigInteger::longValue)
                 .collect(MoreCollectors.toImmutableSet());
         return getLookupRefsForExplicitEquiv(lookupEntryStore.entriesForIds(decodedIds), application);
@@ -629,9 +629,7 @@ public class ContentWriteController {
         // get ID / URI, if ID, lookup URI from it
         LookupEntry lookupEntry;
         if (req.getParameter(ID) != null) {
-            Long contentId = SubstitutionTableNumberCodec
-                    .lowerCaseOnly()
-                    .decode(req.getParameter(ID))
+            Long contentId = codec.decode(req.getParameter(ID))
                     .longValue();
             Iterator<LookupEntry> entryStoreIterator = lookupEntryStore
                     .entriesForIds(Lists.newArrayList(contentId))
@@ -729,10 +727,7 @@ public class ContentWriteController {
     }
 
     private String uriForId(String id) {
-        Long contentId = SubstitutionTableNumberCodec
-                .lowerCaseOnly()
-                .decode(id)
-                .longValue();
+        Long contentId = codec.decode(id).longValue();
         Iterator<LookupEntry> entryStoreIterator = lookupEntryStore
                 .entriesForIds(Lists.newArrayList(contentId))
                 .iterator();
@@ -753,9 +748,7 @@ public class ContentWriteController {
             }
         } else if (!Strings.isNullOrEmpty(id)) {
             lookupEntries = lookupEntryStore.entriesForIds(
-                    ImmutableList.of(
-                            SubstitutionTableNumberCodec.lowerCaseOnly().decode(id).longValue()
-                    )
+                    ImmutableList.of(codec.decode(id).longValue())
             );
             if (!lookupEntries.iterator().hasNext()) {
                 throw new IllegalArgumentException("No lookup entry found for id " + id);

--- a/src/main/java/org/atlasapi/query/v2/ContentWriteController.java
+++ b/src/main/java/org/atlasapi/query/v2/ContentWriteController.java
@@ -330,12 +330,12 @@ public class ContentWriteController {
         List<String> ids = parseList(req.getParameter(IDS));
 
         if (uris.size() + ids.size() != 2) {
-            throw new IllegalArgumentException("Must specify exactly a sum of two of " + URIS + " or " + IDS);
+            throw new IllegalArgumentException("Must specify exactly a distinct sum of two of " + URIS + " or " + IDS);
         }
 
         List<Content> contents = resolveContent(uris, ids);
         if (contents.size() != 2 || contents.get(0).equals(contents.get(1))) {
-            throw new IllegalArgumentException("Must specify exactly a sum of two of " + URIS + " or " + IDS);
+            throw new IllegalArgumentException("Must specify exactly a distinct sum of two of " + URIS + " or " + IDS);
         }
 
         for (Content content : contents) {

--- a/src/main/java/org/atlasapi/query/v2/ContentWriteController.java
+++ b/src/main/java/org/atlasapi/query/v2/ContentWriteController.java
@@ -228,13 +228,13 @@ public class ContentWriteController {
     }
 
     /**
-     * Adds a bidrectional explicit equivalence link between two pieces of content.
+     * Adds a bidirectional explicit equivalence link between two pieces of content.
      * The content record list of explicit equivs is updated much like it is in the regular content update endpoints.
      * Other existing explicit equivalences are left intact.
      * The application must have write permissions to both pieces of content, unless the application has the role
      * "explicit-equivalence-from-read-sources" in which case it must have either write permissions or read permissions
      * to both pieces of content.
-     * An error is thrown if the content is already explicitly equived bidrectionally.
+     * An error is thrown if the content is already explicitly equived bidirectionally.
      */
     @Nullable
     public MultiWriteResponse addExplicitEquivalence(HttpServletRequest req, HttpServletResponse resp) {
@@ -291,7 +291,7 @@ public class ContentWriteController {
     }
 
     /**
-     * Removes an explicit equivalence link bidrectionally between two pieces of content.
+     * Removes an explicit equivalence link bidirectionally between two pieces of content.
      * The content record list of explicit equivs is updated much like it is in the regular content update endpoints.
      * Other existing explicit equivalences are left intact.
      * The application must have write permissions to both pieces of content, unless the application has the role

--- a/src/main/java/org/atlasapi/query/v2/QueryController.java
+++ b/src/main/java/org/atlasapi/query/v2/QueryController.java
@@ -312,6 +312,8 @@ public class QueryController extends BaseController<QueryResult<Identified, ? ex
         return contentWriteController.removeExplicitEquivalence(req, resp);
     }
 
+    // This was created just to fix a bug caused by an ingest writing all transitive equivs as explicit equivs
+    // Please read the comments in the contentWriteController for further context behind this endpoint.
     @RequestMapping(value="/3.0/debug/equivalence/explicit.json", method = RequestMethod.PUT)
     public WriteResponse updateExplicitEquivalenceBySource(HttpServletRequest req, HttpServletResponse resp) {
         return contentWriteController.updateExplicitEquivalenceBySource(req, resp);

--- a/src/main/java/org/atlasapi/query/v2/QueryController.java
+++ b/src/main/java/org/atlasapi/query/v2/QueryController.java
@@ -297,11 +297,6 @@ public class QueryController extends BaseController<QueryResult<Identified, ? ex
         return contentWriteController.unpublishContent(req, resp);
     }
 
-    @RequestMapping(value="/3.0/equivalence/explicit.json", method = RequestMethod.PUT)
-    public WriteResponse updateExplicitEquivalence(HttpServletRequest req, HttpServletResponse resp) {
-        return contentWriteController.updateExplicitEquivalence(req, resp);
-    }
-
     @RequestMapping(value="/3.0/equivalence/explicit.json", method = RequestMethod.POST)
     public MultiWriteResponse addExplicitEquivalence(HttpServletRequest req, HttpServletResponse resp) {
         return contentWriteController.addExplicitEquivalence(req, resp);
@@ -310,12 +305,5 @@ public class QueryController extends BaseController<QueryResult<Identified, ? ex
     @RequestMapping(value="/3.0/equivalence/explicit.json", method = RequestMethod.DELETE)
     public MultiWriteResponse removeExplicitEquivalence(HttpServletRequest req, HttpServletResponse resp) {
         return contentWriteController.removeExplicitEquivalence(req, resp);
-    }
-
-    // This was created just to fix a bug caused by an ingest writing all transitive equivs as explicit equivs
-    // Please read the comments in the contentWriteController for further context behind this endpoint.
-    @RequestMapping(value="/3.0/debug/equivalence/explicit.json", method = RequestMethod.PUT)
-    public WriteResponse updateExplicitEquivalenceBySource(HttpServletRequest req, HttpServletResponse resp) {
-        return contentWriteController.updateExplicitEquivalenceBySource(req, resp);
     }
 }

--- a/src/main/java/org/atlasapi/query/v2/QueryController.java
+++ b/src/main/java/org/atlasapi/query/v2/QueryController.java
@@ -27,7 +27,7 @@ import org.atlasapi.content.criteria.ContentQuery;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Identified;
 import org.atlasapi.media.entity.Publisher;
-import org.atlasapi.media.entity.simple.response.MultiWriteResponse;
+import org.atlasapi.media.entity.simple.response.ExplicitEquivalenceResponse;
 import org.atlasapi.media.entity.simple.response.WriteResponse;
 import org.atlasapi.output.Annotation;
 import org.atlasapi.output.AtlasErrorSummary;
@@ -298,12 +298,12 @@ public class QueryController extends BaseController<QueryResult<Identified, ? ex
     }
 
     @RequestMapping(value="/3.0/equivalence/explicit.json", method = RequestMethod.POST)
-    public MultiWriteResponse addExplicitEquivalence(HttpServletRequest req, HttpServletResponse resp) {
+    public ExplicitEquivalenceResponse addExplicitEquivalence(HttpServletRequest req, HttpServletResponse resp) {
         return contentWriteController.addExplicitEquivalence(req, resp);
     }
 
     @RequestMapping(value="/3.0/equivalence/explicit.json", method = RequestMethod.DELETE)
-    public MultiWriteResponse removeExplicitEquivalence(HttpServletRequest req, HttpServletResponse resp) {
+    public ExplicitEquivalenceResponse removeExplicitEquivalence(HttpServletRequest req, HttpServletResponse resp) {
         return contentWriteController.removeExplicitEquivalence(req, resp);
     }
 }

--- a/src/main/java/org/atlasapi/query/v2/QueryController.java
+++ b/src/main/java/org/atlasapi/query/v2/QueryController.java
@@ -27,6 +27,7 @@ import org.atlasapi.content.criteria.ContentQuery;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Identified;
 import org.atlasapi.media.entity.Publisher;
+import org.atlasapi.media.entity.simple.response.MultiWriteResponse;
 import org.atlasapi.media.entity.simple.response.WriteResponse;
 import org.atlasapi.output.Annotation;
 import org.atlasapi.output.AtlasErrorSummary;
@@ -296,8 +297,23 @@ public class QueryController extends BaseController<QueryResult<Identified, ? ex
         return contentWriteController.unpublishContent(req, resp);
     }
 
-    @RequestMapping(value="/3.0/debug/equivalence/explicit/content.json", method = RequestMethod.PUT)
+    @RequestMapping(value="/3.0/equivalence/explicit.json", method = RequestMethod.PUT)
     public WriteResponse updateExplicitEquivalence(HttpServletRequest req, HttpServletResponse resp) {
         return contentWriteController.updateExplicitEquivalence(req, resp);
+    }
+
+    @RequestMapping(value="/3.0/equivalence/explicit.json", method = RequestMethod.POST)
+    public MultiWriteResponse addExplicitEquivalence(HttpServletRequest req, HttpServletResponse resp) {
+        return contentWriteController.addExplicitEquivalence(req, resp);
+    }
+
+    @RequestMapping(value="/3.0/equivalence/explicit.json", method = RequestMethod.DELETE)
+    public MultiWriteResponse removeExplicitEquivalence(HttpServletRequest req, HttpServletResponse resp) {
+        return contentWriteController.removeExplicitEquivalence(req, resp);
+    }
+
+    @RequestMapping(value="/3.0/debug/equivalence/explicit.json", method = RequestMethod.PUT)
+    public WriteResponse updateExplicitEquivalenceBySource(HttpServletRequest req, HttpServletResponse resp) {
+        return contentWriteController.updateExplicitEquivalenceBySource(req, resp);
     }
 }


### PR DESCRIPTION
ENG-282 contains the context but is to allow
for editors to explicitly equiv brands together
in order to move away from the frankly terrible
automatic brand equiv logic that happens at the
moment between most major broadcasters sources.

* Endpoint to explicitly equiv two pieces of content

* Endpoint to remove explicit equiv between two pieces of content

* Endpoint to update explicit equiv on a single piece of content
This endpoint is not needed but added due to there being a potential
need for it based on previous experience. It was also an initial
implementation for the above before deciding against using it.
Since it does not update the content record explicit equivalence
lists of other content it is explicitly equiving to it may cause
undesirable behaviour when updating explicit equivalence of other
content where the link might break due to a new link being made
to an additional piece of content from the same source - this
is due to the somewhat quirky relationship of the content record
explicit equivalences being a sort-of-subset of the lookup table
explicit equivalences.