### PR TITLE
Eng 241 - Fixed incorrect ids in equiv

### DIFF
--- a/src/main/java/org/atlasapi/equiv/update/ContentEquivalenceResultUpdater.java
+++ b/src/main/java/org/atlasapi/equiv/update/ContentEquivalenceResultUpdater.java
@@ -2,6 +2,8 @@ package org.atlasapi.equiv.update;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+
+import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
 import com.metabroadcast.common.stream.MoreCollectors;
 import org.atlasapi.equiv.generators.EquivalenceGenerator;
 import org.atlasapi.equiv.generators.EquivalenceGenerators;
@@ -21,6 +23,7 @@ import org.atlasapi.equiv.update.metadata.EquivToTelescopeResults;
 import org.atlasapi.equiv.update.metadata.EquivalenceUpdaterMetadata;
 import org.atlasapi.media.entity.Content;
 
+import java.math.BigInteger;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.StreamSupport;
@@ -32,6 +35,9 @@ public class ContentEquivalenceResultUpdater<T extends Content> implements Equiv
     private final EquivalenceGenerators<T> generators;
     private final EquivalenceScorers<T> scorers;
     private final DefaultEquivalenceResultBuilder<T> resultBuilder;
+
+    private final SubstitutionTableNumberCodec codec
+            = SubstitutionTableNumberCodec.lowerCaseOnly();
 
     private final EquivalenceUpdaterMetadata metadata;
 
@@ -75,7 +81,7 @@ public class ContentEquivalenceResultUpdater<T extends Content> implements Equiv
             EquivToTelescopeResults resultsForTelescope
     ) {
         EquivToTelescopeResult resultForTelescope = EquivToTelescopeResult.create(
-                String.valueOf(content.getId()),
+                codec.encode(BigInteger.valueOf(content.getId())),
                 content.getPublisher().toString()
         );
 

--- a/src/main/java/org/atlasapi/equiv/update/ContentEquivalenceUpdater.java
+++ b/src/main/java/org/atlasapi/equiv/update/ContentEquivalenceUpdater.java
@@ -16,8 +16,11 @@ import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.reporting.telescope.OwlTelescopeReporter;
 
+import java.math.BigInteger;
 import java.util.Map;
 import java.util.Set;
+
+import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -26,6 +29,9 @@ public class ContentEquivalenceUpdater<T extends Content> implements Equivalence
     private final Set<EquivalenceResultUpdater<T>> equivalenceResultUpdaters;
     private final EquivalenceResultHandler<T> handler;
     private final EquivalenceResultMessenger<T> messenger;
+
+    private final SubstitutionTableNumberCodec codec
+            = SubstitutionTableNumberCodec.lowerCaseOnly();
 
     private final EquivalenceUpdaterMetadata metadata;
 
@@ -48,7 +54,7 @@ public class ContentEquivalenceUpdater<T extends Content> implements Equivalence
         ReadableDescription desc = new DefaultDescription();
 
         EquivToTelescopeResults resultsForTelescope = EquivToTelescopeResults.create(
-                String.valueOf(content.getId()),
+                codec.encode(BigInteger.valueOf(content.getId())),
                 content.getPublisher().toString()
         );
 

--- a/src/main/java/org/atlasapi/equiv/update/metadata/EquivToTelescopeComponent.java
+++ b/src/main/java/org/atlasapi/equiv/update/metadata/EquivToTelescopeComponent.java
@@ -25,7 +25,7 @@ public class EquivToTelescopeComponent {
     }
 
     public void addComponentResult(long longId, String score) {
-        String id = new SubstitutionTableNumberCodec().encode(
+        String id = new SubstitutionTableNumberCodec().lowerCaseOnly().encode(
                 BigInteger.valueOf(longId)
         );
         componentResults.put(id, score);


### PR DESCRIPTION
Some ids were being encoded with uppercase encoding, this is now changed to use lowercase encoding. Also, some ids were not being encoded at all, but are now encoded correctly using the lowercase codec.