### PR TITLE
Improvements for BBC Txlog equiv

### DIFF
--- a/src/main/java/org/atlasapi/equiv/generators/barb/BarbAliasEquivalenceGeneratorAndScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/barb/BarbAliasEquivalenceGeneratorAndScorer.java
@@ -453,6 +453,7 @@ public class BarbAliasEquivalenceGeneratorAndScorer<T extends Content> implement
         return lookupEntryStore.entriesForAliases(
                 com.google.common.base.Optional.of(alias.getNamespace()),
                 ImmutableSet.of(alias.getValue()),
+                publishers,
                 includeUnpublishedContent
         );
     }

--- a/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
@@ -124,7 +124,6 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
         scoreCandidates(
                 scores,
                 subject,
-                getTotalNumberOfValidBroadcasts(subject),
                 candidates,
                 desc,
                 generatorComponent
@@ -198,17 +197,24 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
     private void scoreCandidates(
             Builder<Item> scores,
             Item subject,
-            int subjectTotalNumberOfValidBroadcasts,
             Set<Item> candidates,
             ResultDescription desc,
             EquivToTelescopeComponent generatorComponent
     ) {
         desc.startStage("Checking matching broadcast ratios");
+        int subjectTotalNumberOfValidBroadcasts = getTotalNumberOfValidBroadcasts(subject);
         for (Item candidate : candidates) {
             int numberOfValidBroadcasts = Math.min(
                             subjectTotalNumberOfValidBroadcasts,
                             getTotalNumberOfValidBroadcasts(candidate)
             );
+
+            if (numberOfValidBroadcasts == 0) {
+                desc.appendText(
+                        String.format("%s : minimum number of valid broadcasts is <=0", candidate.getCanonicalUri())
+                );
+                continue;
+            }
 
             Set<Broadcast> matchingBroadcasts = new HashSet<>();
 

--- a/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
@@ -121,10 +121,16 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
             }
         }
 
+        desc.appendText("Processed %s of %s broadcasts", processedBroadcasts, totalBroadcasts);
+
+        desc.startStage("Checking matching broadcast ratios");
         for (Map.Entry<Item, BroadcastMatchingInfo> candidateEntry : broadcastMatchingInfoMap.entrySet()) {
             Item candidate = candidateEntry.getKey();
             BroadcastMatchingInfo info = candidateEntry.getValue();
             Optional<Score> score = Optional.empty();
+            desc.appendText(
+                    String.format("%s : %.2f", candidate.getCanonicalUri(), info.getRatioOfMatchingBroadcasts())
+            );
             if (matchingBroadcastsThresholdFunction.apply(info.getRatioOfMatchingBroadcasts())) {
                 score = Optional.of(scoreOnMatch);
             } else if (info.getNumberOfMatchingBroadcasts() > 0) {
@@ -140,10 +146,9 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
                 }
             }
         }
+        desc.finishStage();
 
         equivToTelescopeResult.addGeneratorResult(generatorComponent);
-
-        desc.appendText("Processed %s of %s broadcasts", processedBroadcasts, totalBroadcasts);
 
         return scores.build();
     }

--- a/src/main/java/org/atlasapi/equiv/generators/barb/utils/BarbGeneratorUtils.java
+++ b/src/main/java/org/atlasapi/equiv/generators/barb/utils/BarbGeneratorUtils.java
@@ -9,6 +9,7 @@ import org.joda.time.DateTime;
 import org.joda.time.Duration;
 
 import java.util.Set;
+import java.util.function.Predicate;
 
 public class BarbGeneratorUtils {
     /**
@@ -84,6 +85,28 @@ public class BarbGeneratorUtils {
         }
         return false;
     }
+
+    public static Set<Broadcast> getQualifyingBroadcasts(
+            Item item,
+            Broadcast referenceBroadcast,
+            Duration flexibility,
+            Predicate<Broadcast> broadcastFilter
+    ) {
+        ImmutableSet.Builder<Broadcast> qualifyingBroadcasts = ImmutableSet.builder();
+        for (Version version : item.nativeVersions()) {
+            for (Broadcast broadcast : version.getBroadcasts()) {
+                if (around(broadcast, referenceBroadcast, flexibility) && broadcast.getBroadcastOn() != null
+                        && sameChannel(broadcast.getBroadcastOn(), referenceBroadcast.getBroadcastOn())
+                        && broadcast.isActivelyPublished()
+                        && broadcastFilter.test(broadcast)
+                ) {
+                    qualifyingBroadcasts.add(broadcast);
+                }
+            }
+        }
+        return qualifyingBroadcasts.build();
+    }
+
     public static boolean hasFlexibleQualifyingBroadcast(
             Item item,
             Broadcast referenceBroadcast,

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/barb/BarbBbcActualTransmissionItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/barb/BarbBbcActualTransmissionItemUpdaterProvider.java
@@ -47,9 +47,6 @@ public class BarbBbcActualTransmissionItemUpdaterProvider implements Equivalence
                                 dependencies.getScheduleResolver(),
                                 dependencies.getChannelResolver(),
                                 targetPublishers,
-                                //TODO: we may need to increase the flexibility since supposedly the actual transmission
-                                // can differ by up to at least a few hours - perhaps the generator would first try
-                                // 1 hour and gradually increase the search window up to a given limit?
                                 Duration.standardHours(1),
                                 null,
                                 Score.valueOf(4.0)

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/barb/BarbBbcBroadcastItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/barb/BarbBbcBroadcastItemUpdaterProvider.java
@@ -52,7 +52,8 @@ public class BarbBbcBroadcastItemUpdaterProvider implements EquivalenceResultUpd
                                 Duration.standardMinutes(10),
                                 null,
                                 Score.valueOf(3.0),
-                                Score.nullScore()
+                                Score.nullScore(),
+                                threshold -> threshold > 0.5
                         )
                 )
                 .withScorers(

--- a/src/test/java/org/atlasapi/equiv/generators/BarbAliasEquivalenceGeneratorAndScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/generators/BarbAliasEquivalenceGeneratorAndScorerTest.java
@@ -150,6 +150,7 @@ public class BarbAliasEquivalenceGeneratorAndScorerTest {
         when(aliasLookupEntryStore.entriesForAliases(
                 Optional.of("namespaceOne"),
                 ImmutableSet.of("someBcid"),
+                INCLUDED_PUBLISHERS,
                 INCLUDE_UNPUBLISHED_CONTENT
         )).thenReturn(ImmutableSet.of(lookupEntry));
     }
@@ -242,6 +243,7 @@ public class BarbAliasEquivalenceGeneratorAndScorerTest {
             when(aliasLookupEntryStore.entriesForAliases(
                     Optional.of(alias.getNamespace()),
                     ImmutableSet.of(alias.getValue()),
+                    INCLUDED_PUBLISHERS,
                     INCLUDE_UNPUBLISHED_CONTENT
             )).thenReturn(
                     aliasContentMultimap.get(alias).stream()
@@ -735,6 +737,7 @@ public class BarbAliasEquivalenceGeneratorAndScorerTest {
         when(aliasLookupEntryStore.entriesForAliases(
                 Optional.of(alias.getNamespace()),
                 ImmutableSet.of(alias.getValue()),
+                INCLUDED_PUBLISHERS,
                 INCLUDE_UNPUBLISHED_CONTENT
         )).thenReturn(ImmutableList.of(lookupEntryForContent(item), lookupEntryForContent(differentItem)));
 

--- a/src/test/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest.java
@@ -252,6 +252,17 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest {
 
     @Test
     public void broadcastsWithDurationLessThanTenMinutesHaveLowerFlexibility() {
+        BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer generatorWithLargeFlexibility =
+                new BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer(
+                        resolver,
+                        channelResolver,
+                        PUBLISHERS,
+                        standardMinutes(10),
+                        null,
+                        SCORE_ON_MATCH,
+                        Score.valueOf(0.1),
+                        null
+                );
         Item item1 = episodeWithBroadcasts(
                 "subjectitem",
                 Publisher.PA,
@@ -272,7 +283,7 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest {
                         PUBLISHERS)
         ).thenReturn(ImmutableSet.of(item2));
 
-        ScoredCandidates<Item> equivalents = generator.generate(
+        ScoredCandidates<Item> equivalents = generatorWithLargeFlexibility.generate(
                 item1,
                 new DefaultDescription(),
                 EquivToTelescopeResult.create("id", "publisher")

--- a/src/test/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest.java
@@ -1,7 +1,5 @@
 package org.atlasapi.equiv.generators.barb;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.metabroadcast.common.base.Maybe;
@@ -19,7 +17,6 @@ import org.atlasapi.media.entity.Episode;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.MediaType;
 import org.atlasapi.media.entity.Publisher;
-import org.atlasapi.media.entity.Schedule;
 import org.atlasapi.media.entity.Version;
 import org.atlasapi.persistence.content.ScheduleResolver;
 import org.joda.time.DateTime;
@@ -134,30 +131,20 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest {
         );
 
         when(
-                resolver.unmergedSchedule(
+                resolver.resolveItems(
                         utcTime(40000),
                         utcTime(2060000),
                         ImmutableSet.of(BBC_ONE),
                         PUBLISHERS)
-        ).thenReturn(
-                Schedule.fromChannelMap(
-                        ImmutableMap.of(BBC_ONE, ImmutableList.of(item2)),
-                        interval(40000, 2060000)
-                )
-        );
+        ).thenReturn(ImmutableSet.of(item2));
         when(
-                resolver.unmergedSchedule(
+                resolver.resolveItems(
                         utcTime(40000),
                         utcTime(2060000),
                         ImmutableSet.of(BBC_ONE_CAMBRIDGE),
                         PUBLISHERS
                 )
-        ).thenReturn(
-                Schedule.fromChannelMap(
-                        ImmutableMap.of(BBC_ONE_CAMBRIDGE, ImmutableList.of()),
-                        interval(40000, 2060000)
-                )
-        );
+        ).thenReturn(ImmutableSet.of());
 
         ScoredCandidates<Item> equivalents = generator.generate(
                 item1,
@@ -198,16 +185,11 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest {
         );
 
         when(
-                resolver.unmergedSchedule(
+                resolver.resolveItems(
                         time("2014-03-21T14:50:00Z"),
                         time("2014-03-21T16:00:00Z"),
                         ImmutableSet.of(BBC_ONE), ImmutableSet.of(BBC))
-        ).thenReturn(
-                Schedule.fromChannelMap(
-                        ImmutableMap.of(BBC_ONE, ImmutableList.of(item2)),
-                        interval(40000, 260000)
-                )
-        );
+        ).thenReturn(ImmutableSet.of(item2));
 
         ScoredCandidates<Item> equivalents = generator.generate(
                 item1,
@@ -283,17 +265,12 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest {
         );
 
         when(
-                resolver.unmergedSchedule(
+                resolver.resolveItems(
                         utcTime(880000),
                         utcTime(1320000),
                         ImmutableSet.of(BBC_ONE_CAMBRIDGE),
                         PUBLISHERS)
-        ).thenReturn(
-                Schedule.fromChannelMap(
-                        ImmutableMap.of(BBC_ONE_CAMBRIDGE, ImmutableList.of(item2)),
-                        interval(880000, 1320000)
-                )
-        );
+        ).thenReturn(ImmutableSet.of(item2));
 
         ScoredCandidates<Item> equivalents = generator.generate(
                 item1,
@@ -320,7 +297,7 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest {
         final Item item2 = episodeWithBroadcasts(
                 "equivItem",
                 BARB_TRANSMISSIONS,
-                BBC_ONE_CAMBRIDGE,
+                BBC_TWO_ENGLAND,
                 1,
                 new Broadcast(BBC_ONE.getUri(), utcTime(100000), utcTime(2000000)),
                 new Broadcast(BBC_ONE.getUri(), utcTime(4100000), utcTime(6000000)));
@@ -351,35 +328,25 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest {
                 );
 
         when(
-                resolver.unmergedSchedule(
+                resolver.resolveItems(
                         utcTime(40000),
                         utcTime(2060000),
                         ImmutableSet.of(BBC_ONE),
                         ImmutableSet.of(BARB_TRANSMISSIONS)
                 )
-        ).thenReturn(
-                Schedule.fromChannelMap(
-                        ImmutableMap.of(BBC_ONE, ImmutableList.of(item2)),
-                        interval(40000, 2060000)
-                )
-        );
+        ).thenReturn(ImmutableSet.of(item2));
 
         when(
-                resolver.unmergedSchedule(
+                resolver.resolveItems(
                         utcTime(4040000),
                         utcTime(6060000),
                         ImmutableSet.of(BBC_ONE),
                         ImmutableSet.of(BARB_TRANSMISSIONS)
                 )
-        ).thenReturn(
-                Schedule.fromChannelMap(
-                        ImmutableMap.of(BBC_ONE, ImmutableList.of(item2)),
-                        interval(4040000, 6060000)
-                )
-        );
+        ).thenReturn(ImmutableSet.of(item2));
 
         when(
-                resolver.unmergedSchedule(
+                resolver.resolveItems(
                         any(),
                         any(),
                         argThat(new ArgumentMatcher<Iterable<Channel>>() {
@@ -393,12 +360,7 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest {
                         }),
                         any()
                 )
-        ).thenReturn(
-                Schedule.fromChannelMap(
-                        ImmutableMap.of(BBC_ONE_CAMBRIDGE, ImmutableList.of()),
-                        interval(0, 0)
-                )
-        );
+        ).thenReturn(ImmutableSet.of());
 
         ScoredCandidates<Item> equivalents = lowerThresholdGenerator.generate(
                 item1,
@@ -443,7 +405,7 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest {
         );
 
         when(
-                resolver.unmergedSchedule(
+                resolver.resolveItems(
                         utcTime(40000),
                         utcTime(2060000),
                         ImmutableSet.<Channel>builder()
@@ -452,31 +414,16 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest {
                                 .build(),
                         Sets.difference(PUBLISHERS, ImmutableSet.of(BBC_NITRO))
                 )
-        ).thenReturn(
-                Schedule.fromChannelMap(
-                        ImmutableMap.of(
-                                BBC_TWO_SOUTH_TXLOG, ImmutableList.of(txlogItem1),
-                                BBC_TWO_EAST_TXLOG, ImmutableList.of(txlogItem2)
-                        ),
-                        interval(40000, 2060000)
-                )
-        );
+        ).thenReturn(ImmutableSet.of(txlogItem1, txlogItem2));
 
         when(
-                resolver.unmergedSchedule(
+                resolver.resolveItems(
                         utcTime(40000),
                         utcTime(2060000),
                         ImmutableSet.of(BBC_TWO_ENGLAND, BBC_TWO_SOUTH_TXLOG),
                         Sets.difference(PUBLISHERS, ImmutableSet.of(BARB_TRANSMISSIONS))
                 )
-        ).thenReturn(
-                Schedule.fromChannelMap(
-                        ImmutableMap.of(
-                                BBC_TWO_ENGLAND, ImmutableList.of(nitroItem)
-                        ),
-                        interval(40000, 2060000)
-                )
-        );
+        ).thenReturn(ImmutableSet.of(nitroItem));
 
         ScoredCandidates<Item> equivalents = generator.generate(
                 nitroItem,


### PR DESCRIPTION
Added broadcast matching threshold logic for barb broadcast equiv

Also bumped BbcTxlogsItemUpdaterProvider score for actual transmission time equiv and extractor logic to factor in new score

Efficiency improvement in Barb Alias Generator to only resolve LookupEntries from target publishers