### PR TITLE
5min min broadcast filter to regular nitro<->txlog broadcast equiv

### DIFF
--- a/src/main/java/org/atlasapi/equiv/generators/barb/BarbBbcActualTransmissionItemEquivalenceGeneratorAndScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/barb/BarbBbcActualTransmissionItemEquivalenceGeneratorAndScorer.java
@@ -152,7 +152,7 @@ public class BarbBbcActualTransmissionItemEquivalenceGeneratorAndScorer implemen
         for (ScheduleChannel channel : schedule.scheduleChannels()) {
             for (Item scheduleItem : channel.items()) {
                 if (scheduleItem.isActivelyPublished()
-                        && hasQualifyingBroadcast(scheduleItem, subjectBroadcast, flexibility)
+                        && hasQualifyingBroadcast(scheduleItem, subjectBroadcast, flexibility, broadcastFilter)
                         && hasQualifyingActualTransmissionTimeBroadcast(subject, scheduleItem, subjectBroadcast)
                 ) {
                     scores.updateEquivalent(scheduleItem, scoreOnMatch);
@@ -179,6 +179,9 @@ public class BarbBbcActualTransmissionItemEquivalenceGeneratorAndScorer implemen
 
         for (Version scheduleVersion : scheduleItem.nativeVersions()) {
             for (Broadcast scheduleBroadcast : scheduleVersion.getBroadcasts()) {
+                if (!scheduleBroadcast.isActivelyPublished() || !broadcastFilter.test(scheduleBroadcast)) {
+                    continue;
+                }
                 if (subjectIsTxlogAndSuggestionIsNitro
                         && hasQualifyingActualTransmissionTime(subjectBroadcast, scheduleBroadcast)
                 ) {

--- a/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
@@ -135,7 +135,7 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
             for (Item scheduleItem : channel.items()) {
                 if (scheduleItem instanceof Item
                         && scheduleItem.isActivelyPublished()
-                        && hasQualifyingBroadcast(scheduleItem, broadcast, flexibility)) {
+                        && hasQualifyingBroadcast(scheduleItem, broadcast, flexibility, broadcastFilter)) {
                     //we want the maximum score for this scorer to be scoreOnMatch, so we update the
                     //score of a candidate instead of adding it up via the usual .addEquivalent()
                     scores.updateEquivalent(scheduleItem, scoreOnMatch);
@@ -150,7 +150,7 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
                 } else if (scheduleItem instanceof Item
                         && scheduleItem.isActivelyPublished()
                         && hasFlexibleQualifyingBroadcast(
-                                scheduleItem, broadcast, flexibility, EXTENDED_END_TIME_FLEXIBILITY
+                                scheduleItem, broadcast, flexibility, EXTENDED_END_TIME_FLEXIBILITY, broadcastFilter
                 )) {
                     scores.updateEquivalent(scheduleItem, scoreOnExtendedFlexibilityMatch);
 

--- a/src/main/java/org/atlasapi/equiv/generators/barb/utils/BarbGeneratorUtils.java
+++ b/src/main/java/org/atlasapi/equiv/generators/barb/utils/BarbGeneratorUtils.java
@@ -9,6 +9,7 @@ import org.joda.time.DateTime;
 import org.joda.time.Duration;
 
 import java.util.Set;
+import java.util.function.Predicate;
 
 public class BarbGeneratorUtils {
     /**
@@ -71,13 +72,30 @@ public class BarbGeneratorUtils {
         return false;
     }
 
+    public static Predicate<Broadcast> minimumDuration(Duration duration) {
+        return broadcast -> {
+            Duration broadcastDuration = new Duration(
+                    broadcast.getTransmissionTime(),
+                    broadcast.getTransmissionEndTime()
+            );
+            return broadcastDuration.isLongerThan(duration);
+        };
+    }
 
-    public static boolean hasQualifyingBroadcast(Item item, Broadcast referenceBroadcast, Duration flexibility) {
+
+    public static boolean hasQualifyingBroadcast(
+            Item item,
+            Broadcast referenceBroadcast,
+            Duration flexibility,
+            Predicate<? super Broadcast> broadcastFilter
+    ) {
         for (Version version : item.nativeVersions()) {
             for (Broadcast broadcast : version.getBroadcasts()) {
                 if (around(broadcast, referenceBroadcast, flexibility) && broadcast.getBroadcastOn() != null
                         && sameChannel(broadcast.getBroadcastOn(), referenceBroadcast.getBroadcastOn())
-                        && broadcast.isActivelyPublished()) {
+                        && broadcast.isActivelyPublished()
+                        && broadcastFilter.test(broadcast)
+                ) {
                     return true;
                 }
             }
@@ -88,14 +106,17 @@ public class BarbGeneratorUtils {
             Item item,
             Broadcast referenceBroadcast,
             Duration flexibility,
-            Duration extendedEndTimeFlexibility
+            Duration extendedEndTimeFlexibility,
+            Predicate<? super Broadcast> broadcastFilter
     ) {
         for (Version version : item.nativeVersions()) {
             for (Broadcast broadcast : version.getBroadcasts()) {
                 if (flexibleAround(broadcast, referenceBroadcast, flexibility, extendedEndTimeFlexibility)
                         && broadcast.getBroadcastOn() != null
                         && sameChannel(broadcast.getBroadcastOn(), referenceBroadcast.getBroadcastOn())
-                        && broadcast.isActivelyPublished()) {
+                        && broadcast.isActivelyPublished()
+                        && broadcastFilter.test(broadcast)
+                ) {
                     return true;
                 }
             }

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BbcTxlogsItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BbcTxlogsItemUpdaterProvider.java
@@ -31,6 +31,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.joda.time.Duration;
 
+import static org.atlasapi.equiv.generators.barb.utils.BarbGeneratorUtils.minimumDuration;
+
 public class BbcTxlogsItemUpdaterProvider implements EquivalenceResultUpdaterProvider<Item> {
 
     public final boolean isSubjectTxlog;
@@ -65,7 +67,7 @@ public class BbcTxlogsItemUpdaterProvider implements EquivalenceResultUpdaterPro
                                         dependencies.getChannelResolver(),
                                         targetPublishers,
                                         Duration.standardMinutes(10),
-                                        null,
+                                        minimumDuration(Duration.standardMinutes(5)),
                                         Score.valueOf(3.0),
                                         Score.nullScore()
                                 ),

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/barb/BarbBbcBroadcastItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/barb/BarbBbcBroadcastItemUpdaterProvider.java
@@ -26,6 +26,8 @@ import org.joda.time.Duration;
 
 import java.util.Set;
 
+import static org.atlasapi.equiv.generators.barb.utils.BarbGeneratorUtils.minimumDuration;
+
 public class BarbBbcBroadcastItemUpdaterProvider implements EquivalenceResultUpdaterProvider<Item> {
 
 
@@ -50,7 +52,7 @@ public class BarbBbcBroadcastItemUpdaterProvider implements EquivalenceResultUpd
                                 dependencies.getChannelResolver(),
                                 targetPublishers,
                                 Duration.standardMinutes(10),
-                                null,
+                                minimumDuration(Duration.standardMinutes(5)),
                                 Score.valueOf(3.0),
                                 Score.nullScore()
                         )


### PR DESCRIPTION
This is to prevent short children shows being shown back-to-back
causing equiv issues where the txlog broadcasts have shifted by
a small amount, leading to two pieces of content being deemed
valid candidates for the same broadcast slot.

This may need improvement in future but for now this is to
prevent bad equiv even at the cost of no equiv.