### PR TITLE
Rework of Barb Broadcast Equiv

### DIFF
--- a/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
@@ -185,7 +185,7 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
                     subjectItemIndex,
                     candidateItemArray,
                     candidateItemIndex,
-                    desc
+                    nopDesc
             );
             if (!foundCandidate.isPresent()) {
                 desc.appendText("Could not determine candidate from schedule");

--- a/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
@@ -169,11 +169,11 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
             if (candidateItemList.isEmpty()) {
                 continue;
             }
-            desc.startStage("Resolving candidate schedule for " + candidateScheduleChannel.channel().getUri());
+            desc.startStage("Candidate schedule found for " + candidateScheduleChannel.channel().getUri());
             Item[] candidateItemArray = candidateItemList.toArray(new Item[0]);
             int candidateItemIndex = findSuitableCandidateInArray(candidateItemArray, subject, subjectBroadcast, nopDesc);
             if (candidateItemIndex < 0) {
-                desc.appendText("Could not find a suitable item in the candidate schedule");
+                desc.appendText("Could not find any suitable items in the candidate schedule");
                 desc.finishStage();
                 continue;
             }

--- a/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
@@ -161,7 +161,7 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
             desc.startStage("Resolving candidate schedule for " + candidateScheduleChannel.channel().getUri());
             List<Item> candidateItemList = candidateScheduleChannel.items();
             Item[] candidateItemArray = candidateItemList.toArray(new Item[0]);
-            int candidateItemIndex = findSuitableCandidateInArray(candidateItemArray, subject, subjectBroadcast);
+            int candidateItemIndex = findSuitableCandidateInArray(candidateItemArray, subject, subjectBroadcast, desc);
             if (candidateItemIndex < 0) {
                 desc.appendText("Could not find candidate item in the schedule");
                 desc.finishStage();
@@ -171,7 +171,8 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
                     subjectItemArray,
                     subjectItemIndex,
                     candidateItemArray,
-                    candidateItemIndex
+                    candidateItemIndex,
+                    desc
             );
             if (!foundCandidate.isPresent()) {
                 desc.appendText("Could not determine candidate from schedule");
@@ -246,7 +247,12 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
         return false;
     }
 
-    private int findSuitableCandidateInArray(Item[] items, Item subject, Broadcast subjectBroadcast) {
+    private int findSuitableCandidateInArray(
+            Item[] items,
+            Item subject,
+            Broadcast subjectBroadcast,
+            ResultDescription desc
+    ) {
         if (items.length <= 0) {
             return -1;
         }
@@ -269,7 +275,7 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
                 );
             }
             if (shortestDurationOffset == null || offset.isShorterThan(shortestDurationOffset)) {
-                if (isRealPositiveScore(titleMatchingScorer.score(subject, candidate))) {
+                if (isRealPositiveScore(titleMatchingScorer.score(subject, candidate, desc))) {
                     shortestDurationOffset = offset;
                     bestCandidateFound = i;
                 }
@@ -282,7 +288,8 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
             Item[] subjectItemArray,
             int subjectItemPosition,
             Item[] candidateItemArray,
-            int candidateItemPosition
+            int candidateItemPosition,
+            ResultDescription desc
     ) {
         Item subject = subjectItemArray[subjectItemPosition];
         Item possibleCandidate = candidateItemArray[candidateItemPosition];
@@ -292,7 +299,8 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
                 && isRealPositiveScore(
                 titleMatchingScorer.score(
                         subject,
-                        subjectItemArray[subjectPreviousBlockEnd]
+                        subjectItemArray[subjectPreviousBlockEnd],
+                        desc
                 )
         )) {
             subjectPreviousBlockEnd--;
@@ -303,7 +311,8 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
                 && isRealPositiveScore(
                 titleMatchingScorer.score(
                         possibleCandidate,
-                        candidateItemArray[candidatePreviousBlockEnd]
+                        candidateItemArray[candidatePreviousBlockEnd],
+                        desc
                 )
         )) {
             candidatePreviousBlockEnd--;
@@ -320,7 +329,8 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
                 && isRealPositiveScore(
                 titleMatchingScorer.score(
                         subject,
-                        subjectItemArray[subjectNextBlockStart]
+                        subjectItemArray[subjectNextBlockStart],
+                        desc
                 )
         )) {
             subjectNextBlockStart++;
@@ -331,7 +341,9 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
                 && isRealPositiveScore(
                 titleMatchingScorer.score(
                         possibleCandidate,
-                        candidateItemArray[candidateNextBlockStart])
+                        candidateItemArray[candidateNextBlockStart],
+                        desc
+                )
         )) {
             candidateNextBlockStart++;
         }

--- a/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
@@ -8,6 +8,7 @@ import org.atlasapi.equiv.generators.BroadcastMatchingItemEquivalenceGeneratorAn
 import org.atlasapi.equiv.generators.EquivalenceGenerator;
 import org.atlasapi.equiv.generators.metadata.EquivalenceGeneratorMetadata;
 import org.atlasapi.equiv.generators.metadata.SourceLimitedEquivalenceGeneratorMetadata;
+import org.atlasapi.equiv.results.description.NopDescription;
 import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates;
 import org.atlasapi.equiv.results.scores.DefaultScoredCandidates.Builder;
@@ -55,6 +56,7 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
     private final Score scoreOnMatch;
     private final Duration scheduleWindow; //for offset calculation
     private final BarbTitleMatchingItemScorer titleMatchingScorer;
+    private final NopDescription nopDesc;
 
     public BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer(
             ScheduleResolver resolver,
@@ -72,6 +74,7 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
         this.scoreOnMatch = checkNotNull(scoreOnMatch);
         this.titleMatchingScorer = checkNotNull(titleMatchingScorer);
         this.scheduleWindow = checkNotNull(scheduleWindow);
+        this.nopDesc = new NopDescription();
     }
 
     @Override
@@ -169,7 +172,7 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
             desc.startStage("Resolving candidate schedule for " + candidateScheduleChannel.channel().getUri());
             Item[] candidateItemArray = candidateItemList.toArray(new Item[0]);
             desc.startStage("Finding a suitable item in the candidate schedule");
-            int candidateItemIndex = findSuitableCandidateInArray(candidateItemArray, subject, subjectBroadcast, desc);
+            int candidateItemIndex = findSuitableCandidateInArray(candidateItemArray, subject, subjectBroadcast, nopDesc);
             if (candidateItemIndex < 0) {
                 desc.appendText("Could not find a suitable item in the candidate schedule");
                 desc.finishStage();
@@ -193,7 +196,7 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
 
             Item candidate = foundCandidate.get();
             if(candidate.isActivelyPublished()) {
-                Broadcast candidateBroadcast = getBroadcastFromScheduleItem(candidate, desc);
+                Broadcast candidateBroadcast = getBroadcastFromScheduleItem(candidate, nopDesc);
                 desc.appendText(
                         "Found candidate %s with broadcast [%s - %s]",
                         candidate.getCanonicalUri(),

--- a/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
@@ -256,20 +256,20 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
             Item candidate = items[i];
             //The schedule resolver should return items each with a single broadcast corresponding to their schedule slot
             Broadcast candidateBroadcast = candidate.getVersions().iterator().next().getBroadcasts().iterator().next();
-            if (titleMatchingScorer.score(subject, candidate).isRealScore()) {
-                Duration offset;
-                if (subjectBroadcast.getTransmissionTime().isAfter(candidateBroadcast.getTransmissionTime())) {
-                    offset = new Duration(
-                            candidateBroadcast.getTransmissionTime(),
-                            subjectBroadcast.getTransmissionTime()
-                    );
-                } else {
-                    offset = new Duration(
-                            subjectBroadcast.getTransmissionTime(),
-                            candidateBroadcast.getTransmissionTime()
-                    );
-                }
-                if (shortestDurationOffset == null || offset.isShorterThan(shortestDurationOffset)) {
+            Duration offset;
+            if (subjectBroadcast.getTransmissionTime().isAfter(candidateBroadcast.getTransmissionTime())) {
+                offset = new Duration(
+                        candidateBroadcast.getTransmissionTime(),
+                        subjectBroadcast.getTransmissionTime()
+                );
+            } else {
+                offset = new Duration(
+                        subjectBroadcast.getTransmissionTime(),
+                        candidateBroadcast.getTransmissionTime()
+                );
+            }
+            if (shortestDurationOffset == null || offset.isShorterThan(shortestDurationOffset)) {
+                if (isRealPositiveScore(titleMatchingScorer.score(subject, candidate))) {
                     shortestDurationOffset = offset;
                     bestCandidateFound = i;
                 }
@@ -289,13 +289,23 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
 
         int subjectPreviousBlockEnd = subjectItemPosition - 1;
         while (subjectPreviousBlockEnd >= 0
-                && titleMatchingScorer.score(subject, subjectItemArray[subjectPreviousBlockEnd]).isRealScore()) {
+                && isRealPositiveScore(
+                titleMatchingScorer.score(
+                        subject,
+                        subjectItemArray[subjectPreviousBlockEnd]
+                )
+        )) {
             subjectPreviousBlockEnd--;
         }
 
         int candidatePreviousBlockEnd = candidateItemPosition - 1;
         while (candidatePreviousBlockEnd >= 0
-                && titleMatchingScorer.score(possibleCandidate, candidateItemArray[candidatePreviousBlockEnd]).isRealScore()) {
+                && isRealPositiveScore(
+                titleMatchingScorer.score(
+                        possibleCandidate,
+                        candidateItemArray[candidatePreviousBlockEnd]
+                )
+        )) {
             candidatePreviousBlockEnd--;
         }
 
@@ -307,13 +317,22 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
 
         int subjectNextBlockStart = subjectItemPosition + 1;
         while (subjectNextBlockStart < subjectItemArray.length
-                && titleMatchingScorer.score(subject, subjectItemArray[subjectNextBlockStart]).isRealScore()) {
+                && isRealPositiveScore(
+                titleMatchingScorer.score(
+                        subject,
+                        subjectItemArray[subjectNextBlockStart]
+                )
+        )) {
             subjectNextBlockStart++;
         }
 
         int candidateNextBlockStart = candidateItemPosition + 1;
         while (candidateNextBlockStart < candidateItemArray.length
-                && titleMatchingScorer.score(possibleCandidate, candidateItemArray[candidateNextBlockStart]).isRealScore()) {
+                && isRealPositiveScore(
+                titleMatchingScorer.score(
+                        possibleCandidate,
+                        candidateItemArray[candidateNextBlockStart])
+        )) {
             candidateNextBlockStart++;
         }
 
@@ -334,6 +353,10 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
         int foundCandidatePosition = candidatePreviousBlockEnd + subjectPositionInBlock;
 
         return Optional.of(candidateItemArray[foundCandidatePosition]);
+    }
+
+    private boolean isRealPositiveScore(Score score) {
+        return score.isRealScore() && score.asDouble() > 0D;
     }
 
 

--- a/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
@@ -138,7 +138,7 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
             EquivToTelescopeComponent generatorComponent
     ) {
         desc.startStage(
-                "Schedule for " + String.format(
+                "Finding matches for broadcast: " + String.format(
                         "%s [%s - %s]",
                         subjectBroadcast.getBroadcastOn(),
                         subjectBroadcast.getTransmissionTime(),
@@ -200,15 +200,19 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
                         candidateBroadcast.getTransmissionTime(),
                         candidateBroadcast.getTransmissionEndTime()
                 );
-                //we want the maximum score for this scorer to be scoreOnMatch, so we update the
-                //score of a candidate instead of adding it up via the usual .addEquivalent()
-                scores.updateEquivalent(candidate, scoreOnMatch);
+                if (broadcastFilter.test(candidateBroadcast)) {
+                    //we want the maximum score for this scorer to be scoreOnMatch, so we update the
+                    //score of a candidate instead of adding it up via the usual .addEquivalent()
+                    scores.updateEquivalent(candidate, scoreOnMatch);
 
-                if (candidate.getId() != null) {
-                    generatorComponent.addComponentResult(
-                            candidate.getId(),
-                            scoreOnMatch.toString()
-                    );
+                    if (candidate.getId() != null) {
+                        generatorComponent.addComponentResult(
+                                candidate.getId(),
+                                scoreOnMatch.toString()
+                        );
+                    }
+                } else {
+                    desc.appendText("Candidate broadcast did not pass the broadcast filter");
                 }
             }
             desc.finishStage();

--- a/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
@@ -163,7 +163,7 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
             Item[] candidateItemArray = candidateItemList.toArray(new Item[0]);
             int candidateItemIndex = findSuitableCandidateInArray(candidateItemArray, subject, subjectBroadcast, desc);
             if (candidateItemIndex < 0) {
-                desc.appendText("Could not find candidate item in the schedule");
+                desc.appendText("Could not find a suitable item in the candidate schedule");
                 desc.finishStage();
                 continue;
             }

--- a/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
@@ -191,6 +191,7 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
             if (!foundCandidate.isPresent()) {
                 desc.appendText("Could not determine candidate from schedule");
                 desc.finishStage();
+                desc.finishStage();
                 continue;
             }
             desc.finishStage();

--- a/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
@@ -1,11 +1,9 @@
 package org.atlasapi.equiv.generators.barb;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.Predicate;
-
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.metabroadcast.common.base.Maybe;
+import com.metabroadcast.common.stream.MoreCollectors;
 import org.atlasapi.equiv.generators.BroadcastMatchingItemEquivalenceGeneratorAndScorer;
 import org.atlasapi.equiv.generators.EquivalenceGenerator;
 import org.atlasapi.equiv.generators.metadata.EquivalenceGeneratorMetadata;
@@ -27,16 +25,16 @@ import org.atlasapi.media.entity.Schedule;
 import org.atlasapi.media.entity.Schedule.ScheduleChannel;
 import org.atlasapi.media.entity.Version;
 import org.atlasapi.persistence.content.ScheduleResolver;
-
-import com.metabroadcast.common.base.Maybe;
-import com.metabroadcast.common.stream.MoreCollectors;
-
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
@@ -168,12 +168,15 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
             }
             desc.startStage("Resolving candidate schedule for " + candidateScheduleChannel.channel().getUri());
             Item[] candidateItemArray = candidateItemList.toArray(new Item[0]);
+            desc.startStage("Finding a suitable item in the candidate schedule");
             int candidateItemIndex = findSuitableCandidateInArray(candidateItemArray, subject, subjectBroadcast, desc);
             if (candidateItemIndex < 0) {
                 desc.appendText("Could not find a suitable item in the candidate schedule");
                 desc.finishStage();
                 continue;
             }
+            desc.finishStage();
+            desc.startStage("Determining candidate from schedule");
             Optional<Item> foundCandidate = findCandidate(
                     subjectItemArray,
                     subjectItemIndex,
@@ -186,17 +189,16 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
                 desc.finishStage();
                 continue;
             }
+            desc.finishStage();
 
             Item candidate = foundCandidate.get();
             if(candidate.isActivelyPublished()) {
                 Broadcast candidateBroadcast = getBroadcastFromScheduleItem(candidate, desc);
                 desc.appendText(
-                        String.format(
-                                "Found candidate %s with broadcast [%s - %s]",
-                                candidate.getCanonicalUri(),
-                                candidateBroadcast.getTransmissionTime(),
-                                candidateBroadcast.getTransmissionEndTime()
-                        )
+                        "Found candidate %s with broadcast [%s - %s]",
+                        candidate.getCanonicalUri(),
+                        candidateBroadcast.getTransmissionTime(),
+                        candidateBroadcast.getTransmissionEndTime()
                 );
                 //we want the maximum score for this scorer to be scoreOnMatch, so we update the
                 //score of a candidate instead of adding it up via the usual .addEquivalent()
@@ -310,7 +312,7 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
         //The schedule resolver should return items each with a single broadcast corresponding to their schedule slot
         if (broadcasts.size() != 1) {
             desc.appendText(
-                    "Expected one but found multiple broadcasts for schedule item with uri: " + item.getCanonicalUri());
+                    "Expected one broadcast but found multiple for schedule item %s", item.getCanonicalUri());
         }
         return broadcasts.get(0);
     }

--- a/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
@@ -138,7 +138,7 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
                         "%s [%s - %s]",
                         subjectBroadcast.getBroadcastOn(),
                         subjectBroadcast.getTransmissionTime(),
-                        subjectBroadcast.getActualTransmissionEndTime())
+                        subjectBroadcast.getTransmissionEndTime())
         );
         Set<String> channelUris = expandChannelUris(subjectBroadcast.getBroadcastOn());
         Schedule subjectSchedule = scheduleAround(

--- a/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
@@ -176,6 +176,7 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
             if (candidateItemIndex < 0) {
                 desc.appendText("Could not find a suitable item in the candidate schedule");
                 desc.finishStage();
+                desc.finishStage();
                 continue;
             }
             desc.finishStage();

--- a/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
@@ -158,8 +158,11 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
             return;
         }
         for (ScheduleChannel candidateScheduleChannel : candidateSchedule.scheduleChannels()) {
-            desc.startStage("Resolving candidate schedule for " + candidateScheduleChannel.channel().getUri());
             List<Item> candidateItemList = candidateScheduleChannel.items();
+            if (candidateItemList.isEmpty()) {
+                continue;
+            }
+            desc.startStage("Resolving candidate schedule for " + candidateScheduleChannel.channel().getUri());
             Item[] candidateItemArray = candidateItemList.toArray(new Item[0]);
             int candidateItemIndex = findSuitableCandidateInArray(candidateItemArray, subject, subjectBroadcast, desc);
             if (candidateItemIndex < 0) {
@@ -193,6 +196,7 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
                     );
                 }
             }
+            desc.finishStage();
         }
         desc.finishStage();
     }

--- a/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
@@ -171,16 +171,12 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
             }
             desc.startStage("Resolving candidate schedule for " + candidateScheduleChannel.channel().getUri());
             Item[] candidateItemArray = candidateItemList.toArray(new Item[0]);
-            desc.startStage("Finding a suitable item in the candidate schedule");
             int candidateItemIndex = findSuitableCandidateInArray(candidateItemArray, subject, subjectBroadcast, nopDesc);
             if (candidateItemIndex < 0) {
                 desc.appendText("Could not find a suitable item in the candidate schedule");
                 desc.finishStage();
-                desc.finishStage();
                 continue;
             }
-            desc.finishStage();
-            desc.startStage("Determining candidate from schedule");
             Optional<Item> foundCandidate = findCandidate(
                     subjectItemArray,
                     subjectItemIndex,
@@ -191,10 +187,8 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
             if (!foundCandidate.isPresent()) {
                 desc.appendText("Could not determine candidate from schedule");
                 desc.finishStage();
-                desc.finishStage();
                 continue;
             }
-            desc.finishStage();
 
             Item candidate = foundCandidate.get();
             if(candidate.isActivelyPublished()) {

--- a/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
+++ b/src/main/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.java
@@ -1,9 +1,11 @@
 package org.atlasapi.equiv.generators.barb;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
-import com.metabroadcast.common.base.Maybe;
-import com.metabroadcast.common.stream.MoreCollectors;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+
 import org.atlasapi.equiv.generators.BroadcastMatchingItemEquivalenceGeneratorAndScorer;
 import org.atlasapi.equiv.generators.EquivalenceGenerator;
 import org.atlasapi.equiv.generators.metadata.EquivalenceGeneratorMetadata;
@@ -25,16 +27,16 @@ import org.atlasapi.media.entity.Schedule;
 import org.atlasapi.media.entity.Schedule.ScheduleChannel;
 import org.atlasapi.media.entity.Version;
 import org.atlasapi.persistence.content.ScheduleResolver;
+
+import com.metabroadcast.common.base.Maybe;
+import com.metabroadcast.common.stream.MoreCollectors;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.Predicate;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -379,9 +381,7 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
             candidatePreviousBlockEnd--;
         }
 
-        if ((subjectPreviousBlockEnd < 0 && candidatePreviousBlockEnd >= 0)
-                || (candidatePreviousBlockEnd < 0 && subjectPreviousBlockEnd >= 0)
-        ) {
+        if ((subjectPreviousBlockEnd < 0 || candidatePreviousBlockEnd < 0)) {
             return Optional.empty();
         }
 
@@ -409,9 +409,8 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer implements E
             candidateNextBlockStart++;
         }
 
-        if ((subjectNextBlockStart >= subjectItemArray.length && candidateNextBlockStart < candidateItemArray.length)
-                || (candidateNextBlockStart >= candidateItemArray.length && subjectNextBlockStart < subjectItemArray.length)
-        ) {
+        if (subjectNextBlockStart >= subjectItemArray.length
+            || candidateNextBlockStart >= candidateItemArray.length) {
             return Optional.empty();
         }
 

--- a/src/main/java/org/atlasapi/equiv/results/description/NopDescription.java
+++ b/src/main/java/org/atlasapi/equiv/results/description/NopDescription.java
@@ -1,0 +1,40 @@
+package org.atlasapi.equiv.results.description;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+/**
+ * Implementation which can be used to suppress text when not desired.
+ */
+public class NopDescription implements ReadableDescription {
+
+    public NopDescription() {
+
+    }
+
+    @Override
+    public NopDescription appendText(String format, Object... args) {
+        return this;
+    }
+
+    @Override
+    public ResultDescription startStage(String stageName) {
+        return this;
+    }
+
+    @Override
+    public ResultDescription finishStage() {
+        return this;
+    }
+
+    @Override
+    public List<Object> parts() {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public String toString() {
+        return "";
+    }
+}

--- a/src/main/java/org/atlasapi/equiv/scorers/barb/BarbTitleMatchingItemScorer.java
+++ b/src/main/java/org/atlasapi/equiv/scorers/barb/BarbTitleMatchingItemScorer.java
@@ -234,15 +234,6 @@ public class BarbTitleMatchingItemScorer implements EquivalenceScorer<Item> {
         Content compareTo = suggestionParent.isPresent() ? suggestionParent.get() : suggestion;
 
         Score parentScore = scoreContent(compareFrom, compareTo, desc);
-        desc.appendText(
-                String.format(
-                        "%s (for %s) against %s (for %s) scored %.2f",
-                        compareFrom.getCanonicalUri(),
-                        subject.getCanonicalUri(),
-                        compareTo.getCanonicalUri(),
-                        suggestion.getCanonicalUri(),
-                        parentScore.asDouble()
-                ));
         return Optional.of(parentScore);
     }
 
@@ -250,10 +241,16 @@ public class BarbTitleMatchingItemScorer implements EquivalenceScorer<Item> {
         Score score = Score.nullScore();
         if (!Strings.isNullOrEmpty(subject.getTitle())) {
             if (Strings.isNullOrEmpty(suggestion.getTitle())) {
-                desc.appendText("No Title (%s) scored: %s", suggestion.getCanonicalUri(), score);
+                desc.appendText("No Title (%s) scored %s", suggestion.getCanonicalUri(), score);
             } else {
                 score = scoreContent(subject, suggestion);
-                desc.appendText("%s (%s) scored: %s", suggestion.getTitle(), suggestion.getCanonicalUri(), score);
+                desc.appendText("%s (%s) against %s (%s) scored %s",
+                        suggestion.getTitle(),
+                        suggestion.getCanonicalUri(),
+                        subject.getTitle(),
+                        subject.getCanonicalUri(),
+                        score
+                );
             }
         }
         return score;

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BbcTxlogsItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BbcTxlogsItemUpdaterProvider.java
@@ -71,6 +71,7 @@ public class BbcTxlogsItemUpdaterProvider implements EquivalenceResultUpdaterPro
                                                 .withScoreOnMismatch(Score.nullScore())
                                                 .withScoreOnPartialMatch(Score.nullScore())
                                                 .withScoreOnPerfectMatch(Score.ONE)
+                                                .withContainerCacheDuration(60)
                                                 .build()
                                 ),
                                 new BarbBbcActualTransmissionItemEquivalenceGeneratorAndScorer(
@@ -94,6 +95,7 @@ public class BbcTxlogsItemUpdaterProvider implements EquivalenceResultUpdaterPro
                                         .withScoreOnPerfectMatch(Score.valueOf(2.0))
                                         .withScoreOnPartialMatch(Score.ONE)
                                         .withScoreOnMismatch(Score.ZERO)
+                                        .withContainerCacheDuration(60)
                                         .build(),
                                 DescriptionMatchingScorer.makeScorer()
                         )

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BbcTxlogsItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BbcTxlogsItemUpdaterProvider.java
@@ -72,6 +72,7 @@ public class BbcTxlogsItemUpdaterProvider implements EquivalenceResultUpdaterPro
                                                 .withScoreOnPartialMatch(Score.nullScore())
                                                 .withScoreOnPerfectMatch(Score.ONE)
                                                 .withContainerCacheDuration(60)
+                                                .withCheckContainersForAllPublishers(true)
                                                 .build()
                                 ),
                                 new BarbBbcActualTransmissionItemEquivalenceGeneratorAndScorer(
@@ -96,6 +97,7 @@ public class BbcTxlogsItemUpdaterProvider implements EquivalenceResultUpdaterPro
                                         .withScoreOnPartialMatch(Score.ONE)
                                         .withScoreOnMismatch(Score.ZERO)
                                         .withContainerCacheDuration(60)
+                                        .withCheckContainersForAllPublishers(false)
                                         .build(),
                                 DescriptionMatchingScorer.makeScorer()
                         )

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BbcTxlogsItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BbcTxlogsItemUpdaterProvider.java
@@ -1,7 +1,7 @@
 package org.atlasapi.equiv.update.updaters.providers.item;
 
-import java.util.Set;
-
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.atlasapi.equiv.generators.barb.BarbAliasEquivalenceGeneratorAndScorer;
 import org.atlasapi.equiv.generators.barb.BarbBbcActualTransmissionItemEquivalenceGeneratorAndScorer;
 import org.atlasapi.equiv.generators.barb.BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer;
@@ -26,12 +26,9 @@ import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDe
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.persistence.lookup.mongo.MongoLookupEntryStore;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import org.joda.time.Duration;
 
-import static org.atlasapi.equiv.generators.barb.utils.BarbGeneratorUtils.minimumDuration;
+import java.util.Set;
 
 public class BbcTxlogsItemUpdaterProvider implements EquivalenceResultUpdaterProvider<Item> {
 
@@ -66,10 +63,15 @@ public class BbcTxlogsItemUpdaterProvider implements EquivalenceResultUpdaterPro
                                         dependencies.getScheduleResolver(),
                                         dependencies.getChannelResolver(),
                                         targetPublishers,
-                                        Duration.standardMinutes(10),
-                                        minimumDuration(Duration.standardMinutes(5)),
+                                        Duration.standardHours(3),
+                                        null,
                                         Score.valueOf(3.0),
-                                        Score.nullScore()
+                                        BarbTitleMatchingItemScorer.builder()
+                                                .withContentResolver(dependencies.getContentResolver())
+                                                .withScoreOnMismatch(Score.nullScore())
+                                                .withScoreOnPartialMatch(Score.nullScore())
+                                                .withScoreOnPerfectMatch(Score.ONE)
+                                                .build()
                                 ),
                                 new BarbBbcActualTransmissionItemEquivalenceGeneratorAndScorer(
                                         dependencies.getScheduleResolver(),

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BbcTxlogsItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BbcTxlogsItemUpdaterProvider.java
@@ -59,22 +59,26 @@ public class BbcTxlogsItemUpdaterProvider implements EquivalenceResultUpdaterPro
                                         Score.ZERO,
                                         false
                                 ),
-                                new BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer(
-                                        dependencies.getScheduleResolver(),
-                                        dependencies.getChannelResolver(),
-                                        targetPublishers,
-                                        Duration.standardHours(1),
-                                        null,
-                                        Score.valueOf(3.0),
-                                        BarbTitleMatchingItemScorer.builder()
-                                                .withContentResolver(dependencies.getContentResolver())
-                                                .withScoreOnMismatch(Score.nullScore())
-                                                .withScoreOnPartialMatch(Score.nullScore())
-                                                .withScoreOnPerfectMatch(Score.ONE)
-                                                .withContainerCacheDuration(60)
-                                                .withCheckContainersForAllPublishers(true)
-                                                .build()
-                                ),
+                                BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.builder()
+                                        .withScheduleResolver(dependencies.getScheduleResolver())
+                                        .withChannelResolver(dependencies.getChannelResolver())
+                                        .withSupportedPublishers(targetPublishers)
+                                        .withScheduleWindow(Duration.standardHours(1))
+                                        .withBroadcastFlexibility(Duration.standardMinutes(10))
+                                        .withShortBroadcastFlexibility(Duration.standardMinutes(10))
+                                        .withShortBroadcastMaxDuration(Duration.standardMinutes(10))
+                                        .withScoreOnMatch(Score.valueOf(3.0))
+                                        .withTitleMatchingScorer(
+                                                BarbTitleMatchingItemScorer.builder()
+                                                        .withContentResolver(dependencies.getContentResolver())
+                                                        .withScoreOnMismatch(Score.nullScore())
+                                                        .withScoreOnPartialMatch(Score.nullScore())
+                                                        .withScoreOnPerfectMatch(Score.ONE)
+                                                        .withContainerCacheDuration(60)
+                                                        .withCheckContainersForAllPublishers(true)
+                                                        .build()
+                                        )
+                                        .build(),
                                 new BarbBbcActualTransmissionItemEquivalenceGeneratorAndScorer(
                                         dependencies.getScheduleResolver(),
                                         dependencies.getChannelResolver(),

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BbcTxlogsItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/BbcTxlogsItemUpdaterProvider.java
@@ -63,7 +63,7 @@ public class BbcTxlogsItemUpdaterProvider implements EquivalenceResultUpdaterPro
                                         dependencies.getScheduleResolver(),
                                         dependencies.getChannelResolver(),
                                         targetPublishers,
-                                        Duration.standardHours(3),
+                                        Duration.standardHours(1),
                                         null,
                                         Score.valueOf(3.0),
                                         BarbTitleMatchingItemScorer.builder()

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/barb/BarbBbcBroadcastItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/barb/BarbBbcBroadcastItemUpdaterProvider.java
@@ -26,8 +26,6 @@ import org.joda.time.Duration;
 
 import java.util.Set;
 
-import static org.atlasapi.equiv.generators.barb.utils.BarbGeneratorUtils.minimumDuration;
-
 public class BarbBbcBroadcastItemUpdaterProvider implements EquivalenceResultUpdaterProvider<Item> {
 
 
@@ -51,10 +49,15 @@ public class BarbBbcBroadcastItemUpdaterProvider implements EquivalenceResultUpd
                                 dependencies.getScheduleResolver(),
                                 dependencies.getChannelResolver(),
                                 targetPublishers,
-                                Duration.standardMinutes(10),
-                                minimumDuration(Duration.standardMinutes(5)),
+                                Duration.standardHours(3),
+                                null,
                                 Score.valueOf(3.0),
-                                Score.nullScore()
+                                BarbTitleMatchingItemScorer.builder()
+                                        .withContentResolver(dependencies.getContentResolver())
+                                        .withScoreOnMismatch(Score.nullScore())
+                                        .withScoreOnPartialMatch(Score.nullScore())
+                                        .withScoreOnPerfectMatch(Score.ONE)
+                                        .build()
                         )
                 )
                 .withScorers(

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/barb/BarbBbcBroadcastItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/barb/BarbBbcBroadcastItemUpdaterProvider.java
@@ -45,22 +45,26 @@ public class BarbBbcBroadcastItemUpdaterProvider implements EquivalenceResultUpd
                 .withExcludedUris(dependencies.getExcludedUris())
                 .withExcludedIds(dependencies.getExcludedIds())
                 .withGenerator(
-                        new BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer(
-                                dependencies.getScheduleResolver(),
-                                dependencies.getChannelResolver(),
-                                targetPublishers,
-                                Duration.standardHours(1),
-                                null,
-                                Score.valueOf(3.0),
-                                BarbTitleMatchingItemScorer.builder()
-                                        .withContentResolver(dependencies.getContentResolver())
-                                        .withScoreOnMismatch(Score.nullScore())
-                                        .withScoreOnPartialMatch(Score.nullScore())
-                                        .withScoreOnPerfectMatch(Score.ONE)
-                                        .withContainerCacheDuration(60)
-                                        .withCheckContainersForAllPublishers(true)
-                                        .build()
-                        )
+                        BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer.builder()
+                                .withScheduleResolver(dependencies.getScheduleResolver())
+                                .withChannelResolver(dependencies.getChannelResolver())
+                                .withSupportedPublishers(targetPublishers)
+                                .withScheduleWindow(Duration.standardHours(1))
+                                .withBroadcastFlexibility(Duration.standardMinutes(10))
+                                .withShortBroadcastFlexibility(Duration.standardMinutes(10))
+                                .withShortBroadcastMaxDuration(Duration.standardMinutes(10))
+                                .withScoreOnMatch(Score.valueOf(3.0))
+                                .withTitleMatchingScorer(
+                                        BarbTitleMatchingItemScorer.builder()
+                                                .withContentResolver(dependencies.getContentResolver())
+                                                .withScoreOnMismatch(Score.nullScore())
+                                                .withScoreOnPartialMatch(Score.nullScore())
+                                                .withScoreOnPerfectMatch(Score.ONE)
+                                                .withContainerCacheDuration(60)
+                                                .withCheckContainersForAllPublishers(true)
+                                                .build()
+                                )
+                                .build()
                 )
                 .withScorers(
                         ImmutableSet.of(

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/barb/BarbBbcBroadcastItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/barb/BarbBbcBroadcastItemUpdaterProvider.java
@@ -58,6 +58,7 @@ public class BarbBbcBroadcastItemUpdaterProvider implements EquivalenceResultUpd
                                         .withScoreOnPartialMatch(Score.nullScore())
                                         .withScoreOnPerfectMatch(Score.ONE)
                                         .withContainerCacheDuration(60)
+                                        .withCheckContainersForAllPublishers(true)
                                         .build()
                         )
                 )
@@ -69,6 +70,7 @@ public class BarbBbcBroadcastItemUpdaterProvider implements EquivalenceResultUpd
                                         .withScoreOnPartialMatch(Score.ONE)
                                         .withScoreOnMismatch(Score.ZERO)
                                         .withContainerCacheDuration(60)
+                                        .withCheckContainersForAllPublishers(false)
                                         .build(),
                                 DescriptionMatchingScorer.makeScorer()
                         )

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/barb/BarbBbcBroadcastItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/barb/BarbBbcBroadcastItemUpdaterProvider.java
@@ -57,6 +57,7 @@ public class BarbBbcBroadcastItemUpdaterProvider implements EquivalenceResultUpd
                                         .withScoreOnMismatch(Score.nullScore())
                                         .withScoreOnPartialMatch(Score.nullScore())
                                         .withScoreOnPerfectMatch(Score.ONE)
+                                        .withContainerCacheDuration(60)
                                         .build()
                         )
                 )
@@ -67,6 +68,7 @@ public class BarbBbcBroadcastItemUpdaterProvider implements EquivalenceResultUpd
                                         .withScoreOnPerfectMatch(Score.valueOf(2.0))
                                         .withScoreOnPartialMatch(Score.ONE)
                                         .withScoreOnMismatch(Score.ZERO)
+                                        .withContainerCacheDuration(60)
                                         .build(),
                                 DescriptionMatchingScorer.makeScorer()
                         )

--- a/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/barb/BarbBbcBroadcastItemUpdaterProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/providers/item/barb/BarbBbcBroadcastItemUpdaterProvider.java
@@ -49,7 +49,7 @@ public class BarbBbcBroadcastItemUpdaterProvider implements EquivalenceResultUpd
                                 dependencies.getScheduleResolver(),
                                 dependencies.getChannelResolver(),
                                 targetPublishers,
-                                Duration.standardHours(3),
+                                Duration.standardHours(1),
                                 null,
                                 Score.valueOf(3.0),
                                 BarbTitleMatchingItemScorer.builder()

--- a/src/test/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest.java
@@ -9,6 +9,7 @@ import com.metabroadcast.common.base.Maybe;
 import com.metabroadcast.common.stream.MoreCollectors;
 import org.atlasapi.equiv.generators.barb.utils.BarbGeneratorUtils;
 import org.atlasapi.equiv.results.description.DefaultDescription;
+import org.atlasapi.equiv.results.description.ResultDescription;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
 import org.atlasapi.equiv.scorers.barb.BarbTitleMatchingItemScorer;
@@ -187,7 +188,7 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest {
                 )
         );
 
-        when(titleMatchingScorer.score(any(Item.class), any(Item.class))).thenReturn(Score.ONE);
+        when(titleMatchingScorer.score(any(Item.class), any(Item.class), any(ResultDescription.class))).thenReturn(Score.ONE);
 
         ScoredCandidates<Item> equivalents = generator.generate(
                 item1,
@@ -255,7 +256,7 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest {
                 )
         );
 
-        when(titleMatchingScorer.score(any(Item.class), any(Item.class))).thenReturn(Score.ONE);
+        when(titleMatchingScorer.score(any(Item.class), any(Item.class), any(ResultDescription.class))).thenReturn(Score.ONE);
 
 
         ScoredCandidates<Item> equivalents = generator.generate(
@@ -341,7 +342,7 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest {
                 )
         );
 
-        when(titleMatchingScorer.score(any(Item.class), any(Item.class))).thenReturn(Score.ONE);
+        when(titleMatchingScorer.score(any(Item.class), any(Item.class), any(ResultDescription.class))).thenReturn(Score.ONE);
 
         ScoredCandidates<Item> equivalents = generator.generate(
                 nitroItem,
@@ -506,26 +507,28 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest {
                 similarAfterCandidateInSeparateBlock
         );
 
-        when(titleMatchingScorer.score(subject, similarBeforeSubject)).thenReturn(Score.ONE);
-        when(titleMatchingScorer.score(subject, similarBeforeSubject2)).thenReturn(Score.ONE);
-        when(titleMatchingScorer.score(subject, similarAfterSubject)).thenReturn(Score.ONE);
-        when(titleMatchingScorer.score(subject, previousUnrelatedToSubject)).thenReturn(Score.nullScore());
-        when(titleMatchingScorer.score(subject, nextUnrelatedToSubject)).thenReturn(Score.nullScore());
+        ResultDescription desc = new DefaultDescription();
 
-        when(titleMatchingScorer.score(subject, candidate)).thenReturn(Score.ONE);
-        when(titleMatchingScorer.score(subject, similarBeforeCandidate)).thenReturn(Score.ONE);
-        when(titleMatchingScorer.score(subject, similarBeforeCandidate2)).thenReturn(Score.ONE);
-        when(titleMatchingScorer.score(subject, similarAfterCandidate)).thenReturn(Score.ONE);
-        when(titleMatchingScorer.score(subject, previousUnrelatedToCandidate)).thenReturn(Score.nullScore());
-        when(titleMatchingScorer.score(subject, nextUnrelatedToCandidate)).thenReturn(Score.nullScore());
-        when(titleMatchingScorer.score(subject, similarAfterCandidateInSeparateBlock)).thenReturn(Score.ONE);
+        when(titleMatchingScorer.score(subject, similarBeforeSubject, desc)).thenReturn(Score.ONE);
+        when(titleMatchingScorer.score(subject, similarBeforeSubject2, desc)).thenReturn(Score.ONE);
+        when(titleMatchingScorer.score(subject, similarAfterSubject, desc)).thenReturn(Score.ONE);
+        when(titleMatchingScorer.score(subject, previousUnrelatedToSubject, desc)).thenReturn(Score.nullScore());
+        when(titleMatchingScorer.score(subject, nextUnrelatedToSubject, desc)).thenReturn(Score.nullScore());
 
-        when(titleMatchingScorer.score(similarBeforeCandidate, similarBeforeCandidate2)).thenReturn(Score.ONE);
-        when(titleMatchingScorer.score(similarBeforeCandidate, candidate)).thenReturn(Score.ONE);
-        when(titleMatchingScorer.score(similarBeforeCandidate, similarAfterCandidate)).thenReturn(Score.ONE);
-        when(titleMatchingScorer.score(similarBeforeCandidate, previousUnrelatedToCandidate)).thenReturn(Score.nullScore());
-        when(titleMatchingScorer.score(similarBeforeCandidate, nextUnrelatedToCandidate)).thenReturn(Score.nullScore());
-        when(titleMatchingScorer.score(similarBeforeCandidate, similarAfterCandidateInSeparateBlock)).thenReturn(Score.ONE);
+        when(titleMatchingScorer.score(subject, candidate, desc)).thenReturn(Score.ONE);
+        when(titleMatchingScorer.score(subject, similarBeforeCandidate, desc)).thenReturn(Score.ONE);
+        when(titleMatchingScorer.score(subject, similarBeforeCandidate2, desc)).thenReturn(Score.ONE);
+        when(titleMatchingScorer.score(subject, similarAfterCandidate, desc)).thenReturn(Score.ONE);
+        when(titleMatchingScorer.score(subject, previousUnrelatedToCandidate, desc)).thenReturn(Score.nullScore());
+        when(titleMatchingScorer.score(subject, nextUnrelatedToCandidate, desc)).thenReturn(Score.nullScore());
+        when(titleMatchingScorer.score(subject, similarAfterCandidateInSeparateBlock, desc)).thenReturn(Score.ONE);
+
+        when(titleMatchingScorer.score(similarBeforeCandidate, similarBeforeCandidate2, desc)).thenReturn(Score.ONE);
+        when(titleMatchingScorer.score(similarBeforeCandidate, candidate, desc)).thenReturn(Score.ONE);
+        when(titleMatchingScorer.score(similarBeforeCandidate, similarAfterCandidate, desc)).thenReturn(Score.ONE);
+        when(titleMatchingScorer.score(similarBeforeCandidate, previousUnrelatedToCandidate, desc)).thenReturn(Score.nullScore());
+        when(titleMatchingScorer.score(similarBeforeCandidate, nextUnrelatedToCandidate, desc)).thenReturn(Score.nullScore());
+        when(titleMatchingScorer.score(similarBeforeCandidate, similarAfterCandidateInSeparateBlock, desc)).thenReturn(Score.ONE);
 
         when(
                 resolver.unmergedSchedule(
@@ -553,7 +556,7 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest {
 
         ScoredCandidates<Item> equivalents = generator.generate(
                 subject,
-                new DefaultDescription(),
+                desc,
                 EquivToTelescopeResult.create("id", "publisher")
         );
 

--- a/src/test/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest.java
@@ -3,14 +3,15 @@ package org.atlasapi.equiv.generators.barb;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.metabroadcast.common.base.Maybe;
 import com.metabroadcast.common.stream.MoreCollectors;
-import com.metabroadcast.common.time.DateTimeZones;
 import org.atlasapi.equiv.generators.barb.utils.BarbGeneratorUtils;
 import org.atlasapi.equiv.results.description.DefaultDescription;
 import org.atlasapi.equiv.results.scores.Score;
 import org.atlasapi.equiv.results.scores.ScoredCandidates;
+import org.atlasapi.equiv.scorers.barb.BarbTitleMatchingItemScorer;
 import org.atlasapi.equiv.update.metadata.EquivToTelescopeResult;
 import org.atlasapi.media.channel.Channel;
 import org.atlasapi.media.channel.ChannelResolver;
@@ -27,16 +28,21 @@ import org.joda.time.Interval;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static org.atlasapi.media.entity.Publisher.BARB_TRANSMISSIONS;
 import static org.atlasapi.media.entity.Publisher.BBC;
 import static org.atlasapi.media.entity.Publisher.BBC_NITRO;
+import static org.atlasapi.media.entity.Publisher.PA;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.joda.time.Duration.standardHours;
 import static org.joda.time.Duration.standardMinutes;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -92,12 +98,13 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest {
     private static final Set<Publisher> PUBLISHERS = ImmutableSet.of(BBC, BBC_NITRO, BARB_TRANSMISSIONS);
     private static final Score SCORE_ON_MATCH = Score.ONE;
 
+    private final ChannelResolver channelResolver = mock(ChannelResolver.class);
     private final ScheduleResolver resolver = mock(ScheduleResolver.class);
+    private final BarbTitleMatchingItemScorer titleMatchingScorer = mock(BarbTitleMatchingItemScorer.class);
     private BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer generator;
 
     @Before
     public void setUp() {
-        final ChannelResolver channelResolver = mock(ChannelResolver.class);
 
         when(channelResolver.fromUri(BBC_ONE.getUri())).thenReturn(Maybe.just(BBC_ONE));
         when(channelResolver.fromUri(BBC_ONE_CAMBRIDGE.getUri())).thenReturn(Maybe.just(BBC_ONE_CAMBRIDGE));
@@ -110,50 +117,77 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest {
                 resolver,
                 channelResolver,
                 PUBLISHERS,
-                standardMinutes(1),
+                standardHours(1),
                 null,
                 SCORE_ON_MATCH,
-                Score.valueOf(0.1)
+                titleMatchingScorer
         );
     }
 
     @Test
     public void testGenerateEquivalencesForOneMatchingBroadcast() {
         final Item item1 = episodeWithBroadcasts("subjectItem", Publisher.PA,
-                new Broadcast(BBC_ONE.getUri(), utcTime(100000), utcTime(2000000)),
-                new Broadcast(BBC_ONE_CAMBRIDGE.getUri(), utcTime(100000), utcTime(2000000)));
+                new Broadcast(BBC_ONE.getUri(), time("2014-03-21T15:00:00Z"), time("2014-03-21T16:00:00Z")),
+                new Broadcast(BBC_ONE_CAMBRIDGE.getUri(), time("2014-03-21T15:00:00Z"), time("2014-03-21T16:00:00Z"))
+        );
 
         final Item item2 = episodeWithBroadcasts(
                 "equivItem",
                 BBC,
-                new Broadcast(BBC_ONE.getUri(), utcTime(100000), utcTime(2000000))
+                new Broadcast(BBC_ONE.getUri(), time("2014-03-21T15:00:00Z"), time("2014-03-21T16:00:00Z"))
         );
 
         when(
                 resolver.unmergedSchedule(
-                        utcTime(40000),
-                        utcTime(2060000),
+                        time("2014-03-21T14:00:00Z"),
+                        time("2014-03-21T17:00:00Z"),
+                        ImmutableSet.of(BBC_ONE), ImmutableSet.of(PA))
+        ).thenReturn(
+                Schedule.fromChannelMap(
+                        ImmutableMap.of(BBC_ONE, ImmutableList.of(item1)),
+                        interval("2014-03-21T14:00:00Z", "2014-03-21T17:00:00Z")
+                )
+        );
+
+        when(
+                resolver.unmergedSchedule(
+                        time("2014-03-21T14:00:00Z"),
+                        time("2014-03-21T17:00:00Z"),
+                        ImmutableSet.of(BBC_ONE_CAMBRIDGE), ImmutableSet.of(PA))
+        ).thenReturn(
+                Schedule.fromChannelMap(
+                        ImmutableMap.of(BBC_ONE_CAMBRIDGE, ImmutableList.of(item1)),
+                        interval("2014-03-21T14:00:00Z", "2014-03-21T17:00:00Z")
+                )
+        );
+
+        when(
+                resolver.unmergedSchedule(
+                        time("2014-03-21T14:00:00Z"),
+                        time("2014-03-21T17:00:00Z"),
                         ImmutableSet.of(BBC_ONE),
                         PUBLISHERS)
         ).thenReturn(
                 Schedule.fromChannelMap(
                         ImmutableMap.of(BBC_ONE, ImmutableList.of(item2)),
-                        interval(40000, 2060000)
+                        interval("2014-03-21T14:00:00Z", "2014-03-21T17:00:00Z")
                 )
         );
         when(
                 resolver.unmergedSchedule(
-                        utcTime(40000),
-                        utcTime(2060000),
+                        time("2014-03-21T14:00:00Z"),
+                        time("2014-03-21T17:00:00Z"),
                         ImmutableSet.of(BBC_ONE_CAMBRIDGE),
                         PUBLISHERS
                 )
         ).thenReturn(
                 Schedule.fromChannelMap(
                         ImmutableMap.of(BBC_ONE_CAMBRIDGE, ImmutableList.of()),
-                        interval(40000, 2060000)
+                        interval("2014-03-21T14:00:00Z", "2014-03-21T17:00:00Z")
                 )
         );
+
+        when(titleMatchingScorer.score(any(Item.class), any(Item.class))).thenReturn(Score.ONE);
 
         ScoredCandidates<Item> equivalents = generator.generate(
                 item1,
@@ -182,12 +216,12 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest {
                         standardMinutes(10),
                         null,
                         SCORE_ON_MATCH,
-                        Score.valueOf(0.1)
+                        titleMatchingScorer
                 );
 
         final Item item1 = episodeWithBroadcasts(
                 "subjectItem",
-                Publisher.PA,
+                PA,
                 new Broadcast(BBC_ONE.getUri(), time("2014-03-21T15:00:00Z"), time("2014-03-21T15:50:00Z"))
         );
 
@@ -201,13 +235,28 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest {
                 resolver.unmergedSchedule(
                         time("2014-03-21T14:50:00Z"),
                         time("2014-03-21T16:00:00Z"),
+                        ImmutableSet.of(BBC_ONE), ImmutableSet.of(PA))
+        ).thenReturn(
+                Schedule.fromChannelMap(
+                        ImmutableMap.of(BBC_ONE, ImmutableList.of(item1)),
+                        interval("2014-03-21T14:50:00Z", "2014-03-21T16:00:00Z")
+                )
+        );
+
+        when(
+                resolver.unmergedSchedule(
+                        time("2014-03-21T14:50:00Z"),
+                        time("2014-03-21T16:00:00Z"),
                         ImmutableSet.of(BBC_ONE), ImmutableSet.of(BBC))
         ).thenReturn(
                 Schedule.fromChannelMap(
                         ImmutableMap.of(BBC_ONE, ImmutableList.of(item2)),
-                        interval(40000, 260000)
+                        interval("2014-03-21T14:50:00Z", "2014-03-21T16:00:00Z")
                 )
         );
+
+        when(titleMatchingScorer.score(any(Item.class), any(Item.class))).thenReturn(Score.ONE);
+
 
         ScoredCandidates<Item> equivalents = generator.generate(
                 item1,
@@ -221,12 +270,8 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest {
         assertThat(scoreMap.get(item2).asDouble(), is(equalTo(1.0)));
     }
 
-    private Interval interval(long startMillis, long endMillis) {
-        return new Interval(startMillis, endMillis, DateTimeZones.UTC);
-    }
-
-    private DateTime utcTime(long millis) {
-        return new DateTime(millis, DateTimeZones.UTC);
+    private Interval interval(String startDate, String endDate) {
+        return new Interval(time(startDate), time(endDate));
     }
 
     private DateTime time(String date) {
@@ -246,67 +291,40 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest {
     }
 
     @Test
-    public void broadcastsWithDurationLessThanTenMinutesHaveLowerFlexibility() {
-        Item item1 = episodeWithBroadcasts(
-                "subjectitem",
-                Publisher.PA,
-                new Broadcast(BBC_ONE_CAMBRIDGE.getUri(), utcTime(1000000), utcTime(1200000))
-        );
-
-        Item item2 = episodeWithBroadcasts(
-                "equivitem",
-                BBC,
-                new Broadcast(BBC_ONE_CAMBRIDGE.getUri(), utcTime(1000000), utcTime(1200000))
-        );
-
-        when(
-                resolver.unmergedSchedule(
-                        utcTime(880000),
-                        utcTime(1320000),
-                        ImmutableSet.of(BBC_ONE_CAMBRIDGE),
-                        PUBLISHERS)
-        ).thenReturn(
-                Schedule.fromChannelMap(
-                        ImmutableMap.of(BBC_ONE_CAMBRIDGE, ImmutableList.of(item2)),
-                        interval(880000, 1320000)
-                )
-        );
-
-        ScoredCandidates<Item> equivalents = generator.generate(
-                item1,
-                new DefaultDescription(),
-                EquivToTelescopeResult.create("id", "publisher")
-        );
-
-        Map<Item, Score> scoreMap = equivalents.candidates();
-
-        assertThat(scoreMap.size(), is(1));
-        assertThat(scoreMap.get(item2).asDouble(), is(equalTo(1.0)));
-    }
-
-    @Test
     public void testGenerateEquivalencesForBbcTwoEnglandTxlogVariants() {
         final Item nitroItem = episodeWithBroadcasts(
                 "subjectItem",
                 BBC_NITRO,
-                new Broadcast(BBC_TWO_ENGLAND.getUri(), utcTime(100000), utcTime(2000000))
+                new Broadcast(BBC_TWO_ENGLAND.getUri(), time("2014-03-21T15:00:00Z"), time("2014-03-21T16:00:00Z"))
         );
 
         final Item txlogItem1 = episodeWithBroadcasts(
                 "equivItem1",
                 BARB_TRANSMISSIONS,
-                new Broadcast(BBC_TWO_SOUTH_TXLOG.getUri(), utcTime(100000), utcTime(2000000))
+                new Broadcast(BBC_TWO_SOUTH_TXLOG.getUri(), time("2014-03-21T15:00:00Z"), time("2014-03-21T16:00:00Z"))
         );
         final Item txlogItem2 = episodeWithBroadcasts(
                 "equivItem2",
                 BARB_TRANSMISSIONS,
-                new Broadcast(BBC_TWO_EAST_TXLOG.getUri(), utcTime(100000), utcTime(2000000))
+                new Broadcast(BBC_TWO_EAST_TXLOG.getUri(), time("2014-03-21T15:00:00Z"), time("2014-03-21T16:00:00Z"))
         );
 
         when(
                 resolver.unmergedSchedule(
-                        utcTime(40000),
-                        utcTime(2060000),
+                        time("2014-03-21T14:00:00Z"),
+                        time("2014-03-21T17:00:00Z"),
+                        ImmutableSet.of(BBC_TWO_ENGLAND), ImmutableSet.of(BBC_NITRO))
+        ).thenReturn(
+                Schedule.fromChannelMap(
+                        ImmutableMap.of(BBC_TWO_ENGLAND, ImmutableList.of(nitroItem)),
+                        interval("2014-03-21T14:00:00Z", "2014-03-21T17:00:00Z")
+                )
+        );
+
+        when(
+                resolver.unmergedSchedule(
+                        time("2014-03-21T14:00:00Z"),
+                        time("2014-03-21T17:00:00Z"),
                         ImmutableSet.<Channel>builder()
                                 .add(BBC_TWO_ENGLAND)
                                 .addAll(BBC_TWO_ENGLAND_TXLOG_CHANNEL_MAP.values())
@@ -319,25 +337,11 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest {
                                 BBC_TWO_SOUTH_TXLOG, ImmutableList.of(txlogItem1),
                                 BBC_TWO_EAST_TXLOG, ImmutableList.of(txlogItem2)
                         ),
-                        interval(40000, 2060000)
+                        interval("2014-03-21T14:00:00Z", "2014-03-21T17:00:00Z")
                 )
         );
 
-        when(
-                resolver.unmergedSchedule(
-                        utcTime(40000),
-                        utcTime(2060000),
-                        ImmutableSet.of(BBC_TWO_ENGLAND, BBC_TWO_SOUTH_TXLOG),
-                        Sets.difference(PUBLISHERS, ImmutableSet.of(BARB_TRANSMISSIONS))
-                )
-        ).thenReturn(
-                Schedule.fromChannelMap(
-                        ImmutableMap.of(
-                                BBC_TWO_ENGLAND, ImmutableList.of(nitroItem)
-                        ),
-                        interval(40000, 2060000)
-                )
-        );
+        when(titleMatchingScorer.score(any(Item.class), any(Item.class))).thenReturn(Score.ONE);
 
         ScoredCandidates<Item> equivalents = generator.generate(
                 nitroItem,
@@ -351,6 +355,34 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest {
         assertThat(scoreMap.get(txlogItem1), is(SCORE_ON_MATCH));
         assertThat(scoreMap.get(txlogItem2), is(SCORE_ON_MATCH));
 
+        when(
+                resolver.unmergedSchedule(
+                        time("2014-03-21T14:00:00Z"),
+                        time("2014-03-21T17:00:00Z"),
+                        ImmutableSet.of(BBC_TWO_SOUTH_TXLOG), ImmutableSet.of(BARB_TRANSMISSIONS))
+        ).thenReturn(
+                Schedule.fromChannelMap(
+                        ImmutableMap.of(BBC_TWO_SOUTH_TXLOG, ImmutableList.of(txlogItem1)),
+                        interval("2014-03-21T14:00:00Z", "2014-03-21T17:00:00Z")
+                )
+        );
+
+        when(
+                resolver.unmergedSchedule(
+                        time("2014-03-21T14:00:00Z"),
+                        time("2014-03-21T17:00:00Z"),
+                        ImmutableSet.of(BBC_TWO_ENGLAND, BBC_TWO_SOUTH_TXLOG),
+                        Sets.difference(PUBLISHERS, ImmutableSet.of(BARB_TRANSMISSIONS))
+                )
+        ).thenReturn(
+                Schedule.fromChannelMap(
+                        ImmutableMap.of(
+                                BBC_TWO_ENGLAND, ImmutableList.of(nitroItem)
+                        ),
+                        interval("2014-03-21T14:00:00Z", "2014-03-21T17:00:00Z")
+                )
+        );
+
         equivalents = generator.generate(
                 txlogItem1,
                 new DefaultDescription(),
@@ -362,4 +394,175 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest {
         assertThat(scoreMap.size(), is(1));
         assertThat(scoreMap.get(nitroItem), is(SCORE_ON_MATCH));
     }
+
+
+    @Test
+    public void testOffsetScheduleMatchesCorrectEntryInBlock() {
+        generator = new BarbBroadcastMatchingItemEquivalenceGeneratorAndScorer(
+                resolver,
+                channelResolver,
+                PUBLISHERS,
+                standardHours(3),
+                null,
+                SCORE_ON_MATCH,
+                titleMatchingScorer
+        );
+
+        final Item previousUnrelatedToSubject = episodeWithBroadcasts(
+                "unrelatedItem1",
+                Publisher.PA,
+                new Broadcast(BBC_ONE.getUri(), time("2014-03-21T13:00:00Z"), time("2014-03-21T14:20:00Z"))
+        );
+
+        final Item similarBeforeSubject = episodeWithBroadcasts(
+                "similarItem1",
+                Publisher.PA,
+                new Broadcast(BBC_ONE.getUri(), time("2014-03-21T14:20:00Z"), time("2014-03-21T14:40:00Z"))
+        );
+
+        final Item similarBeforeSubject2 = episodeWithBroadcasts(
+                "similarItem2",
+                Publisher.PA,
+                new Broadcast(BBC_ONE.getUri(), time("2014-03-21T14:40:00Z"), time("2014-03-21T15:00:00Z"))
+        );
+
+        final Item subject = episodeWithBroadcasts(
+                "subjectItem",
+                Publisher.PA,
+                new Broadcast(BBC_ONE.getUri(), time("2014-03-21T15:00:00Z"), time("2014-03-21T15:20:00Z"))
+        );
+
+        final Item similarAfterSubject = episodeWithBroadcasts(
+                "similarItem3",
+                Publisher.PA,
+                new Broadcast(BBC_ONE.getUri(), time("2014-03-21T15:20:00Z"), time("2014-03-21T15:40:00Z"))
+        );
+
+        final Item nextUnrelatedToSubject = episodeWithBroadcasts(
+                "unrelatedItem2",
+                Publisher.PA,
+                new Broadcast(BBC_ONE.getUri(), time("2014-03-21T15:40:00Z"), time("2014-03-21T17:00:00Z"))
+        );
+
+        List<Item> subjectSchedule = ImmutableList.of(
+                previousUnrelatedToSubject,
+                similarBeforeSubject,
+                similarBeforeSubject2,
+                subject,
+                similarAfterSubject,
+                nextUnrelatedToSubject
+        );
+
+        //offset by 1h
+        final Item previousUnrelatedToCandidate = episodeWithBroadcasts(
+                "unrelatedItem3",
+                Publisher.BBC,
+                new Broadcast(BBC_ONE.getUri(), time("2014-03-21T14:00:00Z"), time("2014-03-21T15:20:00Z"))
+        );
+
+        final Item similarBeforeCandidate = episodeWithBroadcasts(
+                "similarItem4",
+                Publisher.BBC,
+                new Broadcast(BBC_ONE.getUri(), time("2014-03-21T15:20:00Z"), time("2014-03-21T15:40:00Z"))
+        );
+
+        final Item similarBeforeCandidate2 = episodeWithBroadcasts(
+                "similarItem5",
+                Publisher.BBC,
+                new Broadcast(BBC_ONE.getUri(), time("2014-03-21T15:40:00Z"), time("2014-03-21T16:00:00Z"))
+        );
+
+        final Item candidate = episodeWithBroadcasts(
+                "equivItem",
+                Publisher.BBC,
+                new Broadcast(BBC_ONE.getUri(), time("2014-03-21T16:00:00Z"), time("2014-03-21T16:20:00Z"))
+        );
+
+        final Item similarAfterCandidate = episodeWithBroadcasts(
+                "similarItem6",
+                Publisher.BBC,
+                new Broadcast(BBC_ONE.getUri(), time("2014-03-21T16:20:00Z"), time("2014-03-21T16:40:00Z"))
+        );
+
+        final Item nextUnrelatedToCandidate = episodeWithBroadcasts(
+                "unrelatedItem4",
+                Publisher.BBC,
+                new Broadcast(BBC_ONE.getUri(), time("2014-03-21T16:40:00Z"), time("2014-03-21T17:00:00Z"))
+        );
+
+        final Item similarAfterCandidateInSeparateBlock = episodeWithBroadcasts(
+                "similarItem7",
+                Publisher.BBC,
+                new Broadcast(BBC_ONE.getUri(), time("2014-03-21T17:00:00Z"), time("2014-03-21T17:20:00Z"))
+        );
+
+        List<Item> candidateSchedule = ImmutableList.of(
+                previousUnrelatedToCandidate,
+                similarBeforeCandidate,
+                similarBeforeCandidate2,
+                candidate,
+                similarAfterCandidate,
+                nextUnrelatedToCandidate,
+                similarAfterCandidateInSeparateBlock
+        );
+
+        when(titleMatchingScorer.score(subject, similarBeforeSubject)).thenReturn(Score.ONE);
+        when(titleMatchingScorer.score(subject, similarBeforeSubject2)).thenReturn(Score.ONE);
+        when(titleMatchingScorer.score(subject, similarAfterSubject)).thenReturn(Score.ONE);
+        when(titleMatchingScorer.score(subject, previousUnrelatedToSubject)).thenReturn(Score.nullScore());
+        when(titleMatchingScorer.score(subject, nextUnrelatedToSubject)).thenReturn(Score.nullScore());
+
+        when(titleMatchingScorer.score(subject, candidate)).thenReturn(Score.ONE);
+        when(titleMatchingScorer.score(subject, similarBeforeCandidate)).thenReturn(Score.ONE);
+        when(titleMatchingScorer.score(subject, similarBeforeCandidate2)).thenReturn(Score.ONE);
+        when(titleMatchingScorer.score(subject, similarAfterCandidate)).thenReturn(Score.ONE);
+        when(titleMatchingScorer.score(subject, previousUnrelatedToCandidate)).thenReturn(Score.nullScore());
+        when(titleMatchingScorer.score(subject, nextUnrelatedToCandidate)).thenReturn(Score.nullScore());
+        when(titleMatchingScorer.score(subject, similarAfterCandidateInSeparateBlock)).thenReturn(Score.ONE);
+
+        when(titleMatchingScorer.score(similarBeforeCandidate, similarBeforeCandidate2)).thenReturn(Score.ONE);
+        when(titleMatchingScorer.score(similarBeforeCandidate, candidate)).thenReturn(Score.ONE);
+        when(titleMatchingScorer.score(similarBeforeCandidate, similarAfterCandidate)).thenReturn(Score.ONE);
+        when(titleMatchingScorer.score(similarBeforeCandidate, previousUnrelatedToCandidate)).thenReturn(Score.nullScore());
+        when(titleMatchingScorer.score(similarBeforeCandidate, nextUnrelatedToCandidate)).thenReturn(Score.nullScore());
+        when(titleMatchingScorer.score(similarBeforeCandidate, similarAfterCandidateInSeparateBlock)).thenReturn(Score.ONE);
+
+        when(
+                resolver.unmergedSchedule(
+                        time("2014-03-21T12:00:00Z"),
+                        time("2014-03-21T18:20:00Z"),
+                        ImmutableSet.of(BBC_ONE), ImmutableSet.of(PA))
+        ).thenReturn(
+                Schedule.fromChannelMap(
+                        ImmutableMap.of(BBC_ONE, subjectSchedule),
+                        interval("2014-03-21T12:00:00Z", "2014-03-21T18:20:00Z")
+                )
+        );
+
+        when(
+                resolver.unmergedSchedule(
+                        time("2014-03-21T12:00:00Z"),
+                        time("2014-03-21T18:20:00Z"),
+                        ImmutableSet.of(BBC_ONE), PUBLISHERS)
+        ).thenReturn(
+                Schedule.fromChannelMap(
+                        ImmutableMap.of(BBC_ONE, candidateSchedule),
+                        interval("2014-03-21T12:00:00Z", "2014-03-21T18:20:00Z")
+                )
+        );
+
+        ScoredCandidates<Item> equivalents = generator.generate(
+                subject,
+                new DefaultDescription(),
+                EquivToTelescopeResult.create("id", "publisher")
+        );
+
+        Map<Item, Score> scoreMap = equivalents.candidates();
+
+        assertEquals(1, scoreMap.size());
+        Item scored = Iterables.getOnlyElement(scoreMap.keySet());
+        assertEquals(candidate, scored);
+        assertEquals(SCORE_ON_MATCH, scoreMap.get(scored));
+    }
+
 }

--- a/src/test/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest.java
+++ b/src/test/java/org/atlasapi/equiv/generators/barb/BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest.java
@@ -44,6 +44,7 @@ import static org.joda.time.Duration.standardHours;
 import static org.joda.time.Duration.standardMinutes;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -507,28 +508,26 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest {
                 similarAfterCandidateInSeparateBlock
         );
 
-        ResultDescription desc = new DefaultDescription();
+        setupTitleScoring(subject, similarBeforeSubject, Score.ONE);
+        setupTitleScoring(subject, similarBeforeSubject2, Score.ONE);
+        setupTitleScoring(subject, similarAfterSubject, Score.ONE);
+        setupTitleScoring(subject, previousUnrelatedToSubject, Score.nullScore());
+        setupTitleScoring(subject, nextUnrelatedToSubject, Score.nullScore());
 
-        when(titleMatchingScorer.score(subject, similarBeforeSubject, desc)).thenReturn(Score.ONE);
-        when(titleMatchingScorer.score(subject, similarBeforeSubject2, desc)).thenReturn(Score.ONE);
-        when(titleMatchingScorer.score(subject, similarAfterSubject, desc)).thenReturn(Score.ONE);
-        when(titleMatchingScorer.score(subject, previousUnrelatedToSubject, desc)).thenReturn(Score.nullScore());
-        when(titleMatchingScorer.score(subject, nextUnrelatedToSubject, desc)).thenReturn(Score.nullScore());
+        setupTitleScoring(subject, candidate, Score.ONE);
+        setupTitleScoring(subject, similarBeforeCandidate, Score.ONE);
+        setupTitleScoring(subject, similarBeforeCandidate2, Score.ONE);
+        setupTitleScoring(subject, similarAfterCandidate, Score.ONE);
+        setupTitleScoring(subject, previousUnrelatedToCandidate, Score.nullScore());
+        setupTitleScoring(subject, nextUnrelatedToCandidate, Score.nullScore());
+        setupTitleScoring(subject, similarAfterCandidateInSeparateBlock, Score.ONE);
 
-        when(titleMatchingScorer.score(subject, candidate, desc)).thenReturn(Score.ONE);
-        when(titleMatchingScorer.score(subject, similarBeforeCandidate, desc)).thenReturn(Score.ONE);
-        when(titleMatchingScorer.score(subject, similarBeforeCandidate2, desc)).thenReturn(Score.ONE);
-        when(titleMatchingScorer.score(subject, similarAfterCandidate, desc)).thenReturn(Score.ONE);
-        when(titleMatchingScorer.score(subject, previousUnrelatedToCandidate, desc)).thenReturn(Score.nullScore());
-        when(titleMatchingScorer.score(subject, nextUnrelatedToCandidate, desc)).thenReturn(Score.nullScore());
-        when(titleMatchingScorer.score(subject, similarAfterCandidateInSeparateBlock, desc)).thenReturn(Score.ONE);
-
-        when(titleMatchingScorer.score(similarBeforeCandidate, similarBeforeCandidate2, desc)).thenReturn(Score.ONE);
-        when(titleMatchingScorer.score(similarBeforeCandidate, candidate, desc)).thenReturn(Score.ONE);
-        when(titleMatchingScorer.score(similarBeforeCandidate, similarAfterCandidate, desc)).thenReturn(Score.ONE);
-        when(titleMatchingScorer.score(similarBeforeCandidate, previousUnrelatedToCandidate, desc)).thenReturn(Score.nullScore());
-        when(titleMatchingScorer.score(similarBeforeCandidate, nextUnrelatedToCandidate, desc)).thenReturn(Score.nullScore());
-        when(titleMatchingScorer.score(similarBeforeCandidate, similarAfterCandidateInSeparateBlock, desc)).thenReturn(Score.ONE);
+        setupTitleScoring(similarBeforeCandidate, similarBeforeCandidate2, Score.ONE);
+        setupTitleScoring(similarBeforeCandidate, candidate, Score.ONE);
+        setupTitleScoring(similarBeforeCandidate, similarAfterCandidate, Score.ONE);
+        setupTitleScoring(similarBeforeCandidate, previousUnrelatedToCandidate, Score.nullScore());
+        setupTitleScoring(similarBeforeCandidate, nextUnrelatedToCandidate, Score.nullScore());
+        setupTitleScoring(similarBeforeCandidate, similarAfterCandidateInSeparateBlock, Score.ONE);
 
         when(
                 resolver.unmergedSchedule(
@@ -556,7 +555,7 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest {
 
         ScoredCandidates<Item> equivalents = generator.generate(
                 subject,
-                desc,
+                new DefaultDescription(),
                 EquivToTelescopeResult.create("id", "publisher")
         );
 
@@ -566,6 +565,11 @@ public class BarbBroadcastMatchingItemEquivalenceGeneratorAndScorerTest {
         Item scored = Iterables.getOnlyElement(scoreMap.keySet());
         assertEquals(candidate, scored);
         assertEquals(SCORE_ON_MATCH, scoreMap.get(scored));
+    }
+
+    private void setupTitleScoring(Item item1, Item item2, Score score) {
+        when(titleMatchingScorer.score(argThat(is(item1)), argThat(is(item2)), any(ResultDescription.class)))
+                .thenReturn(score);
     }
 
 }


### PR DESCRIPTION
(N.B. currently only BBC Nitro <-> Txlogs uses this affected class)

The implementation looks to deal with schedule offsets between
txlogs and other schedule data, due to txlogs having actual transmission
times for their broadcasts. The code looks to identify the closest
block of broadcasts for a particular show (determined by the title
scorer) on each schedule, determine which entry within the block
the subject is, and takes the corresponding entry in the other
schedule to equiv to.

* Added container caching in BarbTitleMatchingItemScorer
to improve performance.