### PR TITLE
Unpublish without equivalences

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -436,7 +436,7 @@
         <dependency>
             <groupId>org.atlasapi</groupId>
             <artifactId>atlas-persistence</artifactId>
-            <version>5.7-SNAPSHOT</version>
+            <version>5.0-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>jetty</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -436,7 +436,7 @@
         <dependency>
             <groupId>org.atlasapi</groupId>
             <artifactId>atlas-persistence</artifactId>
-            <version>5.0-SNAPSHOT</version>
+            <version>5.7-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>jetty</artifactId>

--- a/src/main/java/org/atlasapi/equiv/EquivTaskModule.java
+++ b/src/main/java/org/atlasapi/equiv/EquivTaskModule.java
@@ -56,6 +56,8 @@ import org.atlasapi.remotesite.redux.ReduxServices;
 import org.atlasapi.remotesite.youview.YouViewChannelResolver;
 import org.atlasapi.remotesite.youview.YouViewCoreModule;
 import org.atlasapi.util.AlwaysBlockingQueue;
+
+import com.netflix.discovery.converters.Auto;
 import org.joda.time.Duration;
 import org.joda.time.LocalTime;
 import org.joda.time.Period;
@@ -126,6 +128,7 @@ import static org.atlasapi.media.entity.Publisher.YOUVIEW_BT_STAGE;
 import static org.atlasapi.media.entity.Publisher.YOUVIEW_SCOTLAND_RADIO;
 import static org.atlasapi.media.entity.Publisher.YOUVIEW_SCOTLAND_RADIO_STAGE;
 import static org.atlasapi.media.entity.Publisher.YOUVIEW_STAGE;
+import static org.atlasapi.persistence.MongoContentPersistenceModule.EXPLICIT_LOOKUP_WRITER;
 
 @Configuration
 @Import({ EquivModule.class, KafkaMessagingModule.class, YouViewCoreModule.class })
@@ -223,6 +226,7 @@ public class EquivTaskModule {
     @Autowired private ScheduleResolver scheduleResolver;
     @Autowired private ChannelResolver channelResolver;
     @Autowired private LookupWriter lookupWriter;
+    @Autowired @Qualifier(EXPLICIT_LOOKUP_WRITER) private LookupWriter explicitLookupWriter;
     @Autowired private YouViewChannelResolver youviewChannelResolver;
 
     @Autowired @Qualifier("contentUpdater") private EquivalenceUpdater<Content> equivUpdater;
@@ -798,7 +802,7 @@ public class EquivTaskModule {
 
     @Bean
     public EquivalenceBreaker equivalenceBreaker() {
-        return EquivalenceBreaker.create(contentResolver, lookupStore, lookupWriter);
+        return EquivalenceBreaker.create(contentResolver, lookupStore, lookupWriter, explicitLookupWriter);
     }
 
     //Probes...

--- a/src/main/java/org/atlasapi/equiv/EquivTaskModule.java
+++ b/src/main/java/org/atlasapi/equiv/EquivTaskModule.java
@@ -56,8 +56,6 @@ import org.atlasapi.remotesite.redux.ReduxServices;
 import org.atlasapi.remotesite.youview.YouViewChannelResolver;
 import org.atlasapi.remotesite.youview.YouViewCoreModule;
 import org.atlasapi.util.AlwaysBlockingQueue;
-
-import com.netflix.discovery.converters.Auto;
 import org.joda.time.Duration;
 import org.joda.time.LocalTime;
 import org.joda.time.Period;

--- a/src/main/java/org/atlasapi/query/QueryWebModule.java
+++ b/src/main/java/org/atlasapi/query/QueryWebModule.java
@@ -101,6 +101,7 @@ import org.atlasapi.output.simple.TopicModelSimplifier;
 import org.atlasapi.persistence.content.ContentGroupResolver;
 import org.atlasapi.persistence.content.ContentGroupWriter;
 import org.atlasapi.persistence.content.ContentResolver;
+import org.atlasapi.persistence.content.ContentWriter;
 import org.atlasapi.persistence.content.EquivalenceContentWriter;
 import org.atlasapi.persistence.content.LookupBackedContentIdGenerator;
 import org.atlasapi.persistence.content.PeopleQueryResolver;
@@ -163,6 +164,7 @@ import tva.metadata._2010.TVAMainType;
 import javax.xml.bind.JAXBElement;
 
 import static org.atlasapi.persistence.MongoContentPersistenceModule.NON_ID_SETTING_CONTENT_WRITER;
+import static org.atlasapi.persistence.MongoContentPersistenceModule.NO_EQUIVALENCE_WRITING_CONTENT_WRITER;
 
 @Configuration
 @Import({ WatermarkModule.class, QueryExecutorModule.class })
@@ -176,6 +178,7 @@ public class QueryWebModule {
     @Autowired private ContentGroupWriter contentGroupWriter;
     @Autowired private ContentGroupResolver contentGroupResolver;
     @Autowired @Qualifier(NON_ID_SETTING_CONTENT_WRITER) private EquivalenceContentWriter contentWriter;
+    @Autowired @Qualifier(NO_EQUIVALENCE_WRITING_CONTENT_WRITER) private ContentWriter noEquivalenceWritingContentWriter;
     @Autowired private LookupBackedContentIdGenerator lookupBackedContentIdGenerator;
     @Autowired private ScheduleWriter scheduleWriter;
     @Autowired private ContentResolver contentResolver;
@@ -417,6 +420,7 @@ public class QueryWebModule {
                 lookupStore,
                 contentResolver,
                 contentWriter,
+                noEquivalenceWritingContentWriter,
                 EquivalenceBreaker.create(
                         contentResolver,
                         entryStore,

--- a/src/main/java/org/atlasapi/query/QueryWebModule.java
+++ b/src/main/java/org/atlasapi/query/QueryWebModule.java
@@ -165,6 +165,7 @@ import javax.xml.bind.JAXBElement;
 
 import static org.atlasapi.persistence.MongoContentPersistenceModule.NON_ID_SETTING_CONTENT_WRITER;
 import static org.atlasapi.persistence.MongoContentPersistenceModule.NO_EQUIVALENCE_WRITING_CONTENT_WRITER;
+import static org.atlasapi.persistence.MongoContentPersistenceModule.EXPLICIT_LOOKUP_WRITER;
 
 @Configuration
 @Import({ WatermarkModule.class, QueryExecutorModule.class })
@@ -208,6 +209,7 @@ public class QueryWebModule {
     @Autowired private ChannelStore channelStore;
     @Autowired private LookupEntryStore entryStore;
     @Autowired private LookupWriter lookupWriter;
+    @Autowired @Qualifier(EXPLICIT_LOOKUP_WRITER) private LookupWriter explicitLookupWriter;
 
     @Autowired private KnownTypeQueryExecutor queryExecutor;
     @Autowired @Qualifier("YouviewQueryExecutor")  private KnownTypeQueryExecutor allowMultipleFromSamePublisherExecutor;
@@ -424,7 +426,8 @@ public class QueryWebModule {
                 EquivalenceBreaker.create(
                         contentResolver,
                         entryStore,
-                        lookupWriter
+                        lookupWriter,
+                        explicitLookupWriter
                 ),
                 OldContentDeactivator.create(
                         new MongoContentLister(

--- a/src/main/java/org/atlasapi/query/v2/ContentWriteController.java
+++ b/src/main/java/org/atlasapi/query/v2/ContentWriteController.java
@@ -723,24 +723,21 @@ public class ContentWriteController {
         // set publish status
         described.setActivelyPublished(publishStatus);
 
-        // remove from equivset if un-publishing, and write back to DB without changing equiv sets
+        ContentWriter writer;
+        // remove from equiv set if un-publishing, and write back to DB without changing equiv sets
         if(!publishStatus){
             removeItemFromEquivSet(described, lookupEntry);
-            if (described instanceof Item) {
-                noEquivalenceWritingContentWriter.createOrUpdate((Item) described);
-            }
-            if (described instanceof Container) {
-                noEquivalenceWritingContentWriter.createOrUpdate((Container) described);
-            }
+            writer = noEquivalenceWritingContentWriter;
+        } else {
+            writer = contentWriter;
         }
-        else {
-            // write back to DB
-            if (described instanceof Item) {
-                contentWriter.createOrUpdate((Item) described);
-            }
-            if (described instanceof Container) {
-                contentWriter.createOrUpdate((Container) described);
-            }
+
+        // write back to DB
+        if (described instanceof Item) {
+            writer.createOrUpdate((Item) described);
+        }
+        if (described instanceof Container) {
+            writer.createOrUpdate((Container) described);
         }
 
         // return all good

--- a/src/main/java/org/atlasapi/query/v2/ContentWriteController.java
+++ b/src/main/java/org/atlasapi/query/v2/ContentWriteController.java
@@ -733,13 +733,14 @@ public class ContentWriteController {
                 noEquivalenceWritingContentWriter.createOrUpdate((Container) described);
             }
         }
-
-        // write back to DB
-        if (described instanceof Item) {
-            contentWriter.createOrUpdate((Item) described);
-        }
-        if (described instanceof Container) {
-            contentWriter.createOrUpdate((Container) described);
+        else {
+            // write back to DB
+            if (described instanceof Item) {
+                contentWriter.createOrUpdate((Item) described);
+            }
+            if (described instanceof Container) {
+                contentWriter.createOrUpdate((Container) described);
+            }
         }
 
         // return all good

--- a/src/main/java/org/atlasapi/query/v2/ContentWriteController.java
+++ b/src/main/java/org/atlasapi/query/v2/ContentWriteController.java
@@ -115,6 +115,7 @@ public class ContentWriteController {
     private final LookupEntryStore lookupEntryStore;
     private final ContentResolver contentResolver;
     private final ContentWriter contentWriter;
+    private final ContentWriter noEquivalenceWritingContentWriter;
     private final EquivalenceBreaker equivalenceBreaker;
     private final OldContentDeactivator oldContentDeactivator;
 
@@ -127,6 +128,7 @@ public class ContentWriteController {
             LookupEntryStore lookupEntryStore,
             ContentResolver contentResolver,
             ContentWriter contentWriter,
+            ContentWriter noEquivalenceWritingContentWriter,
             EquivalenceBreaker equivalenceBreaker,
             OldContentDeactivator oldContentDeactivator
     ) {
@@ -138,6 +140,7 @@ public class ContentWriteController {
         this.lookupEntryStore = checkNotNull(lookupEntryStore);
         this.contentResolver = checkNotNull(contentResolver);
         this.contentWriter = checkNotNull(contentWriter);
+        this.noEquivalenceWritingContentWriter = checkNotNull(noEquivalenceWritingContentWriter);
         this.equivalenceBreaker = checkNotNull(equivalenceBreaker);
         this.oldContentDeactivator = checkNotNull(oldContentDeactivator);
     }
@@ -151,6 +154,7 @@ public class ContentWriteController {
             LookupEntryStore lookupEntryStore,
             ContentResolver contentResolver,
             ContentWriter contentWriter,
+            ContentWriter noEquivalenceWritingContentWriter,
             EquivalenceBreaker equivalenceBreaker,
             OldContentDeactivator oldContentDeactivator
     ) {
@@ -163,6 +167,7 @@ public class ContentWriteController {
                 lookupEntryStore,
                 contentResolver,
                 contentWriter,
+                noEquivalenceWritingContentWriter,
                 equivalenceBreaker,
                 oldContentDeactivator
         );
@@ -715,13 +720,19 @@ public class ContentWriteController {
             return error(req, resp, apiKeyErrorSummary.get());
         }
 
-        // remove from equivset if un-publishing
+        // set publish status
+        described.setActivelyPublished(publishStatus);
+
+        // remove from equivset if un-publishing, and write back to DB without changing equiv sets
         if(!publishStatus){
             removeItemFromEquivSet(described, lookupEntry);
+            if (described instanceof Item) {
+                noEquivalenceWritingContentWriter.createOrUpdate((Item) described);
+            }
+            if (described instanceof Container) {
+                noEquivalenceWritingContentWriter.createOrUpdate((Container) described);
+            }
         }
-
-        // set publisher status
-        described.setActivelyPublished(publishStatus);
 
         // write back to DB
         if (described instanceof Item) {
@@ -741,12 +752,17 @@ public class ContentWriteController {
      */
     private void removeItemFromEquivSet(Described described, LookupEntry lookupEntry){
 
-        ImmutableSet<String> equivsToRemove = lookupEntry.directEquivalents()
+        ImmutableSet<String> directEquivsToRemove = lookupEntry.directEquivalents()
                 .stream()
                 .map(LookupRef::uri)
                 .collect(MoreCollectors.toImmutableSet());
 
-        equivalenceBreaker.removeFromSet(described, lookupEntry, equivsToRemove);
+        ImmutableSet<String> explicitEquivsToRemove = lookupEntry.explicitEquivalents()
+                .stream()
+                .map(LookupRef::uri)
+                .collect(MoreCollectors.toImmutableSet());
+
+        equivalenceBreaker.removeFromSet(described, lookupEntry, directEquivsToRemove, explicitEquivsToRemove);
     }
 
     private String uriForId(String id) {

--- a/src/main/java/org/atlasapi/remotesite/pa/PaModule.java
+++ b/src/main/java/org/atlasapi/remotesite/pa/PaModule.java
@@ -88,6 +88,7 @@ import static com.metabroadcast.common.scheduling.RepetitionRules.NEVER;
 import static com.metabroadcast.common.scheduling.RepetitionRules.daily;
 import static com.metabroadcast.common.scheduling.RepetitionRules.every;
 import static com.metabroadcast.common.scheduling.RepetitionRules.weekly;
+import static org.atlasapi.persistence.MongoContentPersistenceModule.EXPLICIT_LOOKUP_WRITER;
 
 @SuppressWarnings("PublicConstructor")
 @Configuration
@@ -129,6 +130,7 @@ public class PaModule {
     private @Autowired ContentLister contentLister;
     private @Autowired LookupEntryStore lookupEntryStore;
     private @Autowired LookupWriter lookupWriter;
+    @Autowired @Qualifier(EXPLICIT_LOOKUP_WRITER) private LookupWriter explicitLookupWriter;
 
     // to ensure the complete and daily people ingest jobs are not run simultaneously 
     private final Lock peopleLock = new ReentrantLock();
@@ -534,7 +536,8 @@ public class PaModule {
                 EquivalenceBreaker.create(
                         contentResolver,
                         lookupEntryStore,
-                        lookupWriter
+                        lookupWriter,
+                        explicitLookupWriter
                 ),
                 true
         );

--- a/src/main/java/org/atlasapi/system/ContentPurgeWebModule.java
+++ b/src/main/java/org/atlasapi/system/ContentPurgeWebModule.java
@@ -41,7 +41,6 @@ public class ContentPurgeWebModule {
     @Autowired
     private ContentWriter contentWriter;
 
-    //TODO add a non-equiv content writer?
     @Autowired
     @Qualifier(NO_EQUIVALENCE_WRITING_CONTENT_WRITER)
     private ContentWriter noEquivalenceWritingContentWriter;

--- a/src/main/java/org/atlasapi/system/ContentPurgeWebModule.java
+++ b/src/main/java/org/atlasapi/system/ContentPurgeWebModule.java
@@ -9,9 +9,12 @@ import org.atlasapi.persistence.content.ContentResolver;
 import org.atlasapi.persistence.content.ContentWriter;
 import org.atlasapi.persistence.lookup.entry.LookupEntryStore;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+
+import static org.atlasapi.persistence.MongoContentPersistenceModule.NO_EQUIVALENCE_WRITING_CONTENT_WRITER;
 
 @Configuration
 @Import( { MongoContentPersistenceModule.class, EquivTaskModule.class })
@@ -38,6 +41,11 @@ public class ContentPurgeWebModule {
     @Autowired
     private ContentWriter contentWriter;
 
+    //TODO add a non-equiv content writer?
+    @Autowired
+    @Qualifier(NO_EQUIVALENCE_WRITING_CONTENT_WRITER)
+    private ContentWriter noEquivalenceWritingContentWriter;
+
     @Autowired
     private EquivalenceBreaker equivalenceBreaker;
 
@@ -63,6 +71,7 @@ public class ContentPurgeWebModule {
                 contentResolver,
                 lookupEntryStore,
                 contentWriter,
+                noEquivalenceWritingContentWriter,
                 equivalenceBreaker
         );
     }

--- a/src/main/java/org/atlasapi/system/UnpublishContentController.java
+++ b/src/main/java/org/atlasapi/system/UnpublishContentController.java
@@ -94,7 +94,9 @@ public class UnpublishContentController {
         Optional<Identified> identified = resolveContent(lookupEntry);
         Described described = validatePublisher(publisher, identified);
 
-        removeItemFromEquivSet(described, lookupEntry);
+        if(!status){
+            removeEquivSetOfItem(described, lookupEntry);
+        }
         described.setActivelyPublished(status);
         writeUpdate(described);
     }
@@ -151,14 +153,19 @@ public class UnpublishContentController {
     /**
      * This will take an item, and remove all direct equivalences from it
      */
-    private void removeItemFromEquivSet(Described described, LookupEntry lookupEntry){
+    private void removeEquivSetOfItem(Described described, LookupEntry lookupEntry){
 
-        ImmutableSet<String> equivsToRemove = lookupEntry.directEquivalents()
+        ImmutableSet<String> allDirectEquivs = lookupEntry.directEquivalents()
                 .stream()
                 .map(LookupRef::uri)
                 .collect(MoreCollectors.toImmutableSet());
 
-        equivalenceBreaker.removeFromSet(described, lookupEntry, equivsToRemove);
+        ImmutableSet<String> allExplicitEquivs = lookupEntry.explicitEquivalents()
+                .stream()
+                .map(LookupRef::uri)
+                .collect(MoreCollectors.toImmutableSet());
+
+        equivalenceBreaker.removeFromSet(described, lookupEntry, allDirectEquivs, allExplicitEquivs);
     }
 
     private void writeUpdate(Described described) {

--- a/src/main/java/org/atlasapi/system/UnpublishContentController.java
+++ b/src/main/java/org/atlasapi/system/UnpublishContentController.java
@@ -100,9 +100,11 @@ public class UnpublishContentController {
         described.setActivelyPublished(status);
         if(!status){
             removeEquivSetOfItem(described, lookupEntry);
-            writeUpdate(described, noEquivalenceContentWriter); //if unpublshing, then ignore equivs
+            writeUpdate(described, noEquivalenceContentWriter); //write to db ignoring equivs
         }
-        writeUpdate(described, contentWriter);
+        else {
+            writeUpdate(described, contentWriter);
+        }
     }
 
     private LookupEntry getLookupEntry(Optional<String> id, Optional<String> uri) {

--- a/src/test/java/org/atlasapi/equiv/EquivalenceBreakerTest.java
+++ b/src/test/java/org/atlasapi/equiv/EquivalenceBreakerTest.java
@@ -122,7 +122,7 @@ public class EquivalenceBreakerTest {
                 .stream()
                 .map(LookupRef::uri)
                 .collect(MoreCollectors.toImmutableSet());
-        equivalenceBreaker.removeEquivs(EXAMPLE_ITEM, EXAMPLE_ITEM_LOOKUP, directEquivUris, false);
+        equivalenceBreaker.removeDirectEquivs(EXAMPLE_ITEM, EXAMPLE_ITEM_LOOKUP, directEquivUris);
 
         verify(lookupWriter).writeLookup(argThat(is(ContentRef.valueOf(EXAMPLE_ITEM))),
                 argThat(is(ImmutableList.of())), argThat(is(Publisher.all())));
@@ -145,7 +145,7 @@ public class EquivalenceBreakerTest {
                 .stream()
                 .map(LookupRef::uri)
                 .collect(MoreCollectors.toImmutableSet());
-        equivalenceBreaker.removeEquivs(EXAMPLE_ITEM, EXAMPLE_ITEM_LOOKUP, explicitEquivUris, true);
+        equivalenceBreaker.removeExplicitEquivs(EXAMPLE_ITEM, EXAMPLE_ITEM_LOOKUP, explicitEquivUris);
 
         verify(explicitLookupWriter).writeLookup(argThat(is(ContentRef.valueOf(EXAMPLE_ITEM))),
                 argThat(is(ImmutableList.of())), argThat(is(Publisher.all())));

--- a/src/test/java/org/atlasapi/equiv/EquivalenceBreakerTest.java
+++ b/src/test/java/org/atlasapi/equiv/EquivalenceBreakerTest.java
@@ -1,5 +1,8 @@
 package org.atlasapi.equiv;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.metabroadcast.common.stream.MoreCollectors;
 import org.atlasapi.media.entity.Alias;
 import org.atlasapi.media.entity.Described;
 import org.atlasapi.media.entity.LookupRef;
@@ -10,11 +13,6 @@ import org.atlasapi.persistence.content.ResolvedContent;
 import org.atlasapi.persistence.lookup.LookupWriter;
 import org.atlasapi.persistence.lookup.entry.LookupEntry;
 import org.atlasapi.persistence.lookup.entry.LookupEntryStore;
-
-import com.metabroadcast.common.stream.MoreCollectors;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/org/atlasapi/equiv/EquivalenceBreakerTest.java
+++ b/src/test/java/org/atlasapi/equiv/EquivalenceBreakerTest.java
@@ -56,7 +56,7 @@ public class EquivalenceBreakerTest {
             ImmutableSet.<LookupRef>of(), 
             ImmutableSet.of(LookupRef.from(ITEM_TO_REMOVE), LookupRef.from(ITEM_TO_KEEP)), 
             new DateTime(), new DateTime(), true);
-    
+
     private final ContentResolver contentResolver = mock(ContentResolver.class);
     private final LookupWriter lookupWriter = mock(LookupWriter.class);
     private final LookupEntryStore lookupEntryStore = mock(LookupEntryStore.class);
@@ -120,7 +120,6 @@ public class EquivalenceBreakerTest {
                 argThat(is(ImmutableList.of())), argThat(is(Publisher.all())));
     }
 
-    //TODO test 2 sets of multiple items from equivalent set?
     //TODO test unpublishing without copying over equivalences?
 
 }

--- a/src/test/java/org/atlasapi/equiv/EquivalenceBreakerTest.java
+++ b/src/test/java/org/atlasapi/equiv/EquivalenceBreakerTest.java
@@ -105,12 +105,16 @@ public class EquivalenceBreakerTest {
                         .put(ITEM_TO_KEEP_URI, ITEM_TO_KEEP)
                         .build());
 
-        ImmutableSet<String> allEquivs = EXAMPLE_ITEM_LOOKUP.directEquivalents()
+        ImmutableSet<String> directEquivs = EXAMPLE_ITEM_LOOKUP.directEquivalents()
+                .stream()
+                .map(LookupRef::uri)
+                .collect(MoreCollectors.toImmutableSet());
+        ImmutableSet<String> explicitEquivs = EXAMPLE_ITEM_LOOKUP.explicitEquivalents()
                 .stream()
                 .map(LookupRef::uri)
                 .collect(MoreCollectors.toImmutableSet());
 
-        equivalenceBreaker.removeFromSet(EXAMPLE_ITEM, EXAMPLE_ITEM_LOOKUP, allEquivs);
+        equivalenceBreaker.removeFromSet(EXAMPLE_ITEM, EXAMPLE_ITEM_LOOKUP, directEquivs, explicitEquivs);
 
         verify(lookupWriter).writeLookup(argThat(is(ContentRef.valueOf(EXAMPLE_ITEM))),
                 argThat(is(ImmutableList.of())), argThat(is(Publisher.all())));

--- a/src/test/java/org/atlasapi/equiv/EquivalenceBreakerTest.java
+++ b/src/test/java/org/atlasapi/equiv/EquivalenceBreakerTest.java
@@ -60,7 +60,7 @@ public class EquivalenceBreakerTest {
             LookupRef.from(EXAMPLE_ITEM), ImmutableSet.<String>of(), ImmutableSet.<Alias>of(), 
             ImmutableSet.of(LookupRef.from(DIRECT_EQUIV_TO_REMOVE), LookupRef.from(ITEM_TO_KEEP)),
             ImmutableSet.<LookupRef>of(LookupRef.from(EXPLICIT_EQUIV_TO_REMOVE), LookupRef.from(ITEM_TO_KEEP)),
-            ImmutableSet.of(LookupRef.from(DIRECT_EQUIV_TO_REMOVE), LookupRef.from(ITEM_TO_KEEP)),
+            ImmutableSet.of(LookupRef.from(DIRECT_EQUIV_TO_REMOVE), LookupRef.from(EXPLICIT_EQUIV_TO_REMOVE), LookupRef.from(ITEM_TO_KEEP)),
             new DateTime(), new DateTime(), true);
 
     private final ContentResolver contentResolver = mock(ContentResolver.class);
@@ -81,30 +81,7 @@ public class EquivalenceBreakerTest {
                 LookupRef.from(EXPLICIT_EQUIV_TO_REMOVE),
                 LookupRef.from(ITEM_TO_KEEP)
         ));
-    }
-    
-    @Test
-    public void testRemovesItemFromEquivalentSet() {
-        when(lookupEntryStore.entriesForCanonicalUris(argThat(hasItem(REMOVE_FROM_URI))))
-            .thenReturn(ImmutableSet.of(EXAMPLE_ITEM_LOOKUP));
-        
-        when(contentResolver.findByCanonicalUris(argThat(hasItem(REMOVE_FROM_URI))))
-            .thenReturn(ResolvedContent.builder().put(REMOVE_FROM_URI, EXAMPLE_ITEM).build());
-        
-        when(contentResolver.findByCanonicalUris(argThat(hasItem(ITEM_TO_KEEP_URI))))
-            .thenReturn(ResolvedContent.builder()   
-                                       .put(ITEM_TO_KEEP_URI, ITEM_TO_KEEP)
-                                       .build());
-        
-        equivalenceBreaker.removeFromSet(REMOVE_FROM_URI, DIRECT_EQUIV_TO_REMOVE_URI);
-        
-        verify(lookupWriter).writeLookup(argThat(is(ContentRef.valueOf(EXAMPLE_ITEM))), 
-                argThat(hasItem(ContentRef.valueOf(ITEM_TO_KEEP))), argThat(is(Publisher.all())));
-    }
 
-
-    @Test
-    public void testRemovesMultipleItemsFromEquivalentSet() {
         when(lookupEntryStore.entriesForCanonicalUris(argThat(hasItem(REMOVE_FROM_URI))))
                 .thenReturn(ImmutableSet.of(EXAMPLE_ITEM_LOOKUP));
 
@@ -115,7 +92,19 @@ public class EquivalenceBreakerTest {
                 .thenReturn(ResolvedContent.builder()
                         .put(ITEM_TO_KEEP_URI, ITEM_TO_KEEP)
                         .build());
+    }
+    
+    @Test
+    public void testRemovesItemFromEquivalentSet() {
+        equivalenceBreaker.removeFromSet(REMOVE_FROM_URI, DIRECT_EQUIV_TO_REMOVE_URI);
+        
+        verify(lookupWriter).writeLookup(argThat(is(ContentRef.valueOf(EXAMPLE_ITEM))), 
+                argThat(hasItem(ContentRef.valueOf(ITEM_TO_KEEP))), argThat(is(Publisher.all())));
+    }
 
+
+    @Test
+    public void testRemovesMultipleItemsFromEquivalentSet() {
         ImmutableSet<String> directEquivUris = EXAMPLE_ITEM_LOOKUP.directEquivalents()
                 .stream()
                 .map(LookupRef::uri)
@@ -128,17 +117,6 @@ public class EquivalenceBreakerTest {
 
     @Test
     public void testRemovesExplicitEquivsFromEquivalentSet() {
-        when(lookupEntryStore.entriesForCanonicalUris(argThat(hasItem(REMOVE_FROM_URI))))
-                .thenReturn(ImmutableSet.of(EXAMPLE_ITEM_LOOKUP));
-
-        when(contentResolver.findByCanonicalUris(argThat(hasItem(REMOVE_FROM_URI))))
-                .thenReturn(ResolvedContent.builder().put(REMOVE_FROM_URI, EXAMPLE_ITEM).build());
-
-        when(contentResolver.findByCanonicalUris(argThat(hasItem(ITEM_TO_KEEP_URI))))
-                .thenReturn(ResolvedContent.builder()
-                        .put(ITEM_TO_KEEP_URI, ITEM_TO_KEEP)
-                        .build());
-
         ImmutableSet<String> explicitEquivUris = EXAMPLE_ITEM_LOOKUP.explicitEquivalents()
                 .stream()
                 .map(LookupRef::uri)
@@ -151,17 +129,6 @@ public class EquivalenceBreakerTest {
 
     @Test
     public void testRemovesAllEquivsFromEquivalentSet() {
-        when(lookupEntryStore.entriesForCanonicalUris(argThat(hasItem(REMOVE_FROM_URI))))
-                .thenReturn(ImmutableSet.of(EXAMPLE_ITEM_LOOKUP));
-
-        when(contentResolver.findByCanonicalUris(argThat(hasItem(REMOVE_FROM_URI))))
-                .thenReturn(ResolvedContent.builder().put(REMOVE_FROM_URI, EXAMPLE_ITEM).build());
-
-        when(contentResolver.findByCanonicalUris(argThat(hasItem(ITEM_TO_KEEP_URI))))
-                .thenReturn(ResolvedContent.builder()
-                        .put(ITEM_TO_KEEP_URI, ITEM_TO_KEEP)
-                        .build());
-
         ImmutableSet<String> directEquivUris = EXAMPLE_ITEM_LOOKUP.directEquivalents()
                 .stream()
                 .map(LookupRef::uri)

--- a/src/test/java/org/atlasapi/equiv/EquivalenceBreakerTest.java
+++ b/src/test/java/org/atlasapi/equiv/EquivalenceBreakerTest.java
@@ -120,4 +120,7 @@ public class EquivalenceBreakerTest {
                 argThat(is(ImmutableList.of())), argThat(is(Publisher.all())));
     }
 
+    //TODO test 2 sets of multiple items from equivalent set?
+    //TODO test unpublishing without copying over equivalences?
+
 }

--- a/src/test/java/org/atlasapi/query/v2/ContentWriteControllerTest.java
+++ b/src/test/java/org/atlasapi/query/v2/ContentWriteControllerTest.java
@@ -86,6 +86,7 @@ public class ContentWriteControllerTest {
     private @Mock LookupEntryStore lookupEntryStore;
     private @Mock ContentResolver contentResolver;
     private @Mock ContentWriter contentWriter;
+    private @Mock ContentWriter noEquivalenceWritingContentWriter;
     private @Mock EquivalenceBreaker equivalenceBreaker;
 
     private @Mock HttpServletRequest request;
@@ -157,6 +158,7 @@ public class ContentWriteControllerTest {
                 lookupEntryStore,
                 contentResolver,
                 contentWriter,
+                noEquivalenceWritingContentWriter,
                 equivalenceBreaker,
                 oldContentDeactivator
         );


### PR DESCRIPTION
Improve unpublishing endpoints (ENG-551)

1) the explicit equivs will now also be removed from the
lookup entry.
2) any content level equivs will be ignored when unpublishing
the content. This it to prevent content record equivs from
being written in the lookup entry (as they are considered
explicit equivs).