### PR TITLE
Copied classes from Deer related to Elastic Search

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,29 +217,6 @@
                             <excludes>META-INF/*.RSA,META-INF/*.DSA,META-INF/*.SF</excludes>
                         </configuration>
                     </execution>
-                    <execution>
-                        <id>unpack-atlas-api</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.atlasapi</groupId>
-                                    <version>${deer.version}</version>
-                                    <artifactId>atlas-api</artifactId>
-                                    <classifier>classes</classifier>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${project.build.directory}/atlas-api</outputDirectory>
-                                    <includes>org/atlasapi/*.class,org/atlasapi/util/jetty/*.class,**/*.properties</includes>
-                                    <excludes>**/AtlasMain.class,**/AtlasApiModule.class</excludes>
-                                </artifactItem>
-                            </artifactItems>
-                            <overWriteReleases>false</overWriteReleases>
-                            <overWriteSnapshots>true</overWriteSnapshots>
-                        </configuration>
-                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -486,10 +463,9 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.atlasapi</groupId>
-            <version>${deer.version}</version>
-            <artifactId>atlas-api</artifactId>
-            <classifier>classes</classifier>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch</artifactId>
+            <version>1.7.2</version>
         </dependency>
         <dependency>
             <groupId>com.metabroadcast.status</groupId>

--- a/src/main/java/org/atlasapi/deer/elasticsearch/AvailabilityQueryBuilder.java
+++ b/src/main/java/org/atlasapi/deer/elasticsearch/AvailabilityQueryBuilder.java
@@ -1,0 +1,19 @@
+package org.atlasapi.deer.elasticsearch;
+
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+
+import java.util.Date;
+
+public class AvailabilityQueryBuilder {
+
+    public static QueryBuilder build(Date when, float boost) {
+        return QueryBuilders.nestedQuery(
+                EsContent.LOCATIONS,
+                QueryBuilders.boolQuery()
+                        .boost(boost)
+                        .must(QueryBuilders.rangeQuery(EsLocation.AVAILABILITY_TIME).gte(when))
+                        .must(QueryBuilders.rangeQuery(EsLocation.AVAILABILITY_END_TIME).lt(when))
+        );
+    }
+}

--- a/src/main/java/org/atlasapi/deer/elasticsearch/BroadcastQueryBuilder.java
+++ b/src/main/java/org/atlasapi/deer/elasticsearch/BroadcastQueryBuilder.java
@@ -1,0 +1,28 @@
+package org.atlasapi.deer.elasticsearch;
+
+import com.metabroadcast.common.time.DateTimeZones;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders;
+import org.elasticsearch.search.MultiValueMode;
+import org.joda.time.DateTime;
+
+import java.util.Date;
+
+public class BroadcastQueryBuilder {
+
+    public static QueryBuilder build(QueryBuilder childQuery, Float timeBoost) {
+        Date minusThirtyDays = DateTime.now().minusDays(30).toDateTime(DateTimeZones.UTC).toDate();
+        long minusThirtyDaysMillis = minusThirtyDays.toInstant().getEpochSecond() * 1000;
+        long nowMilis = new Date().toInstant().getEpochSecond() * 1000;
+
+        return QueryBuilders.functionScoreQuery(
+                childQuery
+        ).add(ScoreFunctionBuilders.gaussDecayFunction(
+                EsBroadcast.TRANSMISSION_TIME_IN_MILLIS,
+                nowMilis,
+                minusThirtyDaysMillis
+                ).setMultiValueMode(MultiValueMode.MIN)
+        ).boost(timeBoost);
+    }
+}

--- a/src/main/java/org/atlasapi/deer/elasticsearch/ContentTitleSearcher.java
+++ b/src/main/java/org/atlasapi/deer/elasticsearch/ContentTitleSearcher.java
@@ -1,0 +1,9 @@
+package org.atlasapi.deer.elasticsearch;
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+public interface ContentTitleSearcher {
+
+    ListenableFuture<SearchResults> search(SearchQuery query);
+
+}

--- a/src/main/java/org/atlasapi/deer/elasticsearch/EsAlias.java
+++ b/src/main/java/org/atlasapi/deer/elasticsearch/EsAlias.java
@@ -1,0 +1,60 @@
+package org.atlasapi.deer.elasticsearch;
+
+import com.google.common.base.Function;
+import org.atlasapi.deer.elasticsearch.content.Alias;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class EsAlias extends EsObject {
+
+    private static final Function<Alias, EsAlias> TO_ALIAS = EsAlias::valueOf;
+    public static final String NAMESPACE = "namespace";
+    public static final String VALUE = "value";
+
+    public static final XContentBuilder getMapping() throws IOException {
+        return XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject(EsAlias.NAMESPACE)
+                .field("type").value("string")
+                .field("index").value("not_analyzed")
+                .endObject()
+                .startObject(EsAlias.VALUE)
+                .field("type").value("string")
+                .field("index").value("not_analyzed")
+                .endObject()
+                .endObject();
+    }
+
+    public static final Function<Alias, EsAlias> toEsAlias() {
+        return TO_ALIAS;
+    }
+
+    public static final EsAlias valueOf(Alias alias) {
+        checkNotNull(alias);
+        return new EsAlias()
+                .namespace(alias.getNamespace())
+                .value(alias.getValue());
+    }
+
+    public static EsAlias fromMap(Map<String, Object> map) {
+        return new EsAlias()
+                .namespace((String)map.get(NAMESPACE))
+                .value((String)map.get(VALUE));
+    }
+
+    public EsAlias namespace(String namespace) {
+        properties.put(NAMESPACE, namespace);
+        return this;
+    }
+
+    public EsAlias value(String value) {
+        properties.put(VALUE, value);
+        return this;
+    }
+
+}

--- a/src/main/java/org/atlasapi/deer/elasticsearch/EsBroadcast.java
+++ b/src/main/java/org/atlasapi/deer/elasticsearch/EsBroadcast.java
@@ -1,0 +1,51 @@
+package org.atlasapi.deer.elasticsearch;
+
+import org.joda.time.DateTime;
+
+import java.util.Date;
+import java.util.Map;
+
+public class EsBroadcast extends EsObject {
+
+    public final static String ID = "id";
+    public final static String CHANNEL = "channel";
+    public final static String TRANSMISSION_TIME = "transmissionTime";
+    public final static String TRANSMISSION_END_TIME = "transmissionEndTime";
+    public final static String TRANSMISSION_TIME_IN_MILLIS = "transmissionTimeInMillis";
+    public final static String REPEAT = "repeat";
+
+    public EsBroadcast id(String id) {
+        properties.put(ID, id);
+        return this;
+    }
+
+    public EsBroadcast channel(Long channel) {
+        properties.put(CHANNEL, channel);
+        return this;
+    }
+
+    public EsBroadcast transmissionTime(Date transmissionTime) {
+        properties.put(TRANSMISSION_TIME, transmissionTime);
+        return this;
+    }
+
+    public EsBroadcast transmissionEndTime(Date transmissionEndTime) {
+        properties.put(TRANSMISSION_END_TIME, transmissionEndTime);
+        return this;
+    }
+
+    public EsBroadcast repeat(Boolean repeat) {
+        properties.put(REPEAT, repeat);
+        return this;
+    }
+
+    public static EsBroadcast fromMap(Map<String, Object> map) {
+        EsBroadcast broadcast = new EsBroadcast();
+        broadcast.id((String) map.get(ID));
+        broadcast.channel(((Integer) map.get(CHANNEL)).longValue());
+        broadcast.transmissionTime(new DateTime(map.get(TRANSMISSION_TIME)).toDate());
+        broadcast.transmissionEndTime(new DateTime(map.get(TRANSMISSION_END_TIME)).toDate());
+        broadcast.repeat((Boolean) map.get(REPEAT));
+        return broadcast;
+    }
+}

--- a/src/main/java/org/atlasapi/deer/elasticsearch/EsContent.java
+++ b/src/main/java/org/atlasapi/deer/elasticsearch/EsContent.java
@@ -1,0 +1,307 @@
+package org.atlasapi.deer.elasticsearch;
+
+import com.google.common.base.Functions;
+import com.google.common.collect.Iterables;
+import org.atlasapi.deer.elasticsearch.content.Alias;
+import org.atlasapi.deer.elasticsearch.content.ContentType;
+import org.atlasapi.deer.elasticsearch.content.Id;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+
+public class EsContent extends EsObject {
+
+    public final static String TOP_LEVEL_CONTAINER = "container";
+    public final static String CHILD_ITEM = "child_item";
+    public final static String TOP_LEVEL_ITEM = "top_item";
+
+    public final static String ID = "id";
+    public final static String TYPE = "type";
+    public final static String SOURCE = "source";
+    public final static String ALIASES = "aliases";
+    public final static String TITLE = "title";
+    public final static String FLATTENED_TITLE = "flattenedTitle";
+    public final static String PARENT_TITLE = "parentTitle";
+    public final static String PARENT_FLATTENED_TITLE = "parentFlattenedTitle";
+    public final static String SPECIALIZATION = "specialization";
+    public final static String BROADCASTS = "broadcasts";
+    public final static String LOCATIONS = "locations";
+    public final static String TOPICS = "topics";
+    public final static String HAS_CHILDREN = "hasChildren";
+    public final static String GENRE = "genre";
+    public final static String PRICE = "price";
+    public static final String AGE = "age";
+    public static final String CONTENT_GROUPS = "contentGroups";
+    public static final String PARENT = "_parent";
+    public static final String PRIORITY = "priority";
+    public static final String SERIES_NUMBER = "seriesNumber";
+    public static final String EPISODE_NUMBER = "episodeNumber";
+    public static final String BRAND = "brand";
+    public static final String SERIES = "series";
+    public static final String SORT_KEY = "sortKey";
+    public static final String CANONICAL_ID = "canonicalId";
+
+    public static final XContentBuilder getTopLevelMapping(String type) throws IOException {
+        return addCommonProperties(XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject(type)
+                .startObject("_all")
+                .field("enabled").value(false)
+                .endObject()
+                .startObject("properties"))
+                .endObject()
+                .endObject()
+                .endObject();
+    }
+
+    public static final XContentBuilder getChildMapping() throws IOException {
+        return addCommonProperties(XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject(EsContent.CHILD_ITEM)
+                .startObject(PARENT)
+                .field("type").value(EsContent.TOP_LEVEL_CONTAINER)
+                .endObject()
+                .startObject("_all")
+                .field("enabled").value(false)
+                .endObject()
+                .startObject("_routing")
+                .field("required").value(false)
+                .endObject()
+                .startObject("properties"))
+                .endObject()
+                .endObject()
+                .endObject();
+    }
+
+    private static XContentBuilder addCommonProperties(XContentBuilder obj) throws IOException {
+        return addScheduleOnlyProperties(obj
+                .startObject(EsContent.TYPE)
+                .field("type").value("string")
+                .field("index").value("not_analyzed")
+                .endObject()
+                .startObject(ALIASES)
+                .field("type").value("nested")
+                .rawField("properties", EsAlias.getMapping().bytes())
+                .endObject()
+                .startObject(EsContent.TITLE)
+                .field("type").value("string")
+                .field("index").value("not_analyzed")
+                .endObject()
+                .startObject(EsContent.FLATTENED_TITLE)
+                .field("type").value("string")
+                .field("index").value("not_analyzed")
+                .endObject()
+                .startObject(EsContent.SOURCE)
+                .field("type").value("string")
+                .field("index").value("not_analyzed")
+                .endObject()
+                .startObject(EsContent.SPECIALIZATION)
+                .field("type").value("string")
+                .field("index").value("not_analyzed")
+                .endObject()
+                .startObject(EsContent.TOPICS)
+                .field("type").value("nested")
+                .rawField("properties", EsTopicMapping.getMapping().bytes())
+                .endObject()
+                .startObject(EsContent.LOCATIONS)
+                .field("type").value("nested")
+                .rawField("properties", EsLocation.getMapping().bytes())
+                .endObject()
+                .startObject(EsContent.GENRE)
+                .field("type").value("string")
+                .field("index").value("not_analyzed")
+                .endObject()
+                .startObject(EsContent.PRICE)
+                .field("type").value("nested")
+                .rawField("properties", EsPriceMapping.getMapping().bytes())
+                .endObject()
+                .startObject(EsContent.AGE)
+                .field("type").value("integer")
+                .field("index").value("not_analyzed")
+                .endObject()
+                .startObject(EsContent.CONTENT_GROUPS)
+                .field("type").value("long")
+                .field("index").value("not_analyzed")
+                .endObject()
+                .startObject(EsContent.PRIORITY)
+                .field("type").value("double")
+                .field("index").value("not_analyzed")
+                .endObject()
+                .startObject(EsBroadcast.TRANSMISSION_TIME_IN_MILLIS)
+                .field("type").value("long")
+                .field("index").value("not_analyzed")
+                .endObject()
+                .startObject(SERIES_NUMBER)
+                .field("type").value("integer")
+                .field("index").value("not_analyzed")
+                .endObject()
+                .startObject(EPISODE_NUMBER)
+                .field("type").value("integer")
+                .field("index").value("not_analyzed")
+                .endObject()
+                .startObject(BRAND)
+                .field("type").value("long")
+                .field("index").value("not_analyzed")
+                .endObject()
+                .startObject(SERIES)
+                .field("type").value("long")
+                .field("index").value("not_analyzed")
+                .endObject()
+                .startObject(SORT_KEY)
+                .field("type").value("string")
+                .field("index").value("not_analyzed")
+                .endObject()
+                .startObject(CANONICAL_ID)
+                .field("type").value("long")
+                .field("index").value("not_analyzed")
+                .endObject()
+        );
+    }
+
+    private static XContentBuilder addScheduleOnlyProperties(XContentBuilder obj)
+            throws IOException {
+        return obj.startObject(EsContent.ID)
+                .field("type").value("long")
+                .field("index").value("not_analyzed")
+                .endObject()
+                .startObject(EsContent.BROADCASTS)
+                .field("type").value("nested")
+                .startObject("properties")
+                .startObject(EsBroadcast.CHANNEL)
+                .field("type").value("string")
+                .field("index").value("not_analyzed")
+                .endObject()
+                .endObject()
+                .endObject();
+    }
+
+    public EsContent id(long id) {
+        properties.put(ID, id);
+        return this;
+    }
+
+    public EsContent type(ContentType type) {
+        properties.put(TYPE, type.getKey());
+        return this;
+    }
+
+    public EsContent aliases(Iterable<Alias> aliases) {
+        properties.put(
+                ALIASES,
+                Iterables.transform(aliases, Functions.compose(TO_MAP, EsAlias.toEsAlias()))
+        );
+        return this;
+    }
+
+    public EsContent title(String title) {
+        properties.put(TITLE, title);
+        return this;
+    }
+
+    public EsContent flattenedTitle(String flattenedTitle) {
+        properties.put(FLATTENED_TITLE, flattenedTitle);
+        return this;
+    }
+
+    public EsContent parentTitle(String parentTitle) {
+        properties.put(PARENT_TITLE, parentTitle);
+        return this;
+    }
+
+    public EsContent parentFlattenedTitle(String parentFlattenedTitle) {
+        properties.put(PARENT_FLATTENED_TITLE, parentFlattenedTitle);
+        return this;
+    }
+
+    public EsContent source(String publisher) {
+        properties.put(SOURCE, publisher);
+        return this;
+    }
+
+    public EsContent specialization(String specialization) {
+        properties.put(SPECIALIZATION, specialization);
+        return this;
+    }
+
+    public EsContent broadcasts(Iterable<EsBroadcast> broadcasts) {
+        properties.put(BROADCASTS, Iterables.transform(broadcasts, TO_MAP));
+        return this;
+    }
+
+    public EsContent locations(Iterable<EsLocation> locations) {
+        properties.put(LOCATIONS, Iterables.transform(locations, TO_MAP));
+        return this;
+    }
+
+    public EsContent topics(Collection<EsTopicMapping> topics) {
+        properties.put(TOPICS, Iterables.transform(topics, TO_MAP));
+        return this;
+    }
+
+    public EsContent hasChildren(Boolean hasChildren) {
+        properties.put(HAS_CHILDREN, hasChildren);
+        return this;
+    }
+
+    public EsContent genre(Iterable<String> genre) {
+        properties.put(GENRE, genre);
+        return this;
+    }
+
+    public EsContent price(Iterable<EsPriceMapping> prices) {
+        properties.put(PRICE, Iterables.transform(prices, TO_MAP));
+        return this;
+    }
+
+    public EsContent age(Integer age) {
+        properties.put(AGE, age);
+        return this;
+    }
+
+    public EsContent contentGroups(Iterable<Id> contentGroupIds) {
+        properties.put(CONTENT_GROUPS, contentGroupIds);
+        return this;
+    }
+
+    public EsContent priority(Double priority) {
+        properties.put(PRIORITY, priority);
+        return this;
+    }
+
+    public EsContent broadcastStartTimeInMillis(Iterable<Long> startTimes) {
+        properties.put(EsBroadcast.TRANSMISSION_TIME_IN_MILLIS, startTimes);
+        return this;
+    }
+
+    public EsContent brandId(Id id) {
+        properties.put(BRAND, id.longValue());
+        return this;
+    }
+
+    public EsContent seriesId(Id id) {
+        properties.put(SERIES, id.longValue());
+        return this;
+    }
+
+    public EsContent seriesNumber(Integer seriesNumber) {
+        properties.put(SERIES_NUMBER, seriesNumber);
+        return this;
+    }
+
+    public EsContent episodeNumber(Integer episodeNumber) {
+        properties.put(EPISODE_NUMBER, episodeNumber);
+        return this;
+    }
+
+    public EsContent sortKey(String sortKey) {
+        properties.put(SORT_KEY, sortKey);
+        return this;
+    }
+
+    public EsContent canonicalId(long id) {
+        properties.put(CANONICAL_ID, id);
+        return this;
+    }
+}

--- a/src/main/java/org/atlasapi/deer/elasticsearch/EsContentTitleSearcher.java
+++ b/src/main/java/org/atlasapi/deer/elasticsearch/EsContentTitleSearcher.java
@@ -1,0 +1,147 @@
+package org.atlasapi.deer.elasticsearch;
+
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.index.query.FilterBuilder;
+import org.elasticsearch.index.query.FilterBuilders;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.TermsFilterBuilder;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.sort.SortBuilders;
+import org.elasticsearch.search.sort.SortOrder;
+
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.elasticsearch.index.query.FilterBuilders.andFilter;
+import static org.elasticsearch.index.query.FilterBuilders.termFilter;
+import static org.elasticsearch.index.query.FilterBuilders.typeFilter;
+import static org.elasticsearch.index.query.QueryBuilders.filteredQuery;
+import static org.elasticsearch.index.query.QueryBuilders.hasChildQuery;
+
+public class EsContentTitleSearcher implements ContentTitleSearcher {
+
+    private final Client index;
+
+    public EsContentTitleSearcher(Client index) {
+        this.index = index;
+    }
+
+    @Override
+    public final ListenableFuture<SearchResults> search(SearchQuery search) {
+        QueryBuilder titleQuery = null;
+        QueryBuilder availabilityQuery = null;
+        QueryBuilder broadcastQuery = null;
+        QueryBuilder contentQuery = null;
+
+        Preconditions.checkArgument(
+                !Strings.isNullOrEmpty(search.getTerm()),
+                "query term null or empty"
+        );
+
+        titleQuery = TitleQueryBuilder.build(search.getTerm(), search.getTitleWeighting());
+
+        List<TermsFilterBuilder> filters = new LinkedList<TermsFilterBuilder>();
+        if (search.getIncludedPublishers() != null && !search.getIncludedPublishers().isEmpty()) {
+            filters.add(FiltersBuilder.buildForPublishers(
+                    EsContent.SOURCE,
+                    search.getIncludedPublishers()
+            ));
+        }
+        if (search.getIncludedSpecializations() != null
+                && !search.getIncludedSpecializations().isEmpty()) {
+            filters.add(FiltersBuilder.buildForSpecializations(search.getIncludedSpecializations()));
+        }
+        if (!filters.isEmpty()) {
+            titleQuery = QueryBuilders.filteredQuery(
+                    titleQuery,
+                    FilterBuilders.andFilter(filters.toArray(new FilterBuilder[filters.size()]))
+            );
+        }
+
+        if (search.getBroadcastWeighting() != 0.0f) {
+            broadcastQuery = BroadcastQueryBuilder.build(
+                    titleQuery,
+                    1f
+            );
+        } else {
+            broadcastQuery = titleQuery;
+        }
+
+        if (search.getCatchupWeighting() != 0.0f) {
+            availabilityQuery = AvailabilityQueryBuilder.build(
+                    new Date(),
+                    search.getCatchupWeighting()
+            );
+        }
+
+        if (availabilityQuery != null) {
+            contentQuery = QueryBuilders.boolQuery().must(broadcastQuery).should(availabilityQuery);
+        } else {
+            contentQuery = broadcastQuery;
+        }
+
+        QueryBuilder finalQuery = QueryBuilders.boolQuery()
+                .should(
+                        filteredQuery(
+                                contentQuery,
+                                andFilter(
+                                        typeFilter(EsContent.TOP_LEVEL_ITEM),
+                                        termFilter(EsContent.HAS_CHILDREN, Boolean.FALSE)
+                                )
+                        )
+                )
+                .should(
+                        hasChildQuery(EsContent.CHILD_ITEM, contentQuery)
+                                .scoreType("sum")
+                );
+
+        final SettableFuture<SearchResults> result = SettableFuture.create();
+        index.prepareSearch(EsSchema.CONTENT_INDEX)
+                .setQuery(finalQuery)
+                .addField(EsContent.ID)
+                .addSort(SortBuilders.scoreSort().order(SortOrder.DESC))
+                .setFrom(search.getSelection().getOffset())
+                .setSize(search.getSelection().limitOrDefaultValue(10))
+                .execute(new SearchResponseListener(result));
+        return result;
+    }
+
+    private static class SearchResponseListener implements ActionListener<SearchResponse> {
+
+        private final SettableFuture<SearchResults> result;
+
+        public SearchResponseListener(SettableFuture<SearchResults> result) {
+            this.result = result;
+        }
+
+        @Override
+        public void onResponse(SearchResponse response) {
+            Iterable<Long> uris = Iterables.transform(response.getHits(), new SearchHitToId());
+            result.set(SearchResults.from(uris));
+        }
+
+        @Override
+        public void onFailure(Throwable e) {
+            result.setException(e);
+        }
+    }
+
+    private static class SearchHitToId implements Function<SearchHit, Long> {
+
+        @Override
+        public Long apply(SearchHit input) {
+            Number idNumber = input.field(EsContent.ID).value();
+            return idNumber.longValue();
+        }
+    }
+}

--- a/src/main/java/org/atlasapi/deer/elasticsearch/EsLocation.java
+++ b/src/main/java/org/atlasapi/deer/elasticsearch/EsLocation.java
@@ -1,0 +1,92 @@
+package org.atlasapi.deer.elasticsearch;
+
+import com.google.common.base.Functions;
+import com.google.common.collect.Iterables;
+import org.atlasapi.deer.elasticsearch.content.Alias;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.joda.time.DateTime;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+public class EsLocation extends EsObject {
+
+    public static final String AVAILABILITY_TIME = "availabilityTime";
+    public static final String AVAILABILITY_END_TIME = "availabilityEndTime";
+    public static final String ALIASES = "aliases";
+
+    public static XContentBuilder getMapping() throws IOException {
+        return XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject(AVAILABILITY_TIME)
+                .field("type").value("date")
+                .field("format").value("dateOptionalTime")
+                .endObject()
+                .startObject(AVAILABILITY_END_TIME)
+                .field("type").value("date")
+                .field("format").value("dateOptionalTime")
+                .endObject()
+                .startObject(ALIASES)
+                .field("type").value("nested")
+                .rawField("properties", EsAlias.getMapping().bytes())
+                .endObject()
+                .endObject();
+    }
+
+    public EsLocation availabilityTime(Date availabilityTime) {
+        properties.put(AVAILABILITY_TIME, availabilityTime);
+        return this;
+    }
+
+    public EsLocation availabilityEndTime(Date availabilityEndTime) {
+        properties.put(AVAILABILITY_END_TIME, availabilityEndTime);
+        return this;
+    }
+
+    public EsLocation aliases(Iterable<Alias> aliases) {
+        properties.put(
+                ALIASES,
+                Iterables.transform(aliases, Functions.compose(TO_MAP, EsAlias.toEsAlias()))
+        );
+        return this;
+    }
+
+    public EsLocation aliasesFromEs(Iterable<EsAlias> aliases) {
+        properties.put(
+                ALIASES,
+                StreamSupport.stream(aliases.spliterator(), false)
+                        .map(TO_MAP::apply)
+                        .collect(Collectors.toList())
+        );
+
+        return this;
+    }
+
+    public static EsLocation fromMap(Map<String, Object> map) {
+        EsLocation esLocation = new EsLocation();
+        if (map.get(AVAILABILITY_TIME) != null) {
+            esLocation.availabilityTime(new DateTime(map.get(AVAILABILITY_TIME)).toDate());
+        }
+        if (map.get(AVAILABILITY_END_TIME) != null) {
+            esLocation.availabilityEndTime(new DateTime(map.get(AVAILABILITY_END_TIME)).toDate());
+        }
+
+        if (map.get(ALIASES) != null) {
+                esLocation.aliasesFromEs(
+                        (List<EsAlias>) StreamSupport.stream(
+                                ((Iterable<Map>)map.get(ALIASES)).spliterator(),
+                                false
+                        )
+                                .map(EsAlias::fromMap)
+                                .collect(Collectors.toList())
+                );
+        }
+        return esLocation;
+    }
+
+}

--- a/src/main/java/org/atlasapi/deer/elasticsearch/EsObject.java
+++ b/src/main/java/org/atlasapi/deer/elasticsearch/EsObject.java
@@ -1,0 +1,35 @@
+package org.atlasapi.deer.elasticsearch;
+
+import com.google.common.base.Function;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class EsObject {
+
+    public final static FromEsObjectToMap TO_MAP = new FromEsObjectToMap();
+
+    protected Map<String, Object> properties = new HashMap<String, Object>() {
+
+        @Override
+        public Object put(String k, Object v) {
+            if (k != null && v != null) {
+                return super.put(k, v);
+            } else {
+                return null;
+            }
+        }
+    };
+
+    public Map<String, Object> toMap() {
+        return properties;
+    }
+
+    public static class FromEsObjectToMap implements Function<EsObject, Map<String, Object>> {
+
+        @Override
+        public Map<String, Object> apply(EsObject input) {
+            return input.toMap();
+        }
+    }
+}

--- a/src/main/java/org/atlasapi/deer/elasticsearch/EsPriceMapping.java
+++ b/src/main/java/org/atlasapi/deer/elasticsearch/EsPriceMapping.java
@@ -1,0 +1,38 @@
+package org.atlasapi.deer.elasticsearch;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+
+import java.io.IOException;
+import java.util.Currency;
+
+public class EsPriceMapping extends EsObject {
+
+    public static final String CURRENCY = "currency";
+    public static final String VALUE = "value";
+
+    public static final XContentBuilder getMapping() throws IOException {
+        return XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject(EsPriceMapping.CURRENCY)
+                .field("type").value("string")
+                .field("index").value("not_analyzed")
+                .endObject()
+                .startObject(EsPriceMapping.VALUE)
+                .field("type").value("integer")
+                .field("index").value("not_analyzed")
+                .endObject()
+                .endObject();
+    }
+
+    public EsPriceMapping currency(Currency currency) {
+        properties.put(CURRENCY, currency.getCurrencyCode());
+        return this;
+    }
+
+    public EsPriceMapping value(Integer value) {
+        properties.put(VALUE, value);
+        return this;
+    }
+
+}

--- a/src/main/java/org/atlasapi/deer/elasticsearch/EsSchema.java
+++ b/src/main/java/org/atlasapi/deer/elasticsearch/EsSchema.java
@@ -1,0 +1,8 @@
+package org.atlasapi.deer.elasticsearch;
+
+public interface EsSchema {
+
+    public final static String CONTENT_INDEX = "content";
+    public final static String TOPICS_INDEX = "topics";
+
+}

--- a/src/main/java/org/atlasapi/deer/elasticsearch/EsTopicMapping.java
+++ b/src/main/java/org/atlasapi/deer/elasticsearch/EsTopicMapping.java
@@ -1,0 +1,63 @@
+package org.atlasapi.deer.elasticsearch;
+
+import com.google.common.collect.ImmutableMap;
+import org.atlasapi.deer.elasticsearch.content.Tag;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+
+import java.io.IOException;
+
+public class EsTopicMapping extends EsObject {
+
+    public static final XContentBuilder getMapping() throws IOException {
+        return XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject(EsTopicMapping.TOPIC)
+                .field("type").value("nested")
+                .startObject(EsTopicMapping.ID)
+                .field("type").value("long")
+                .endObject()
+                .endObject()
+                .startObject(EsTopicMapping.SUPERVISED)
+                .field("type").value("boolean")
+                .endObject()
+                .startObject(EsTopicMapping.WEIGHTING)
+                .field("type").value("float")
+                .endObject()
+                .startObject(EsTopicMapping.RELATIONSHIP)
+                .field("type").value("string")
+                .field("index").value("not_analyzed")
+                .endObject()
+                .endObject();
+    }
+
+    public final static String TOPIC = "topic";
+    public final static String ID = "id";
+    public static final String TOPIC_ID = TOPIC + "." + ID;
+    public static final String SUPERVISED = "supervised";
+    public static final String WEIGHTING = "weighting";
+    public static final String RELATIONSHIP = "relationship";
+
+    public EsTopicMapping topicId(Long id) {
+        properties.put(TOPIC, ImmutableMap.of(ID, id));
+        return this;
+    }
+
+    public EsTopicMapping supervised(Boolean supervised) {
+        properties.put(SUPERVISED, supervised);
+        return this;
+    }
+
+    public EsTopicMapping weighting(Float weighting) {
+        properties.put(WEIGHTING, weighting);
+        return this;
+    }
+
+    public EsTopicMapping relationship(Tag.Relationship relationship) {
+        if (relationship != null) {
+            properties.put(RELATIONSHIP, relationship.toString());
+        }
+        return this;
+    }
+
+}

--- a/src/main/java/org/atlasapi/deer/elasticsearch/FiltersBuilder.java
+++ b/src/main/java/org/atlasapi/deer/elasticsearch/FiltersBuilder.java
@@ -1,0 +1,30 @@
+package org.atlasapi.deer.elasticsearch;
+
+import com.google.common.collect.Iterables;
+import org.atlasapi.deer.elasticsearch.content.Specialization;
+import org.atlasapi.media.entity.Publisher;
+import org.elasticsearch.index.query.FilterBuilders;
+import org.elasticsearch.index.query.TermsFilterBuilder;
+
+// I have simplified this class to avoid importing other classes we don't need
+public class FiltersBuilder {
+
+    private FiltersBuilder() {
+    }
+
+    public static TermsFilterBuilder buildForPublishers(
+            String field,
+            Iterable<Publisher> publishers
+    ) {
+        return FilterBuilders.termsFilter(field, Iterables.transform(publishers, Publisher.TO_KEY));
+    }
+
+    public static TermsFilterBuilder buildForSpecializations(
+            Iterable<Specialization> specializations
+    ) {
+        return FilterBuilders.termsFilter(
+                EsContent.SPECIALIZATION,
+                Iterables.transform(specializations, Enum::name)
+        );
+    }
+}

--- a/src/main/java/org/atlasapi/deer/elasticsearch/SearchQuery.java
+++ b/src/main/java/org/atlasapi/deer/elasticsearch/SearchQuery.java
@@ -1,0 +1,243 @@
+package org.atlasapi.deer.elasticsearch;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.metabroadcast.common.query.Selection;
+import com.metabroadcast.common.url.QueryStringParameters;
+import org.atlasapi.deer.elasticsearch.content.Specialization;
+import org.atlasapi.media.entity.Publisher;
+
+import java.util.Set;
+
+public class SearchQuery {
+
+    public static final Builder builder(String query) {
+        return new Builder(query);
+    }
+
+    public static class Builder {
+
+        private final String query;
+        private Selection selection = Selection.ALL;
+        private Set<Specialization> specializations = ImmutableSet.of();
+        private Set<Publisher> publishers = ImmutableSet.of();
+        private float title = 0;
+        private float broadcast = 0;
+        private float catchup = 0;
+        private String type;
+        private Boolean topLevelOnly;
+        private Boolean currentBroadcastsOnly;
+        private float priorityChannelWeighting = 1.0f;
+
+        public Builder(String query) {
+            this.query = query;
+        }
+
+        public Builder withSelection(Selection selection) {
+            this.selection = selection;
+            return this;
+        }
+
+        public Builder withSpecializations(Iterable<Specialization> specializations) {
+            this.specializations = ImmutableSet.copyOf(specializations);
+            return this;
+        }
+
+        public Builder withPublishers(Iterable<Publisher> publishers) {
+            this.publishers = ImmutableSet.copyOf(publishers);
+            return this;
+        }
+
+        public Builder withTitleWeighting(float titleWeighting) {
+            this.title = titleWeighting;
+            return this;
+        }
+
+        public Builder withBroadcastWeighting(float broadcastWeighting) {
+            this.broadcast = broadcastWeighting;
+            return this;
+        }
+
+        public Builder withCatchupWeighting(float catchupWeighting) {
+            this.catchup = catchupWeighting;
+            return this;
+        }
+
+        public Builder withType(String type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder withCurrentBroadcastsOnly(boolean currentBroadcastsOnly) {
+            this.currentBroadcastsOnly = currentBroadcastsOnly;
+            return this;
+        }
+
+        public Builder withPriorityChannelWeighting(float priorityChannelWeighting) {
+            this.priorityChannelWeighting = priorityChannelWeighting;
+            return this;
+        }
+
+        public org.atlasapi.deer.elasticsearch.SearchQuery build() {
+            return new org.atlasapi.deer.elasticsearch.SearchQuery(query,
+                    selection,
+                    specializations,
+                    publishers,
+                    title,
+                    broadcast,
+                    catchup,
+                    type,
+                    topLevelOnly,
+                    currentBroadcastsOnly,
+                    priorityChannelWeighting
+            );
+        }
+
+        public Builder isTopLevelOnly(Boolean topLevel) {
+            this.topLevelOnly = topLevel;
+            return this;
+        }
+    }
+
+    private static final Joiner CSV = Joiner.on(',');
+
+    private final String term;
+    private final Selection selection;
+    private final Set<Specialization> includedSpecializations;
+    private final Set<Publisher> includedPublishers;
+    private final float titleWeighting;
+    private final float broadcastWeighting;
+    private final float catchupWeighting;
+    private final String type;
+    private final float priorityChannelWeighting;
+    private final Boolean topLevelOnly;
+    private final Boolean currentBroadcastsOnly;
+
+    /**
+     * Use a Builder
+     */
+    @Deprecated
+    public SearchQuery(String term, Selection selection, float titleWeighting,
+                       float broadcastWeighting, float availabilityWeighting) {
+        this(
+                term,
+                selection,
+                Sets.<Specialization>newHashSet(),
+                Sets.<Publisher>newHashSet(),
+                titleWeighting,
+                broadcastWeighting,
+                availabilityWeighting,
+                null,
+                null,
+                null,
+                1.0f
+        );
+    }
+
+    /**
+     * Use a Builder
+     */
+    @Deprecated
+    public SearchQuery(String term, Selection selection, Iterable<Publisher> includedPublishers,
+                       float titleWeighting, float broadcastWeighting, float availabilityWeighting) {
+        this(
+                term,
+                selection,
+                Sets.<Specialization>newHashSet(),
+                includedPublishers,
+                titleWeighting,
+                broadcastWeighting,
+                availabilityWeighting,
+                null,
+                null,
+                null,
+                1.0f
+        );
+    }
+
+    public SearchQuery(String term, Selection selection,
+                       Iterable<Specialization> includedSpecializations,
+                       Iterable<Publisher> includedPublishers,
+                       float titleWeighting, float broadcastWeighting, float availabilityWeighting,
+                       String type, Boolean topLevelOnly, Boolean currentBroadcastsOnly,
+                       float priorityChannelWeighting) {
+        this.term = term;
+        this.selection = selection;
+        this.titleWeighting = titleWeighting;
+        this.broadcastWeighting = broadcastWeighting;
+        this.catchupWeighting = availabilityWeighting;
+        this.type = type;
+        this.topLevelOnly = topLevelOnly;
+        this.currentBroadcastsOnly = currentBroadcastsOnly;
+        this.includedSpecializations = ImmutableSet.copyOf(includedSpecializations);
+        this.includedPublishers = ImmutableSet.copyOf(includedPublishers);
+        this.priorityChannelWeighting = priorityChannelWeighting;
+    }
+
+    public String getTerm() {
+        return term;
+    }
+
+    public Selection getSelection() {
+        return selection;
+    }
+
+    public Set<Specialization> getIncludedSpecializations() {
+        return includedSpecializations;
+    }
+
+    public Set<Publisher> getIncludedPublishers() {
+        return includedPublishers;
+    }
+
+    public float getTitleWeighting() {
+        return titleWeighting;
+    }
+
+    public float getBroadcastWeighting() {
+        return broadcastWeighting;
+    }
+
+    public float getCatchupWeighting() {
+        return catchupWeighting;
+    }
+
+    public String type() {
+        return this.type;
+    }
+
+    public Boolean topLevelOnly() {
+        return this.topLevelOnly;
+    }
+
+    public Boolean currentBroadcastsOnly() {
+        return this.currentBroadcastsOnly;
+    }
+
+    public float getPriorityChannelWeighting() {
+        return this.priorityChannelWeighting;
+    }
+
+    public QueryStringParameters toQueryStringParameters() {
+        QueryStringParameters params = new QueryStringParameters()
+                .add("title", term)
+                .addAll(selection.asQueryStringParameters())
+                .add("specializations", CSV.join(includedSpecializations))
+                .add("publishers", CSV.join(includedPublishers))
+                .add("titleWeighting", String.valueOf(titleWeighting))
+                .add("broadcastWeighting", String.valueOf(broadcastWeighting))
+                .add("priorityChannelWeighting", String.valueOf(priorityChannelWeighting))
+                .add("catchupWeighting", String.valueOf(catchupWeighting));
+        if (topLevelOnly != null) {
+            params.add("topLevelOnly", topLevelOnly.toString());
+        }
+        if (type != null) {
+            params.add("type", type);
+        }
+        if (currentBroadcastsOnly != null) {
+            params.add("currentBroadcastsOnly", currentBroadcastsOnly.toString());
+        }
+        return params;
+    }
+}

--- a/src/main/java/org/atlasapi/deer/elasticsearch/SearchResults.java
+++ b/src/main/java/org/atlasapi/deer/elasticsearch/SearchResults.java
@@ -1,0 +1,33 @@
+package org.atlasapi.deer.elasticsearch;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import org.atlasapi.deer.elasticsearch.content.Id;
+
+import java.util.Iterator;
+import java.util.List;
+
+public class SearchResults implements Iterable<Id> {
+
+    private ImmutableSet<Id> results;
+
+    public SearchResults() { /* for GSON */ }
+
+    public static final SearchResults from(Iterable<Long> ids) {
+        return new SearchResults(Iterables.transform(ids, Id.fromLongValue()));
+    }
+
+    public SearchResults(Iterable<Id> ids) {
+        //ImmutableSet maintains insertion order
+        this.results = ImmutableSet.copyOf(ids);
+    }
+
+    public List<Id> getIds() {
+        return results.asList();
+    }
+
+    @Override
+    public Iterator<Id> iterator() {
+        return results.iterator();
+    }
+}

--- a/src/main/java/org/atlasapi/deer/elasticsearch/Strings.java
+++ b/src/main/java/org/atlasapi/deer/elasticsearch/Strings.java
@@ -1,0 +1,49 @@
+package org.atlasapi.deer.elasticsearch;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.util.CharArraySet;
+import org.apache.lucene.util.Version;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.List;
+
+public class Strings {
+
+    public static List<String> tokenize(String value, boolean filterStopWords) {
+        List<String> tokensAsStrings = Lists.newArrayList();
+        try {
+            TokenStream tokens;
+            if (filterStopWords) {
+                tokens = new StandardAnalyzer(Version.LATEST)
+                        .tokenStream("", new StringReader(value));
+            } else {
+                tokens = new StandardAnalyzer(Version.LATEST, CharArraySet.EMPTY_SET)
+                        .tokenStream("", new StringReader(value));
+            }
+            tokens.reset();
+            while (tokens.incrementToken()) {
+                CharTermAttribute token = tokens.getAttribute(CharTermAttribute.class);
+                tokensAsStrings.add(token.toString());
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        if (tokensAsStrings.isEmpty() && filterStopWords) {
+            return tokenize(value, false);
+        } else {
+            return tokensAsStrings;
+        }
+    }
+
+    public static String flatten(String value) {
+        return Joiner.on("")
+                .join(tokenize(value, true))
+                .replaceAll("[^a-zA-Z0-9]", "")
+                .toLowerCase();
+    }
+}

--- a/src/main/java/org/atlasapi/deer/elasticsearch/TitleQueryBuilder.java
+++ b/src/main/java/org/atlasapi/deer/elasticsearch/TitleQueryBuilder.java
@@ -1,0 +1,125 @@
+package org.atlasapi.deer.elasticsearch;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import org.elasticsearch.common.unit.Fuzziness;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.FuzzyQueryBuilder;
+import org.elasticsearch.index.query.PrefixQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.TermQueryBuilder;
+
+import java.util.List;
+import java.util.Map;
+
+public class TitleQueryBuilder {
+
+    private static final Joiner JOINER = Joiner.on("");
+    private static final int USE_PREFIX_SEARCH_UP_TO = 2;
+    private static final Map<String, String> EXPANSIONS = ImmutableMap.<String, String>builder().put(
+            "dr",
+            "doctor"
+    ).put("rd", "road").build();
+    private static final Function<String, String> TOKEN_EXPANDER = token -> {
+        String expanded = EXPANSIONS.get(token);
+        if (expanded != null) {
+            return expanded;
+        }
+        return token;
+    };
+
+    public static QueryBuilder build(String title, float boost) {
+        List<String> tokens = Strings.tokenize(title, true);
+        QueryBuilder query = null;
+        if (shouldUsePrefixSearch(tokens)) {
+            query = prefixSearch(Iterables.getOnlyElement(tokens));
+        } else {
+            query = fuzzyTermSearch(Strings.flatten(title), tokens);
+        }
+        return QueryBuilders.functionScoreQuery(query).boost(boost);
+    }
+
+    private static boolean shouldUsePrefixSearch(List<String> tokens) {
+        return tokens.size() == 1
+                && Iterables.getOnlyElement(tokens).length() <= USE_PREFIX_SEARCH_UP_TO;
+    }
+
+    private static QueryBuilder prefixSearch(String token) {
+        BoolQueryBuilder withExpansions = new BoolQueryBuilder();
+        withExpansions.minimumNumberShouldMatch(1);
+        withExpansions.should(prefixQuery(token));
+        //
+        String expanded = EXPANSIONS.get(token);
+        if (expanded != null) {
+            withExpansions.should(prefixQuery(expanded));
+        }
+        return withExpansions;
+    }
+
+    private static QueryBuilder prefixQuery(String prefix) {
+        return new PrefixQueryBuilder(EsContent.PARENT_FLATTENED_TITLE, prefix);
+    }
+
+    private static QueryBuilder fuzzyTermSearch(String value, List<String> tokens) {
+        BoolQueryBuilder queryForTerms = new BoolQueryBuilder();
+        for (String token : tokens) {
+            BoolQueryBuilder queryForThisTerm = new BoolQueryBuilder();
+            queryForThisTerm.minimumNumberShouldMatch(1);
+
+            QueryBuilder prefix = QueryBuilders.functionScoreQuery(new PrefixQueryBuilder(
+                    EsContent.PARENT_TITLE,
+                    token
+            )).boost(50);
+            queryForThisTerm.should(prefix);
+
+            QueryBuilder fuzzy = new FuzzyQueryBuilder(EsContent.PARENT_TITLE, token)
+                    .fuzziness(Fuzziness.AUTO)
+                    .prefixLength(USE_PREFIX_SEARCH_UP_TO);
+            queryForThisTerm.should(fuzzy);
+
+            queryForTerms.must(queryForThisTerm);
+        }
+
+        BoolQueryBuilder either = new BoolQueryBuilder();
+        either.minimumNumberShouldMatch(1);
+
+        either.should(queryForTerms);
+        either.should(fuzzyWithoutSpaces(value));
+
+        QueryBuilder prefix = QueryBuilders.functionScoreQuery(prefixSearch(value)).boost(50);
+        either.should(prefix);
+
+        QueryBuilder exact = QueryBuilders.functionScoreQuery(exactMatch(value, tokens)).boost(200);
+        either.should(exact);
+
+        return either;
+    }
+
+    private static QueryBuilder exactMatch(String value, Iterable<String> tokens) {
+        BoolQueryBuilder exactMatch = new BoolQueryBuilder();
+        exactMatch.minimumNumberShouldMatch(1);
+        exactMatch.should(new TermQueryBuilder(EsContent.PARENT_FLATTENED_TITLE, value));
+
+        Iterable<String> transformed = Iterables.transform(tokens, TOKEN_EXPANDER);
+
+        String flattenedAndExpanded = JOINER.join(transformed);
+
+        if (!flattenedAndExpanded.equals(value)) {
+            exactMatch.should(new TermQueryBuilder(
+                    EsContent.PARENT_FLATTENED_TITLE,
+                    flattenedAndExpanded
+            ));
+        }
+        return exactMatch;
+    }
+
+    private static QueryBuilder fuzzyWithoutSpaces(String value) {
+        return new FuzzyQueryBuilder(EsContent.PARENT_FLATTENED_TITLE, value)
+                .fuzziness(Fuzziness.AUTO)
+                .prefixLength(USE_PREFIX_SEARCH_UP_TO)
+                .boost(20);
+    }
+}

--- a/src/main/java/org/atlasapi/deer/elasticsearch/content/Alias.java
+++ b/src/main/java/org/atlasapi/deer/elasticsearch/content/Alias.java
@@ -1,0 +1,52 @@
+package org.atlasapi.deer.elasticsearch.content;
+
+import com.google.common.base.Objects;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class Alias implements Hashable {
+
+    public static final String URI_NAMESPACE = "uri";
+
+    private final String namespace;
+    private final String value;
+
+    public Alias(String namespace, String value) {
+        this.namespace = checkNotNull(namespace);
+        this.value = checkNotNull(value);
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public int hashCode() {
+        return namespace.hashCode() ^ value.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object that) {
+        if (this == that) {
+            return true;
+        }
+        if (that instanceof Alias) {
+            Alias other = (Alias) that;
+            return namespace.equals(other.namespace)
+                    && value.equals(other.value);
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(getClass())
+                .add("namespace", namespace)
+                .add("value", value)
+                .toString();
+    }
+}

--- a/src/main/java/org/atlasapi/deer/elasticsearch/content/ContentType.java
+++ b/src/main/java/org/atlasapi/deer/elasticsearch/content/ContentType.java
@@ -1,0 +1,23 @@
+package org.atlasapi.deer.elasticsearch.content;
+
+// I have simplified this class to avoid importing other classes we don't need
+public enum ContentType {
+
+    BRAND,
+    SERIES,
+    ITEM,
+    EPISODE,
+    FILM,
+    SONG,
+    CLIP,
+    ;
+
+    public String getKey() {
+        return this.name().toLowerCase();
+    }
+
+    @Override
+    public String toString() {
+        return getKey();
+    }
+}

--- a/src/main/java/org/atlasapi/deer/elasticsearch/content/FieldName.java
+++ b/src/main/java/org/atlasapi/deer/elasticsearch/content/FieldName.java
@@ -1,0 +1,14 @@
+package org.atlasapi.deer.elasticsearch.content;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface FieldName {
+
+    String value();
+
+}

--- a/src/main/java/org/atlasapi/deer/elasticsearch/content/Hashable.java
+++ b/src/main/java/org/atlasapi/deer/elasticsearch/content/Hashable.java
@@ -1,0 +1,8 @@
+package org.atlasapi.deer.elasticsearch.content;
+
+/**
+ * Indicates that this class can be hashed by our custom hashing logic
+ */
+public interface Hashable {
+
+}

--- a/src/main/java/org/atlasapi/deer/elasticsearch/content/Id.java
+++ b/src/main/java/org/atlasapi/deer/elasticsearch/content/Id.java
@@ -1,0 +1,104 @@
+package org.atlasapi.deer.elasticsearch.content;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.google.common.base.Function;
+import com.google.common.primitives.Longs;
+
+import java.math.BigInteger;
+
+public final class Id implements Comparable<Id>, Hashable {
+
+    public static final Function<Id, Long> toLongValue() {
+        return ToLongValueFunction.INSTANCE;
+    }
+
+    private enum ToLongValueFunction implements Function<Id, Long> {
+        INSTANCE;
+
+        @Override
+        public Long apply(Id input) {
+            return input.longValue;
+        }
+
+    }
+
+    public static final Function<Long, Id> fromLongValue() {
+        return FromLongValueFunction.INSTANCE;
+    }
+
+    private enum FromLongValueFunction implements Function<Long, Id> {
+        INSTANCE;
+
+        @Override
+        public Id apply(Long input) {
+            return Id.valueOf(input);
+        }
+    }
+
+    public static Id valueOf(String id) {
+        return valueOf(Long.parseLong(id));
+    }
+
+    public static final Id valueOf(BigInteger bigInt) {
+        return valueOf(bigInt.longValue());
+    }
+
+    public static final Id valueOf(int intValue) {
+        return valueOf((long) intValue);
+    }
+
+    public static final Id valueOf(long longValue) {
+        return new Id(longValue);
+    }
+
+    private long longValue;
+
+    private Id(Long longValue) {
+        this.longValue = longValue;
+    }
+
+    @JsonCreator
+    private Id(long longValue) {
+        this.longValue = longValue;
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
+    @JsonSubTypes.Type(value = Long.class)
+    public long longValue() {
+        return longValue;
+    }
+
+    public BigInteger toBigInteger() {
+        return BigInteger.valueOf(longValue);
+    }
+
+    @Override
+    public int compareTo(Id other) {
+        return Longs.compare(longValue, other.longValue);
+    }
+
+    @Override
+    public boolean equals(Object that) {
+        if (this == that) {
+            return true;
+        }
+        if (that instanceof Id) {
+            Id other = (Id) that;
+            return longValue == other.longValue;
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Longs.hashCode(longValue);
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(longValue);
+    }
+
+}

--- a/src/main/java/org/atlasapi/deer/elasticsearch/content/Specialization.java
+++ b/src/main/java/org/atlasapi/deer/elasticsearch/content/Specialization.java
@@ -1,0 +1,56 @@
+package org.atlasapi.deer.elasticsearch.content;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Sets;
+import com.metabroadcast.common.base.Maybe;
+
+import java.util.Set;
+
+public enum Specialization {
+
+    TV,
+    RADIO,
+    MUSIC,
+    FILM;
+    private static final Splitter CSV_SPLITTER = Splitter.on(',').trimResults();
+
+    public static Maybe<Specialization> fromKey(String key) {
+        for (Specialization s : Specialization.values()) {
+            if (key.toLowerCase().equals(s.toString())) {
+                return Maybe.just(s);
+            }
+        }
+        return Maybe.nothing();
+    }
+
+    public static Function<String, Optional<Specialization>> FROM_KEY() {
+        return str -> {
+            Maybe<Specialization> maybe = Specialization.fromKey(str);
+            if (maybe.hasValue()) {
+                return Optional.of(maybe.requireValue());
+            }
+            return Optional.absent();
+        };
+    }
+
+    public static Iterable<Specialization> fromCsv(String csv) {
+        Iterable<String> splits = CSV_SPLITTER.split(csv);
+        Set<Specialization> result = Sets.newHashSet();
+        for (String candidate : splits) {
+            for (Specialization specialization : Specialization.values()) {
+                if (candidate.toLowerCase().equals(specialization.toString())) {
+                    result.add(specialization);
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return name().toLowerCase();
+    }
+}

--- a/src/main/java/org/atlasapi/deer/elasticsearch/content/Tag.java
+++ b/src/main/java/org/atlasapi/deer/elasticsearch/content/Tag.java
@@ -1,0 +1,175 @@
+package org.atlasapi.deer.elasticsearch.content;
+
+import com.google.common.base.Function;
+import com.google.common.base.Functions;
+import com.google.common.base.Objects;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import org.atlasapi.media.entity.Publisher;
+
+import javax.annotation.Nullable;
+
+// I have simplified this class to avoid importing other classes we don't need
+public class Tag implements Hashable {
+
+    private Id topic;
+    private Publisher publisher;
+    private Boolean supervised;
+    private Float weighting;
+    private Relationship relationship;
+    private Integer offset;
+
+    public static Tag valueOf(Id topicId, Float weighting, Boolean supervised,
+            Relationship relationship) {
+        return new Tag(topicId, weighting, supervised, relationship);
+    }
+
+    public Tag(long topicId, Float weighting, Boolean supervised, Relationship relationship) {
+        this(Id.valueOf(topicId), weighting, supervised, relationship, null);
+    }
+
+    public Tag(Id topicId, Float weighting, Boolean supervised, Relationship relationship) {
+        this(topicId, weighting, supervised, relationship, null);
+    }
+
+    public Tag(Id topicId, Float weighting, Boolean supervised, Relationship relationship,
+            Integer offset) {
+        this.topic = topicId;
+        this.weighting = weighting;
+        this.supervised = supervised;
+        this.relationship = relationship;
+        this.offset = offset;
+    }
+
+    public void setTopicUri(Id topic) {
+        this.topic = topic;
+    }
+
+    public void setWeighting(Float weighting) {
+        this.weighting = weighting;
+    }
+
+    public void setSupervised(Boolean supervised) {
+        this.supervised = supervised;
+    }
+
+    public void setRelationship(Relationship relationship) {
+        this.relationship = relationship;
+    }
+
+    @FieldName("weighting")
+    public Float getWeighting() {
+        return weighting;
+    }
+
+    @FieldName("is_supervised")
+    public Boolean isSupervised() {
+        return supervised;
+    }
+
+    @FieldName("topic")
+    public Id getTopic() {
+        return topic;
+    }
+
+    @FieldName("relationship")
+    public Relationship getRelationship() {
+        return relationship;
+    }
+
+    public void setOffset(Integer offset) {
+        this.offset = offset;
+    }
+
+    @FieldName("offset")
+    public Integer getOffset() {
+        return this.offset;
+    }
+
+    public void setPublisher(Publisher publisher) {
+        this.publisher = publisher;
+    }
+
+    @FieldName("publisher")
+    public Publisher getPublisher() {
+        return publisher;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(supervised, topic, weighting, relationship);
+    }
+
+    @Override
+    public boolean equals(Object that) {
+        if (this == that) {
+            return true;
+        }
+        if (that instanceof Tag) {
+            Tag other = (Tag) that;
+            return Objects.equal(supervised, other.supervised)
+                    && Objects.equal(weighting, other.weighting)
+                    && Objects.equal(topic, other.topic)
+                    && Objects.equal(relationship, other.relationship);
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "Ref topic %s, %+.2f, %s supervised, with relationship %s",
+                topic,
+                weighting,
+                supervised ? "" : "not",
+                relationship
+        );
+    }
+
+    public enum Relationship {
+
+        ABOUT("about"),
+        TWITTER_AUDIENCE("twitter:audience"),
+        TWITTER_AUDIENCE_RELATED("twitter:audience-related"),
+        TWITTER_AUDIENCE_REALTIME("twitter:audience:realtime"),
+        TRANSCRIPTION("transcription"),
+        TRANSCRIPTION_SUBTITLES("transcription:subtitles"),
+        TRANSCRIPTION_SUBTITLES_REALTIME("transcription:subtitles:realtime");
+        private final String name;
+
+        Relationship(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+
+        private static ImmutableSet<Relationship> ALL = ImmutableSet.copyOf(values());
+
+        public static ImmutableSet<Relationship> all() {
+            return ALL;
+        }
+
+        private static ImmutableMap<String, Optional<Relationship>> LOOKUP = ImmutableMap.copyOf(
+                Maps.transformValues(
+                        Maps.uniqueIndex(all(), Functions.toStringFunction()),
+                        new Function<Relationship, Optional<Relationship>>() {
+
+                            @Override
+                            public Optional<Relationship> apply(@Nullable Relationship input) {
+                                return Optional.fromNullable(input);
+                            }
+                        }
+                ));
+
+        public static Optional<Relationship> fromString(String relationship) {
+            Optional<Relationship> possibleRelationship = LOOKUP.get(relationship);
+            return possibleRelationship != null ? possibleRelationship
+                                                : Optional.absent();
+        }
+    }
+}

--- a/src/main/java/org/atlasapi/query/SearchModule.java
+++ b/src/main/java/org/atlasapi/query/SearchModule.java
@@ -1,9 +1,10 @@
 package org.atlasapi.query;
 
-import javax.annotation.PostConstruct;
-
-import org.atlasapi.content.ContentTitleSearcher;
-import org.atlasapi.content.EsContentTitleSearcher;
+import com.google.common.base.Strings;
+import com.google.common.primitives.Ints;
+import com.metabroadcast.common.properties.Configurer;
+import org.atlasapi.deer.elasticsearch.ContentTitleSearcher;
+import org.atlasapi.deer.elasticsearch.EsContentTitleSearcher;
 import org.atlasapi.persistence.content.ContentResolver;
 import org.atlasapi.persistence.content.PeopleQueryResolver;
 import org.atlasapi.persistence.content.SearchResolver;
@@ -11,14 +12,9 @@ import org.atlasapi.persistence.content.query.KnownTypeQueryExecutor;
 import org.atlasapi.persistence.lookup.entry.LookupEntryStore;
 import org.atlasapi.query.content.fuzzy.RemoteFuzzySearcher;
 import org.atlasapi.query.content.search.ContentResolvingSearcher;
-import org.atlasapi.query.content.search.DummySearcher;
 import org.atlasapi.query.content.search.DeerSearchResolver;
+import org.atlasapi.query.content.search.DummySearcher;
 import org.atlasapi.search.ContentSearcher;
-
-import com.metabroadcast.common.properties.Configurer;
-
-import com.google.common.base.Strings;
-import com.google.common.primitives.Ints;
 import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -29,6 +25,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+
+import javax.annotation.PostConstruct;
 
 @Configuration
 public class SearchModule {

--- a/src/main/java/org/atlasapi/query/content/search/DeerSearchResolver.java
+++ b/src/main/java/org/atlasapi/query/content/search/DeerSearchResolver.java
@@ -1,27 +1,26 @@
 package org.atlasapi.query.content.search;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
-import org.atlasapi.content.ContentTitleSearcher;
-import org.atlasapi.entity.Id;
+import com.google.common.collect.ImmutableSet;
+import com.metabroadcast.applications.client.model.internal.Application;
+import com.metabroadcast.common.base.Maybe;
+import com.metabroadcast.common.stream.MoreCollectors;
+import com.metabroadcast.common.stream.MoreStreams;
+import org.atlasapi.deer.elasticsearch.ContentTitleSearcher;
+import org.atlasapi.deer.elasticsearch.SearchResults;
+import org.atlasapi.deer.elasticsearch.content.Id;
+import org.atlasapi.deer.elasticsearch.content.Specialization;
 import org.atlasapi.media.entity.Identified;
 import org.atlasapi.persistence.content.ContentResolver;
 import org.atlasapi.persistence.content.ResolvedContent;
 import org.atlasapi.persistence.content.SearchResolver;
 import org.atlasapi.persistence.lookup.entry.LookupEntry;
 import org.atlasapi.persistence.lookup.entry.LookupEntryStore;
-import org.atlasapi.search.SearchResults;
 
-import com.metabroadcast.applications.client.model.internal.Application;
-import com.metabroadcast.common.base.Maybe;
-import com.metabroadcast.common.stream.MoreCollectors;
-import com.metabroadcast.common.stream.MoreStreams;
-
-import com.google.common.collect.ImmutableSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -49,8 +48,8 @@ public class DeerSearchResolver implements SearchResolver {
             org.atlasapi.search.model.SearchQuery owlQuery,
             Application application
     ) {
-        org.atlasapi.search.SearchQuery.Builder deerSearchQuery =
-                new org.atlasapi.search.SearchQuery.Builder(owlQuery.getTerm());
+        org.atlasapi.deer.elasticsearch.SearchQuery.Builder deerSearchQuery =
+                new org.atlasapi.deer.elasticsearch.SearchQuery.Builder(owlQuery.getTerm());
 
         if (owlQuery.getSelection() != null) {
             deerSearchQuery.withSelection(owlQuery.getSelection());
@@ -84,7 +83,7 @@ public class DeerSearchResolver implements SearchResolver {
         return search(deerSearchQuery.build());
     }
 
-    public List<Identified> search(org.atlasapi.search.SearchQuery query) {
+    public List<Identified> search(org.atlasapi.deer.elasticsearch.SearchQuery query) {
         try {
             SearchResults results = searcher.search(query).get(timeout, TimeUnit.MILLISECONDS);
             return resolveIds(results.getIds());
@@ -107,12 +106,12 @@ public class DeerSearchResolver implements SearchResolver {
         return resolved.getAllResolvedResults();
     }
 
-    private Set<org.atlasapi.content.Specialization> getDeerSpecializations(
+    private Set<Specialization> getDeerSpecializations(
             Set<org.atlasapi.media.entity.Specialization> owlSpecializations) {
 
         return owlSpecializations.stream()
                 .map(org.atlasapi.media.entity.Specialization::toString)
-                .map(org.atlasapi.content.Specialization::fromKey)
+                .map(Specialization::fromKey)
                 .filter(Maybe::hasValue)
                 .map(Maybe::requireValue)
                 .collect(Collectors.toSet());


### PR DESCRIPTION
Simplified a few classes to avoid having to import
other classes that would not be needed.

Although not ideal we are copying these so that we
do not have to import deer libraries. The main reason
is that some beans in deer are being discovered
by autowiring that are causing issues sometimes when
deploying owl-api.

Since we are likely moving away from the current
elastic search anyway, a more proper solution will
likely not be worth the trouble.