### PR TITLE
Move equiv messaging to lookup writer (ENG-757)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -446,7 +446,7 @@
         <dependency>
             <groupId>org.atlasapi</groupId>
             <artifactId>atlas-persistence</artifactId>
-            <version>5.1-SNAPSHOT</version>
+            <version>${atlas.version}</version>
             <exclusions>
                 <exclusion>
                     <artifactId>jetty</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -446,7 +446,7 @@
         <dependency>
             <groupId>org.atlasapi</groupId>
             <artifactId>atlas-persistence</artifactId>
-            <version>${atlas.version}</version>
+            <version>5.1-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>jetty</artifactId>

--- a/src/main/java/org/atlasapi/equiv/update/messagers/providers/container/StandardSeriesMessengerProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/messagers/providers/container/StandardSeriesMessengerProvider.java
@@ -2,7 +2,6 @@ package org.atlasapi.equiv.update.messagers.providers.container;
 
 import org.atlasapi.equiv.messengers.EquivalenceResultMessenger;
 import org.atlasapi.equiv.messengers.NopEquivalenceResultMessenger;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.update.messagers.providers.EquivalenceResultMessengerProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Container;

--- a/src/main/java/org/atlasapi/equiv/update/messagers/providers/container/StandardSeriesMessengerProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/messagers/providers/container/StandardSeriesMessengerProvider.java
@@ -1,6 +1,7 @@
 package org.atlasapi.equiv.update.messagers.providers.container;
 
 import org.atlasapi.equiv.messengers.EquivalenceResultMessenger;
+import org.atlasapi.equiv.messengers.NopEquivalenceResultMessenger;
 import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.update.messagers.providers.EquivalenceResultMessengerProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
@@ -23,9 +24,8 @@ public class StandardSeriesMessengerProvider implements EquivalenceResultMesseng
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return QueueingEquivalenceResultMessenger.create(
-                dependencies.getMessageSender(),
-                dependencies.getLookupEntryStore()
-        );
+        // This used to be a QueueingEquivalenceResultMessenger but this has been disabled due to the messaging being
+        // moved to the TransitiveLookupWriter. Framework has been kept intact for possible future use.
+        return new NopEquivalenceResultMessenger<>();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/messagers/providers/container/StandardTopLevelContainerMessengerProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/messagers/providers/container/StandardTopLevelContainerMessengerProvider.java
@@ -2,7 +2,6 @@ package org.atlasapi.equiv.update.messagers.providers.container;
 
 import org.atlasapi.equiv.messengers.EquivalenceResultMessenger;
 import org.atlasapi.equiv.messengers.NopEquivalenceResultMessenger;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.update.messagers.providers.EquivalenceResultMessengerProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Container;

--- a/src/main/java/org/atlasapi/equiv/update/messagers/providers/container/StandardTopLevelContainerMessengerProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/messagers/providers/container/StandardTopLevelContainerMessengerProvider.java
@@ -1,6 +1,7 @@
 package org.atlasapi.equiv.update.messagers.providers.container;
 
 import org.atlasapi.equiv.messengers.EquivalenceResultMessenger;
+import org.atlasapi.equiv.messengers.NopEquivalenceResultMessenger;
 import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
 import org.atlasapi.equiv.update.messagers.providers.EquivalenceResultMessengerProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
@@ -23,9 +24,8 @@ public class StandardTopLevelContainerMessengerProvider implements EquivalenceRe
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return QueueingEquivalenceResultMessenger.create(
-                dependencies.getMessageSender(),
-                dependencies.getLookupEntryStore()
-        );
+        // This used to be a QueueingEquivalenceResultMessenger but this has been disabled due to the messaging being
+        // moved to the TransitiveLookupWriter. Framework has been kept intact for possible future use.
+        return new NopEquivalenceResultMessenger<>();
     }
 }

--- a/src/main/java/org/atlasapi/equiv/update/messagers/providers/item/StandardItemMessengerProvider.java
+++ b/src/main/java/org/atlasapi/equiv/update/messagers/providers/item/StandardItemMessengerProvider.java
@@ -1,7 +1,7 @@
 package org.atlasapi.equiv.update.messagers.providers.item;
 
 import org.atlasapi.equiv.messengers.EquivalenceResultMessenger;
-import org.atlasapi.equiv.messengers.QueueingEquivalenceResultMessenger;
+import org.atlasapi.equiv.messengers.NopEquivalenceResultMessenger;
 import org.atlasapi.equiv.update.messagers.providers.EquivalenceResultMessengerProvider;
 import org.atlasapi.equiv.update.updaters.providers.EquivalenceUpdaterProviderDependencies;
 import org.atlasapi.media.entity.Item;
@@ -23,9 +23,8 @@ public class StandardItemMessengerProvider implements EquivalenceResultMessenger
             EquivalenceUpdaterProviderDependencies dependencies,
             Set<Publisher> targetPublishers
     ) {
-        return QueueingEquivalenceResultMessenger.create(
-                dependencies.getMessageSender(),
-                dependencies.getLookupEntryStore()
-        );
+        // This used to be a QueueingEquivalenceResultMessenger but this has been disabled due to the messaging being
+        // moved to the TransitiveLookupWriter. Framework has been kept intact for possible future use.
+        return new NopEquivalenceResultMessenger<>();
     }
 }


### PR DESCRIPTION
Disabled equiv messaging in messenger step of equiv framework.

It has been moved to the underlying lookup writer where it has full view of direct, explicit, and blacklisted equivs.