### PR TITLE
Change merge strategy for topics in nitro from KEEP to REPLACE.

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/bbc/nitro/LocalOrRemoteNitroFetcher.java
+++ b/src/main/java/org/atlasapi/remotesite/bbc/nitro/LocalOrRemoteNitroFetcher.java
@@ -59,7 +59,7 @@ public class LocalOrRemoteNitroFetcher {
         this(resolver, contentAdapter,
                 new ContentMerger(
                         MergeStrategy.NITRO_VERSIONS_REVOKE,
-                        MergeStrategy.KEEP,
+                        MergeStrategy.REPLACE,
                         MergeStrategy.REPLACE
                 ),
                 new Predicate<Item>() {
@@ -127,7 +127,7 @@ public class LocalOrRemoteNitroFetcher {
                 contentAdapter,
                 new ContentMerger(
                         MergeStrategy.NITRO_VERSIONS_REVOKE,
-                        MergeStrategy.KEEP,
+                        MergeStrategy.REPLACE,
                         MergeStrategy.REPLACE
                 ),
                 fullFetchPermitted


### PR DESCRIPTION
Now topics should be ingested for all content, new or old. This fixes an issue where ingests on old content would never gain a topic.