### PR TITLE
Ignore presentation channel when not in channel 4 channel map

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/channel4/pmlsd/C4BrandBasicDetailsExtractor.java
+++ b/src/main/java/org/atlasapi/remotesite/channel4/pmlsd/C4BrandBasicDetailsExtractor.java
@@ -4,6 +4,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.atlasapi.media.channel.Channel;
 import org.atlasapi.media.entity.Brand;
 import org.atlasapi.media.entity.MediaType;
 import org.atlasapi.media.entity.Publisher;
@@ -20,6 +21,8 @@ import com.sun.syndication.feed.atom.Category;
 import com.sun.syndication.feed.atom.Entry;
 import com.sun.syndication.feed.atom.Feed;
 import com.sun.syndication.feed.atom.Link;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Extracts basic properties of a Brand from a C4 Atom Feed representing a Brand.
@@ -27,6 +30,8 @@ import com.sun.syndication.feed.atom.Link;
  * @author Fred van den Driessche (fred@metabroadcast.com)
  */
 public class C4BrandBasicDetailsExtractor implements ContentExtractor<Feed, Brand> {
+
+    Logger log = LoggerFactory.getLogger(C4BrandBasicDetailsExtractor.class);
 
     private static final String PRESENTATION_BRAND = "relation.presentationBrand";
 
@@ -71,7 +76,17 @@ public class C4BrandBasicDetailsExtractor implements ContentExtractor<Feed, Bran
 
         String presentationBrand = getPresentationBrand(source);
         if(presentationBrand != null) {
-            brand.setPresentationChannel(c4AtomApi.getChannelMap().get(presentationBrand));
+            Channel channel = c4AtomApi.getChannelMap().get(presentationBrand);
+            if (channel != null) {
+                brand.setPresentationChannel(channel);
+            } else {
+                log.warn(String.format(
+                        "Tried to set presentation channel for brand (%s), but could not find %s in"
+                        + " the channel map.",
+                        brand.getTitle(),
+                        presentationBrand
+                ));
+            }
         }
 
         C4AtomApi.addImages(brand, source.getLogo());


### PR DESCRIPTION
An investigation prompted by ENG-913 found that the C4 channel map currently contains entries for C4, M4, F4, E4, 4M, and 4S, but nothing for ALL4. This causes brands with presentation channels not in the map (e.g. Community of ALL4) to not get ingested, without manually hitting a channel 4 reingest endpoint. Adding this ignore step allows these brands to be ingested, though also adds a log line for when we come across a presentation channel that does not exist in the map.