### PR TITLE
Improve channel group api write logic

### DIFF
--- a/src/main/java/org/atlasapi/query/v2/ChannelGroupController.java
+++ b/src/main/java/org/atlasapi/query/v2/ChannelGroupController.java
@@ -1,19 +1,23 @@
 package org.atlasapi.query.v2;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.validation.ConstraintViolationException;
-
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+import com.metabroadcast.applications.client.model.internal.Application;
+import com.metabroadcast.common.http.HttpStatusCode;
+import com.metabroadcast.common.ids.NumberToShortStringCodec;
+import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
+import com.metabroadcast.common.query.Selection;
+import com.metabroadcast.common.query.Selection.SelectionBuilder;
+import com.metabroadcast.common.social.exceptions.BadRequestException;
+import org.apache.commons.cli.MissingArgumentException;
 import org.atlasapi.application.query.ApplicationFetcher;
 import org.atlasapi.application.query.InvalidApiKeyException;
 import org.atlasapi.application.v3.DefaultApplication;
@@ -36,26 +40,6 @@ import org.atlasapi.output.exceptions.UnauthorizedException;
 import org.atlasapi.persistence.logging.AdapterLog;
 import org.atlasapi.query.v2.ChannelGroupFilterer.ChannelGroupFilter;
 import org.atlasapi.query.v2.ChannelGroupFilterer.ChannelGroupFilter.ChannelGroupFilterBuilder;
-
-import com.metabroadcast.applications.client.model.internal.Application;
-import com.metabroadcast.common.http.HttpStatusCode;
-import com.metabroadcast.common.ids.NumberToShortStringCodec;
-import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
-import com.metabroadcast.common.query.Selection;
-import com.metabroadcast.common.query.Selection.SelectionBuilder;
-import com.metabroadcast.common.social.exceptions.BadRequestException;
-
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
-import com.google.common.base.Joiner;
-import com.google.common.base.Optional;
-import com.google.common.base.Splitter;
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Sets;
-import org.apache.commons.cli.MissingArgumentException;
 import org.joda.time.LocalDate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,6 +48,19 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.ConstraintViolationException;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -440,7 +437,7 @@ public class ChannelGroupController extends BaseController<Iterable<ChannelGroup
         Optional<ChannelGroup> channelGroup = channelGroupWriteExecutor.createOrUpdateChannelGroup(
                 request,
                 complexChannelGroup,
-                simpleChannelGroup,
+                simpleChannelGroup.getChannels(),
                 channelResolver
         );
 

--- a/src/main/java/org/atlasapi/query/v2/ChannelGroupWriteExecutor.java
+++ b/src/main/java/org/atlasapi/query/v2/ChannelGroupWriteExecutor.java
@@ -130,11 +130,15 @@ public class ChannelGroupWriteExecutor {
             List<org.atlasapi.media.entity.simple.ChannelNumbering> simpleNumberings,
             ChannelResolver channelResolver
     ) {
-        complex.setChannelNumberings(
-                simpleNumberings.stream()
-                        .map(numbering -> transformChannelNumbering(numbering, complex.getId()))
-                        .collect(MoreCollectors.toImmutableSet())
-        );
+        // These aren't always set by the complexifier because sometimes only a uri is initially specified on the channel
+        // group, with the channel numberings requiring a channel group id
+        if (complex.getChannelNumberings().isEmpty() && !simpleNumberings.isEmpty()) {
+            complex.setChannelNumberings(
+                    simpleNumberings.stream()
+                            .map(numbering -> transformChannelNumbering(numbering, complex.getId()))
+                            .collect(MoreCollectors.toImmutableSet())
+            );
+        }
         Set<ChannelNumbering> existingChannelNumberings = getExistingChannelNumberings(complex.getId());
         ChannelGroup channelGroup = channelGroupStore.createOrUpdate(complex);
         updateChannelGroupNumberings(

--- a/src/main/java/org/atlasapi/query/v2/ChannelGroupWriteExecutor.java
+++ b/src/main/java/org/atlasapi/query/v2/ChannelGroupWriteExecutor.java
@@ -57,12 +57,12 @@ public class ChannelGroupWriteExecutor {
     public com.google.common.base.Optional<ChannelGroup> createOrUpdateChannelGroup(
             HttpServletRequest request,
             ChannelGroup complex,
-            org.atlasapi.media.entity.simple.ChannelGroup simple,
+            List<org.atlasapi.media.entity.simple.ChannelNumbering> simpleNumberings,
             ChannelResolver channelResolver
     ) {
         try {
             if (complex.getId() != null) {
-                return updateChannelGroup(complex, simple.getChannels(), channelResolver);
+                return updateChannelGroup(complex, simpleNumberings, channelResolver);
             }
             if (complex.getCanonicalUri() != null) {
                 com.google.common.base.Optional<ChannelGroup> existingChannelGroup = channelGroupStore
@@ -71,7 +71,7 @@ public class ChannelGroupWriteExecutor {
                 if(existingChannelGroup.isPresent()) {
                     complex.setId(existingChannelGroup.get().getId());
                 }
-                return updateChannelGroup(complex, simple.getChannels(), channelResolver);
+                return updateChannelGroup(complex, simpleNumberings, channelResolver);
             }
             //if it's a new group, create it
             ChannelGroup newChannelGroup = channelGroupStore.createOrUpdate(complex);
@@ -89,7 +89,7 @@ public class ChannelGroupWriteExecutor {
                 ));
                 newChannelGroup = channelGroupStore.createOrUpdate(newChannelGroup);
             }
-            Set<ChannelNumbering> channelNumberings = simple.getChannels().stream()
+            Set<ChannelNumbering> channelNumberings = simpleNumberings.stream()
                     .map(numbering -> transformChannelNumbering(numbering, complex.getId()))
                     .collect(MoreCollectors.toImmutableSet());
             Set<Long> channelsToUpdate = channelNumberings.stream()

--- a/src/test/java/org/atlasapi/query/v2/ChannelGroupWriteExecutorTest.java
+++ b/src/test/java/org/atlasapi/query/v2/ChannelGroupWriteExecutorTest.java
@@ -1,23 +1,26 @@
 package org.atlasapi.query.v2;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.metabroadcast.common.base.Maybe;
+import org.atlasapi.media.channel.Channel;
+import org.atlasapi.media.channel.ChannelGroup;
 import org.atlasapi.media.channel.ChannelGroupStore;
+import org.atlasapi.media.channel.ChannelNumbering;
 import org.atlasapi.media.channel.ChannelResolver;
 import org.atlasapi.media.channel.ChannelStore;
 import org.atlasapi.media.channel.Platform;
-import org.atlasapi.media.entity.Publisher;
-import org.atlasapi.media.entity.simple.Channel;
-import org.atlasapi.media.entity.simple.ChannelNumbering;
+import org.joda.time.LocalDate;
 import org.junit.Before;
 import org.junit.Test;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.Set;
 
-import static org.mockito.Matchers.anyLong;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -25,13 +28,8 @@ import static org.mockito.Mockito.when;
 
 public class ChannelGroupWriteExecutorTest {
 
-    private Channel simpleChannel;
-    private org.atlasapi.media.channel.Channel complexChannel;
     private ChannelResolver channelResolver;
     private ChannelStore channelStore;
-    private ChannelNumbering channelNumbering;
-    private org.atlasapi.media.channel.ChannelGroup complexChannelGroup;
-    private org.atlasapi.media.channel.ChannelNumbering complexChannelNumbering;
     private ChannelGroupStore channelGroupStore;
     private HttpServletRequest request;
     private HttpServletResponse response;
@@ -40,84 +38,414 @@ public class ChannelGroupWriteExecutorTest {
 
     @Before
     public void setUp() {
-        simpleChannel = mock(Channel.class);
-        complexChannel = mock(org.atlasapi.media.channel.Channel.class);
         channelResolver = mock(ChannelResolver.class);
         channelStore = mock(ChannelStore.class);
-        channelNumbering = mock(ChannelNumbering.class);
-        complexChannelGroup = mock(org.atlasapi.media.channel.ChannelGroup.class);
-        complexChannelNumbering = mock(org.atlasapi.media.channel.ChannelNumbering.class);
         channelGroupStore = mock(ChannelGroupStore.class);
         request = mock(HttpServletRequest.class);
         response = mock(HttpServletResponse.class);
-
         executor = ChannelGroupWriteExecutor.create(channelGroupStore, channelStore);
     }
 
+    private org.atlasapi.media.entity.simple.ChannelNumbering simpleNumbering(String channelId, String channelNumber) {
+        org.atlasapi.media.entity.simple.ChannelNumbering numbering = new org.atlasapi.media.entity.simple.ChannelNumbering();
+        org.atlasapi.media.entity.simple.Channel channel = new org.atlasapi.media.entity.simple.Channel();
+        channel.setId(channelId);
+        numbering.setChannel(channel);
+        numbering.setChannelNumber(channelNumber);
+        return numbering;
+    }
+
     @Test
-    public void testUpdateExistingChannelGroup() {
-        org.atlasapi.media.channel.ChannelGroup existingComplexChannelGroup = mock(org.atlasapi.media.channel.ChannelGroup.class);
-        org.atlasapi.media.channel.ChannelNumbering existingComplexChannelNumbering = mock(org.atlasapi.media.channel.ChannelNumbering.class);
-        when(complexChannelGroup.getId()).thenReturn(17L);
-        when(channelGroupStore.channelGroupFor(17L)).thenReturn(Optional.of(existingComplexChannelGroup));
-        when(existingComplexChannelGroup.getChannelNumberings()).thenReturn(Sets.newHashSet(existingComplexChannelNumbering));
-        when(existingComplexChannelNumbering.getChannel()).thenReturn(16L);
-        when(channelGroupStore.createOrUpdate(complexChannelGroup)).thenReturn(complexChannelGroup);
-        when(complexChannelGroup.getChannelNumberings()).thenReturn(Sets.newHashSet(complexChannelNumbering));
-        when(complexChannelNumbering.getChannel()).thenReturn(22515L);
-        when(channelResolver.fromId(anyLong())).thenReturn(Maybe.just(complexChannel));
-        when(channelNumbering.getChannel()).thenReturn(simpleChannel);
-        when(simpleChannel.getId()).thenReturn("pnd");
+    public void testChannelNumberIsUpdated() {
+        ChannelGroup existingChannelGroup = new Platform();
+        existingChannelGroup.setId(1L);
+        ChannelNumbering existingChannelNumbering = ChannelNumbering.builder()
+                .withChannel(10L)
+                .withChannelGroup(existingChannelGroup.getId())
+                .withChannelNumber("10")
+                .build();
+        existingChannelGroup.addChannelNumbering(existingChannelNumbering);
+        Channel channel = Channel.builder()
+                .withChannelNumber(existingChannelNumbering)
+                .build();
+        channel.setId(10L);
+
+        when(channelGroupStore.channelGroupFor(1L)).thenReturn(Optional.of(existingChannelGroup));
+        when(channelResolver.fromId(10L)).thenReturn(Maybe.just(channel));
+
+        ChannelGroup newChannelGroup = new Platform();
+        newChannelGroup.setId(1L);
+
+        when(channelGroupStore.createOrUpdate(newChannelGroup)).thenReturn(newChannelGroup);
 
         executor.createOrUpdateChannelGroup(
                 request,
-                complexChannelGroup,
-                Lists.newArrayList(channelNumbering),
+                newChannelGroup,
+                ImmutableList.of(
+                        simpleNumbering("p", "20")
+                ),
                 channelResolver
         );
 
-        verify(channelGroupStore, times(1)).channelGroupFor(17L);
-        verify(channelGroupStore, times(1)).createOrUpdate(complexChannelGroup);
-        verify(channelStore, times(2)).createOrUpdate(complexChannel);
+        Set<ChannelNumbering> expectedNumberings = ImmutableSet.of(
+                ChannelNumbering.builder()
+                        .withChannel(10L)
+                        .withChannelGroup(existingChannelGroup.getId())
+                        .withChannelNumber("20")
+                        .build()
+        );
+
+        assertEquals(expectedNumberings, newChannelGroup.getChannelNumberings());
+        verify(channelGroupStore, times(1)).createOrUpdate(newChannelGroup);
+        assertEquals(expectedNumberings, channel.getChannelNumbers());
+        verify(channelStore, times(1)).createOrUpdate(channel);
     }
 
     @Test
-    public void testWriteNewChannelGroupAndUpdateChannelNumberings() {
-        org.atlasapi.media.channel.ChannelGroup updatedChannelGroup = new Platform();
-        updatedChannelGroup.setId(17L);
-        updatedChannelGroup.setPublisher(Publisher.BT_TV_CHANNELS);
+    public void testNumberingOnNewChannelIsAdded() {
+        ChannelGroup existingChannelGroup = new Platform();
+        existingChannelGroup.setId(1L);
+        Channel channel = Channel.builder().build();
+        channel.setId(10L);
 
-        when(complexChannelGroup.getId()).thenReturn(null).thenReturn(17L);
-        when(channelGroupStore.createOrUpdate(complexChannelGroup)).thenReturn(updatedChannelGroup);
-        when(channelGroupStore.createOrUpdate(updatedChannelGroup)).thenReturn(updatedChannelGroup);
-        when(channelNumbering.getChannel()).thenReturn(simpleChannel);
-        when(simpleChannel.getId()).thenReturn("pnd");
-        when(channelResolver.fromId(anyLong())).thenReturn(Maybe.just(complexChannel));
+        when(channelGroupStore.channelGroupFor(1L)).thenReturn(Optional.of(existingChannelGroup));
+        when(channelResolver.fromId(10L)).thenReturn(Maybe.just(channel));
+
+        ChannelGroup newChannelGroup = new Platform();
+        newChannelGroup.setId(1L);
+
+        when(channelGroupStore.createOrUpdate(newChannelGroup)).thenReturn(newChannelGroup);
 
         executor.createOrUpdateChannelGroup(
                 request,
-                complexChannelGroup,
-                Lists.newArrayList(channelNumbering),
+                newChannelGroup,
+                ImmutableList.of(
+                        simpleNumbering("p", "20")
+                ),
                 channelResolver
         );
 
-        verify(channelGroupStore, times(1)).createOrUpdate(complexChannelGroup);
-        verify(channelGroupStore, times(1)).createOrUpdate(updatedChannelGroup);
-        verify(channelStore, times(1)).createOrUpdate(complexChannel);
+        Set<ChannelNumbering> expectedNumberings = ImmutableSet.of(
+                ChannelNumbering.builder()
+                        .withChannel(10L)
+                        .withChannelGroup(existingChannelGroup.getId())
+                        .withChannelNumber("20")
+                        .build()
+        );
+
+        assertEquals(expectedNumberings, newChannelGroup.getChannelNumberings());
+        verify(channelGroupStore, times(1)).createOrUpdate(newChannelGroup);
+        assertEquals(expectedNumberings, channel.getChannelNumbers());
+        verify(channelStore, times(1)).createOrUpdate(channel);
     }
 
     @Test
-    public void testDeleteExistingChannelGroup() {
-        when(channelGroupStore.channelGroupFor(17L)).thenReturn(Optional.of(complexChannelGroup));
-        when(complexChannelGroup.getChannelNumberings()).thenReturn(Sets.newHashSet(complexChannelNumbering));
-        when(complexChannelNumbering.getChannel()).thenReturn(16L);
-        when(channelResolver.fromId(16L)).thenReturn(Maybe.just(complexChannel));
+    public void testNumberingOnRemovedChannelIsRemoved() {
+        ChannelGroup existingChannelGroup = new Platform();
+        existingChannelGroup.setId(1L);
+        ChannelNumbering existingChannelNumbering = ChannelNumbering.builder()
+                .withChannel(10L)
+                .withChannelGroup(existingChannelGroup.getId())
+                .withChannelNumber("10")
+                .build();
+        existingChannelGroup.addChannelNumbering(existingChannelNumbering);
+        Channel channel = Channel.builder()
+                .withChannelNumber(existingChannelNumbering)
+                .build();
+        channel.setId(10L);
 
-        executor.deletePlatform(request, response, 17L, channelResolver);
+        when(channelGroupStore.channelGroupFor(1L)).thenReturn(Optional.of(existingChannelGroup));
+        when(channelResolver.fromId(10L)).thenReturn(Maybe.just(channel));
 
-        verify(channelGroupStore, times(1)).channelGroupFor(17L);
-        verify(channelStore, times(1)).createOrUpdate(complexChannel);
-        verify(channelGroupStore, times(1)).deleteChannelGroupById(17L);
+        ChannelGroup newChannelGroup = new Platform();
+        newChannelGroup.setId(1L);
+
+        when(channelGroupStore.createOrUpdate(newChannelGroup)).thenReturn(newChannelGroup);
+
+        executor.createOrUpdateChannelGroup(
+                request,
+                newChannelGroup,
+                ImmutableList.of(),
+                channelResolver
+        );
+
+        Set<ChannelNumbering> expectedNumberings = ImmutableSet.of();
+
+        assertEquals(expectedNumberings, newChannelGroup.getChannelNumberings());
+        verify(channelGroupStore, times(1)).createOrUpdate(newChannelGroup);
+        assertEquals(expectedNumberings, channel.getChannelNumbers());
+        verify(channelStore, times(1)).createOrUpdate(channel);
     }
 
+    @Test
+    public void testNoChangeDoesNotUpdateChannel() {
+        ChannelGroup existingChannelGroup = new Platform();
+        existingChannelGroup.setId(1L);
+        ChannelNumbering existingChannelNumbering = ChannelNumbering.builder()
+                .withChannel(10L)
+                .withChannelGroup(existingChannelGroup.getId())
+                .withChannelNumber("10")
+                .build();
+        existingChannelGroup.addChannelNumbering(existingChannelNumbering);
+        Channel channel = Channel.builder()
+                .withChannelNumber(existingChannelNumbering)
+                .build();
+        channel.setId(10L);
+
+        when(channelGroupStore.channelGroupFor(1L)).thenReturn(Optional.of(existingChannelGroup));
+        when(channelResolver.fromId(10L)).thenReturn(Maybe.just(channel));
+
+        ChannelGroup newChannelGroup = new Platform();
+        newChannelGroup.setId(1L);
+
+        when(channelGroupStore.createOrUpdate(newChannelGroup)).thenReturn(newChannelGroup);
+
+        executor.createOrUpdateChannelGroup(
+                request,
+                newChannelGroup,
+                ImmutableList.of(
+                        simpleNumbering("p", "10")
+                ),
+                channelResolver
+        );
+
+        Set<ChannelNumbering> expectedNumberings = ImmutableSet.of(
+                ChannelNumbering.builder()
+                        .withChannel(10L)
+                        .withChannelGroup(existingChannelGroup.getId())
+                        .withChannelNumber("10")
+                        .build()
+        );
+
+        assertEquals(expectedNumberings, newChannelGroup.getChannelNumberings());
+        verify(channelGroupStore, times(1)).createOrUpdate(newChannelGroup);
+        assertEquals(expectedNumberings, channel.getChannelNumbers());
+        verify(channelStore, times(0)).createOrUpdate(channel);
+    }
+
+    @Test
+    public void testOnlyOldNumberingsForChannelGroupRemovedFromChannel() {
+        ChannelGroup existingChannelGroup = new Platform();
+        existingChannelGroup.setId(1L);
+        Set<ChannelNumbering> existingChannelNumberings = ImmutableSet.of(
+                ChannelNumbering.builder()
+                        .withChannel(10L)
+                        .withChannelGroup(existingChannelGroup.getId())
+                        .withChannelNumber("10")
+                        .withStartDate(LocalDate.parse("2020-01-01"))
+                        .withEndDate(LocalDate.parse("2030-01-01"))
+                        .build(),
+                ChannelNumbering.builder()
+                        .withChannel(10L)
+                        .withChannelGroup(existingChannelGroup.getId())
+                        .withChannelNumber("100")
+                        .withStartDate(LocalDate.parse("2010-01-01"))
+                        .withEndDate(LocalDate.parse("2020-01-01"))
+                        .build()
+        );
+        existingChannelGroup.setChannelNumberings(existingChannelNumberings);
+
+        Set<ChannelNumbering> numberingsForOtherChannelGroups = ImmutableSet.of(
+                ChannelNumbering.builder()
+                        .withChannel(10L)
+                        .withChannelGroup(2L)
+                        .withChannelNumber("10")
+                        .withStartDate(LocalDate.parse("2020-01-01"))
+                        .withEndDate(LocalDate.parse("2030-01-01"))
+                        .build(),
+                ChannelNumbering.builder()
+                        .withChannel(10L)
+                        .withChannelGroup(3L)
+                        .withChannelNumber("100")
+                        .withStartDate(LocalDate.parse("2010-01-01"))
+                        .withEndDate(LocalDate.parse("2020-01-01"))
+                        .build()
+        );
+        Channel channel = Channel.builder()
+                .withChannelNumbers(Sets.union(numberingsForOtherChannelGroups, existingChannelNumberings))
+                .build();
+        channel.setId(10L);
+
+        when(channelGroupStore.channelGroupFor(1L)).thenReturn(Optional.of(existingChannelGroup));
+        when(channelResolver.fromId(10L)).thenReturn(Maybe.just(channel));
+
+        ChannelGroup newChannelGroup = new Platform();
+        newChannelGroup.setId(1L);
+
+        when(channelGroupStore.createOrUpdate(newChannelGroup)).thenReturn(newChannelGroup);
+
+        executor.createOrUpdateChannelGroup(
+                request,
+                newChannelGroup,
+                ImmutableList.of(
+                        simpleNumbering("p", "20")
+                ),
+                channelResolver
+        );
+
+        Set<ChannelNumbering> expectedChannelGroupNumberings = ImmutableSet.of(
+                ChannelNumbering.builder()
+                        .withChannel(10L)
+                        .withChannelGroup(existingChannelGroup.getId())
+                        .withChannelNumber("20")
+                        .build()
+        );
+
+        assertEquals(expectedChannelGroupNumberings, newChannelGroup.getChannelNumberings());
+        verify(channelGroupStore, times(1)).createOrUpdate(newChannelGroup);
+        assertEquals(Sets.union(numberingsForOtherChannelGroups, expectedChannelGroupNumberings), channel.getChannelNumbers());
+        verify(channelStore, times(1)).createOrUpdate(channel);
+    }
+
+    @Test
+    public void testMultipleUpdateTypesOnMultipleChannels() {
+        ChannelGroup existingChannelGroup = new Platform();
+        existingChannelGroup.setId(1L);
+        ChannelNumbering existingChannelNumbering1 = ChannelNumbering.builder()
+                .withChannel(10L)
+                .withChannelGroup(existingChannelGroup.getId())
+                .withChannelNumber("10")
+                .build();
+        existingChannelGroup.addChannelNumbering(existingChannelNumbering1);
+        ChannelNumbering existingChannelNumbering2 = ChannelNumbering.builder()
+                .withChannel(11L)
+                .withChannelGroup(existingChannelGroup.getId())
+                .withChannelNumber("11")
+                .build();
+        existingChannelGroup.addChannelNumbering(existingChannelNumbering2);
+        ChannelNumbering existingChannelNumbering3 = ChannelNumbering.builder()
+                .withChannel(13L)
+                .withChannelGroup(existingChannelGroup.getId())
+                .withChannelNumber("13")
+                .build();
+        existingChannelGroup.addChannelNumbering(existingChannelNumbering3);
+        Channel channel1 = Channel.builder()
+                .withChannelNumber(existingChannelNumbering1)
+                .build();
+        channel1.setId(10L);
+        Channel channel2 = Channel.builder()
+                .withChannelNumber(existingChannelNumbering2)
+                .build();
+        channel2.setId(11L);
+        Channel channel3 = Channel.builder()
+                .build();
+        channel3.setId(12L);
+        Channel channel4 = Channel.builder()
+                .withChannelNumber(existingChannelNumbering3)
+                .build();
+        channel4.setId(13L);
+
+        when(channelGroupStore.channelGroupFor(1L)).thenReturn(Optional.of(existingChannelGroup));
+        when(channelResolver.fromId(10L)).thenReturn(Maybe.just(channel1));
+        when(channelResolver.fromId(11L)).thenReturn(Maybe.just(channel2));
+        when(channelResolver.fromId(12L)).thenReturn(Maybe.just(channel3));
+        when(channelResolver.fromId(13L)).thenReturn(Maybe.just(channel4));
+
+        ChannelGroup newChannelGroup = new Platform();
+        newChannelGroup.setId(1L);
+
+        when(channelGroupStore.createOrUpdate(newChannelGroup)).thenReturn(newChannelGroup);
+
+        executor.createOrUpdateChannelGroup(
+                request,
+                newChannelGroup,
+                ImmutableList.of(
+                        simpleNumbering("p", "20"),
+                        simpleNumbering("r", "22"),
+                        simpleNumbering("s", "13")
+                ),
+                channelResolver
+        );
+
+        ChannelNumbering expectedChannelNumbering1 = ChannelNumbering.builder()
+                .withChannel(10L)
+                .withChannelGroup(existingChannelGroup.getId())
+                .withChannelNumber("20")
+                .build();
+
+        ChannelNumbering expectedChannelNumbering2 = ChannelNumbering.builder()
+                .withChannel(12L)
+                .withChannelGroup(existingChannelGroup.getId())
+                .withChannelNumber("22")
+                .build();
+
+        ChannelNumbering expectedChannelNumbering3 = ChannelNumbering.builder()
+                .withChannel(13L)
+                .withChannelGroup(existingChannelGroup.getId())
+                .withChannelNumber("13")
+                .build();
+
+        Set<ChannelNumbering> expectedNumberings = ImmutableSet.of(
+                expectedChannelNumbering1,
+                expectedChannelNumbering2,
+                expectedChannelNumbering3
+        );
+
+        assertEquals(expectedNumberings, newChannelGroup.getChannelNumberings());
+        verify(channelGroupStore, times(1)).createOrUpdate(newChannelGroup);
+
+        //Modify
+        assertEquals(ImmutableSet.of(expectedChannelNumbering1), channel1.getChannelNumbers());
+        verify(channelStore, times(1)).createOrUpdate(channel1);
+
+        //Remove
+        assertEquals(ImmutableSet.of(), channel2.getChannelNumbers());
+        verify(channelStore, times(1)).createOrUpdate(channel2);
+
+        //Add
+        assertEquals(ImmutableSet.of(expectedChannelNumbering2), channel3.getChannelNumbers());
+        verify(channelStore, times(1)).createOrUpdate(channel3);
+
+        //Unchanged
+        assertEquals(ImmutableSet.of(expectedChannelNumbering3), channel4.getChannelNumbers());
+        verify(channelStore, times(0)).createOrUpdate(channel4);
+    }
+
+    @Test
+    public void testDeletePlatformUpdatesAllChannels() {
+        ChannelGroup existingChannelGroup = new Platform();
+        existingChannelGroup.setId(1L);
+        ChannelNumbering existingChannelNumbering1 = ChannelNumbering.builder()
+                .withChannel(10L)
+                .withChannelGroup(existingChannelGroup.getId())
+                .withChannelNumber("10")
+                .withStartDate(LocalDate.parse("2020-01-01"))
+                .withEndDate(LocalDate.parse("2030-01-01"))
+                .build();
+        existingChannelGroup.addChannelNumbering(existingChannelNumbering1);
+        ChannelNumbering existingChannelNumbering2 = ChannelNumbering.builder()
+                .withChannel(11L)
+                .withChannelGroup(existingChannelGroup.getId())
+                .withChannelNumber("100")
+                .withStartDate(LocalDate.parse("2010-01-01"))
+                .withEndDate(LocalDate.parse("2020-01-01"))
+                .build();
+        existingChannelGroup.addChannelNumbering(existingChannelNumbering2);
+
+        Channel channel1 = Channel.builder()
+                .withChannelNumber(existingChannelNumbering1)
+                .build();
+        channel1.setId(10L);
+        Channel channel2 = Channel.builder()
+                .withChannelNumber(existingChannelNumbering2)
+                .build();
+        channel2.setId(11L);
+
+        when(channelGroupStore.channelGroupFor(1L)).thenReturn(Optional.of(existingChannelGroup));
+        when(channelResolver.fromId(10L)).thenReturn(Maybe.just(channel1));
+        when(channelResolver.fromId(11L)).thenReturn(Maybe.just(channel2));
+
+        executor.deletePlatform(
+                request,
+                response,
+                1L,
+                channelResolver
+        );
+
+        verify(channelGroupStore, times(1)).deleteChannelGroupById(1L);
+        assertEquals(ImmutableSet.of(), channel1.getChannelNumbers());
+        verify(channelStore, times(1)).createOrUpdate(channel1);
+        assertEquals(ImmutableSet.of(), channel2.getChannelNumbers());
+        verify(channelStore, times(1)).createOrUpdate(channel2);
+    }
 }

--- a/src/test/java/org/atlasapi/query/v2/ChannelGroupWriteExecutorTest.java
+++ b/src/test/java/org/atlasapi/query/v2/ChannelGroupWriteExecutorTest.java
@@ -1,8 +1,9 @@
 package org.atlasapi.query.v2;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.metabroadcast.common.base.Maybe;
 import org.atlasapi.media.channel.ChannelGroupStore;
 import org.atlasapi.media.channel.ChannelResolver;
 import org.atlasapi.media.channel.ChannelStore;
@@ -11,14 +12,11 @@ import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.media.entity.simple.Channel;
 import org.atlasapi.media.entity.simple.ChannelGroup;
 import org.atlasapi.media.entity.simple.ChannelNumbering;
-
-import com.metabroadcast.common.base.Maybe;
-
-import com.google.common.base.Optional;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import org.junit.Before;
 import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -61,11 +59,15 @@ public class ChannelGroupWriteExecutorTest {
 
     @Test
     public void testUpdateExistingChannelGroup() {
+        org.atlasapi.media.channel.ChannelGroup existingComplexChannelGroup = mock(org.atlasapi.media.channel.ChannelGroup.class);
+        org.atlasapi.media.channel.ChannelNumbering existingComplexChannelNumbering = mock(org.atlasapi.media.channel.ChannelNumbering.class);
         when(complexChannelGroup.getId()).thenReturn(17L);
-        when(channelGroupStore.channelGroupFor(17L)).thenReturn(Optional.of(complexChannelGroup));
+        when(channelGroupStore.channelGroupFor(17L)).thenReturn(Optional.of(existingComplexChannelGroup));
+        when(existingComplexChannelGroup.getChannelNumberings()).thenReturn(Sets.newHashSet(existingComplexChannelNumbering));
+        when(existingComplexChannelNumbering.getChannel()).thenReturn(16L);
         when(channelGroupStore.createOrUpdate(complexChannelGroup)).thenReturn(complexChannelGroup);
         when(complexChannelGroup.getChannelNumberings()).thenReturn(Sets.newHashSet(complexChannelNumbering));
-        when(complexChannelNumbering.getChannel()).thenReturn(16L);
+        when(complexChannelNumbering.getChannel()).thenReturn(22515L);
         when(channelResolver.fromId(anyLong())).thenReturn(Maybe.just(complexChannel));
         when(simpleChannelGroup.getChannels()).thenReturn(Lists.newArrayList(channelNumbering));
         when(channelNumbering.getChannel()).thenReturn(simpleChannel);
@@ -89,7 +91,7 @@ public class ChannelGroupWriteExecutorTest {
         updatedChannelGroup.setId(17L);
         updatedChannelGroup.setPublisher(Publisher.BT_TV_CHANNELS);
 
-        when(complexChannelGroup.getId()).thenReturn(null);
+        when(complexChannelGroup.getId()).thenReturn(null).thenReturn(17L);
         when(channelGroupStore.createOrUpdate(complexChannelGroup)).thenReturn(updatedChannelGroup);
         when(channelGroupStore.createOrUpdate(updatedChannelGroup)).thenReturn(updatedChannelGroup);
         when(simpleChannelGroup.getChannels()).thenReturn(Lists.newArrayList(channelNumbering));

--- a/src/test/java/org/atlasapi/query/v2/ChannelGroupWriteExecutorTest.java
+++ b/src/test/java/org/atlasapi/query/v2/ChannelGroupWriteExecutorTest.java
@@ -10,7 +10,6 @@ import org.atlasapi.media.channel.ChannelStore;
 import org.atlasapi.media.channel.Platform;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.media.entity.simple.Channel;
-import org.atlasapi.media.entity.simple.ChannelGroup;
 import org.atlasapi.media.entity.simple.ChannelNumbering;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,7 +30,6 @@ public class ChannelGroupWriteExecutorTest {
     private ChannelResolver channelResolver;
     private ChannelStore channelStore;
     private ChannelNumbering channelNumbering;
-    private ChannelGroup simpleChannelGroup;
     private org.atlasapi.media.channel.ChannelGroup complexChannelGroup;
     private org.atlasapi.media.channel.ChannelNumbering complexChannelNumbering;
     private ChannelGroupStore channelGroupStore;
@@ -49,7 +47,6 @@ public class ChannelGroupWriteExecutorTest {
         channelNumbering = mock(ChannelNumbering.class);
         complexChannelGroup = mock(org.atlasapi.media.channel.ChannelGroup.class);
         complexChannelNumbering = mock(org.atlasapi.media.channel.ChannelNumbering.class);
-        simpleChannelGroup = mock(ChannelGroup.class);
         channelGroupStore = mock(ChannelGroupStore.class);
         request = mock(HttpServletRequest.class);
         response = mock(HttpServletResponse.class);
@@ -69,14 +66,13 @@ public class ChannelGroupWriteExecutorTest {
         when(complexChannelGroup.getChannelNumberings()).thenReturn(Sets.newHashSet(complexChannelNumbering));
         when(complexChannelNumbering.getChannel()).thenReturn(22515L);
         when(channelResolver.fromId(anyLong())).thenReturn(Maybe.just(complexChannel));
-        when(simpleChannelGroup.getChannels()).thenReturn(Lists.newArrayList(channelNumbering));
         when(channelNumbering.getChannel()).thenReturn(simpleChannel);
         when(simpleChannel.getId()).thenReturn("pnd");
 
         executor.createOrUpdateChannelGroup(
                 request,
                 complexChannelGroup,
-                simpleChannelGroup,
+                Lists.newArrayList(channelNumbering),
                 channelResolver
         );
 
@@ -94,7 +90,6 @@ public class ChannelGroupWriteExecutorTest {
         when(complexChannelGroup.getId()).thenReturn(null).thenReturn(17L);
         when(channelGroupStore.createOrUpdate(complexChannelGroup)).thenReturn(updatedChannelGroup);
         when(channelGroupStore.createOrUpdate(updatedChannelGroup)).thenReturn(updatedChannelGroup);
-        when(simpleChannelGroup.getChannels()).thenReturn(Lists.newArrayList(channelNumbering));
         when(channelNumbering.getChannel()).thenReturn(simpleChannel);
         when(simpleChannel.getId()).thenReturn("pnd");
         when(channelResolver.fromId(anyLong())).thenReturn(Maybe.just(complexChannel));
@@ -102,7 +97,7 @@ public class ChannelGroupWriteExecutorTest {
         executor.createOrUpdateChannelGroup(
                 request,
                 complexChannelGroup,
-                simpleChannelGroup,
+                Lists.newArrayList(channelNumbering),
                 channelResolver
         );
 

--- a/src/test/java/org/atlasapi/query/v2/ChannelGroupWriteExecutorTest.java
+++ b/src/test/java/org/atlasapi/query/v2/ChannelGroupWriteExecutorTest.java
@@ -16,6 +16,7 @@ import org.joda.time.LocalDate;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.Set;
@@ -47,11 +48,22 @@ public class ChannelGroupWriteExecutorTest {
     }
 
     private org.atlasapi.media.entity.simple.ChannelNumbering simpleNumbering(String channelId, String channelNumber) {
+        return simpleNumbering(channelId, channelNumber, null, null);
+    }
+
+    private org.atlasapi.media.entity.simple.ChannelNumbering simpleNumbering(
+            String channelId,
+            String channelNumber,
+            @Nullable LocalDate start,
+            @Nullable LocalDate end
+    ) {
         org.atlasapi.media.entity.simple.ChannelNumbering numbering = new org.atlasapi.media.entity.simple.ChannelNumbering();
         org.atlasapi.media.entity.simple.Channel channel = new org.atlasapi.media.entity.simple.Channel();
         channel.setId(channelId);
         numbering.setChannel(channel);
         numbering.setChannelNumber(channelNumber);
+        numbering.setStartDate(start.toDate());
+        numbering.setEndDate(end.toDate());
         return numbering;
     }
 
@@ -278,7 +290,8 @@ public class ChannelGroupWriteExecutorTest {
                 request,
                 newChannelGroup,
                 ImmutableList.of(
-                        simpleNumbering("p", "20")
+                        simpleNumbering("p", "20", LocalDate.parse("2000-06-01"), LocalDate.parse("2005-12-01")),
+                        simpleNumbering("p", "21", LocalDate.parse("2020-06-01"), LocalDate.parse("2025-12-01"))
                 ),
                 channelResolver
         );
@@ -288,6 +301,15 @@ public class ChannelGroupWriteExecutorTest {
                         .withChannel(10L)
                         .withChannelGroup(existingChannelGroup.getId())
                         .withChannelNumber("20")
+                        .withStartDate(LocalDate.parse("2000-06-01"))
+                        .withEndDate(LocalDate.parse("2005-12-01"))
+                        .build(),
+                ChannelNumbering.builder()
+                        .withChannel(10L)
+                        .withChannelGroup(existingChannelGroup.getId())
+                        .withChannelNumber("21")
+                        .withStartDate(LocalDate.parse("2020-06-01"))
+                        .withEndDate(LocalDate.parse("2025-12-01"))
                         .build()
         );
 


### PR DESCRIPTION
Existing logic did not appear to accurately deal with updating numberings on channels which were already part of the channel group being updated, and had to update every channel in the channel group since the initial channel group before the channel update step removed all numberings.