### PR TITLE
Fix c4pmlsd equivalence configuration

### DIFF
--- a/src/main/java/org/atlasapi/equiv/update/updaters/configuration/UpdaterConfigurationRegistry.java
+++ b/src/main/java/org/atlasapi/equiv/update/updaters/configuration/UpdaterConfigurationRegistry.java
@@ -1293,7 +1293,8 @@ public class UpdaterConfigurationRegistry {
                 .withSource(C4_PMLSD)
                 .withItemEquivalenceUpdater(
                         ImmutableMap.of(
-                                BARB_ITEM, ImmutableSet.of(PA, RADIO_TIMES, BARB_MASTER),
+                                STANDARD_ITEM, ImmutableSet.of(PA, RADIO_TIMES),
+                                BARB_ITEM, ImmutableSet.of(BARB_MASTER),
                                 TXLOGS_ITEM, ImmutableSet.of(BARB_TRANSMISSIONS)
                         ),
                         STANDARD_ITEM_HANDLER,


### PR DESCRIPTION
 Move pa and rt item equivalence to standard_item updater type, since items from PA were not scoring high enough (4+) to get matched correctly.