### PR TITLE
Lower jetty version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -810,7 +810,7 @@
         <atlas.version>${project.version}</atlas.version>
         <common.version>1.0-SNAPSHOT</common.version>
         <netbeans.hint.deploy.server>Tomcat60</netbeans.hint.deploy.server>
-        <jetty.version>9.4.32.v20200930</jetty.version>
+        <jetty.version>9.4.24.v20191120</jetty.version>
         <jacoco.version>0.7.5.201505241946</jacoco.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 

--- a/pom.xml
+++ b/pom.xml
@@ -764,17 +764,12 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>5.4.3.Final</version>
+            <version>5.2.4.Final</version>
         </dependency>
         <dependency>
             <groupId>javax.el</groupId>
             <artifactId>javax.el-api</artifactId>
-            <version>2.2.5</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.web</groupId>
-            <artifactId>javax.el</artifactId>
-            <version>2.2.6</version>
+            <version>2.2.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -815,7 +810,7 @@
         <atlas.version>${project.version}</atlas.version>
         <common.version>1.0-SNAPSHOT</common.version>
         <netbeans.hint.deploy.server>Tomcat60</netbeans.hint.deploy.server>
-        <jetty.version>9.4.32.v20200930</jetty.version>
+        <jetty.version>9.4.1.v20170120</jetty.version>
         <jacoco.version>0.7.5.201505241946</jacoco.version>
         <spring.version>4.3.29.RELEASE</spring.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -810,7 +810,7 @@
         <atlas.version>${project.version}</atlas.version>
         <common.version>1.0-SNAPSHOT</common.version>
         <netbeans.hint.deploy.server>Tomcat60</netbeans.hint.deploy.server>
-        <jetty.version>9.4.1.v20170120</jetty.version>
+        <jetty.version>9.4.32.v20200930</jetty.version>
         <jacoco.version>0.7.5.201505241946</jacoco.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 

--- a/pom.xml
+++ b/pom.xml
@@ -810,7 +810,7 @@
         <atlas.version>${project.version}</atlas.version>
         <common.version>1.0-SNAPSHOT</common.version>
         <netbeans.hint.deploy.server>Tomcat60</netbeans.hint.deploy.server>
-        <jetty.version>9.4.24.v20191120</jetty.version>
+        <jetty.version>9.4.32.v20200930</jetty.version>
         <jacoco.version>0.7.5.201505241946</jacoco.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 

--- a/pom.xml
+++ b/pom.xml
@@ -810,7 +810,7 @@
         <atlas.version>${project.version}</atlas.version>
         <common.version>1.0-SNAPSHOT</common.version>
         <netbeans.hint.deploy.server>Tomcat60</netbeans.hint.deploy.server>
-        <jetty.version>9.4.32.v20200930</jetty.version>
+        <jetty.version>9.4.1.v20170120</jetty.version>
         <jacoco.version>0.7.5.201505241946</jacoco.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 

--- a/pom.xml
+++ b/pom.xml
@@ -764,22 +764,22 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>5.2.4.Final</version>
+            <version>5.4.3.Final</version>
         </dependency>
         <dependency>
             <groupId>javax.el</groupId>
             <artifactId>javax.el-api</artifactId>
-            <version>2.2.4</version>
+            <version>2.2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.web</groupId>
+            <artifactId>javax.el</artifactId>
+            <version>2.2.6</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>fluent-hc</artifactId>
             <version>4.5.3</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
-            <version>${spring.version}</version>
         </dependency>
         <dependency>
             <groupId>com.metabroadcast.sherlock</groupId>
@@ -812,7 +812,6 @@
         <netbeans.hint.deploy.server>Tomcat60</netbeans.hint.deploy.server>
         <jetty.version>9.4.1.v20170120</jetty.version>
         <jacoco.version>0.7.5.201505241946</jacoco.version>
-        <spring.version>4.3.29.RELEASE</spring.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <sonar.jacoco.itReportPath>${project.basedir}/target/jacoco-it.exec


### PR DESCRIPTION
A more recent version of jetty causes issues with a recent commit. It would seem it causes a different version of guava to possibly be used preventing the project from running successfully. We should investigate exactly what causes this since this version of jetty was working for a while with the project; but in the meantime we will revert it so that the recent commit will work.

The spring dependency was added back on master just as a quick test to see if that was the cause, and so has been removed again.