### PR TITLE
Bump jetty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -506,24 +506,10 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.14.0</version>
             <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <artifactId>jms</artifactId>
-                    <groupId>javax.jms</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>jmxtools</artifactId>
-                    <groupId>com.sun.jdmk</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>jmxri</artifactId>
-                    <groupId>com.sun.jmx</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -852,7 +838,7 @@
         <dependency>
             <groupId>com.metabroadcast.sherlock</groupId>
             <artifactId>client-shaded</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.1-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.metabroadcast.common</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -851,7 +851,7 @@
         </dependency>
         <dependency>
             <groupId>com.metabroadcast.sherlock</groupId>
-            <artifactId>client-shaded</artifactId>
+            <artifactId>client</artifactId>
             <version>1.0-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
@@ -869,6 +869,18 @@
                 <exclusion>
                     <groupId>io.dropwizard</groupId>
                     <artifactId>dropwizard-jackson</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.metabroadcast.common</groupId>
+                    <artifactId>common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.metabroadcast.common.health</groupId>
+                    <artifactId>common-health</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.metabroadcast.common.queue</groupId>
+                    <artifactId>common-queue</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -422,11 +422,23 @@
             <groupId>org.atlasapi</groupId>
             <artifactId>atlas-model</artifactId>
             <version>${atlas.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.atlasapi</groupId>
             <artifactId>atlas-feeds</artifactId>
             <version>${atlas.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.atlasapi</groupId>
@@ -438,6 +450,10 @@
             <artifactId>atlas-persistence</artifactId>
             <version>${atlas.version}</version>
             <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
                 <exclusion>
                     <artifactId>jetty</artifactId>
                     <groupId>org.mortbay.jetty</groupId>
@@ -456,6 +472,12 @@
             <groupId>com.metabroadcast.status</groupId>
             <artifactId>client</artifactId>
             <version>1.0-SNAPSHOT</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -613,22 +635,44 @@
             <groupId>com.metabroadcast.common</groupId>
             <artifactId>common</artifactId>
             <version>2.0-SNAPSHOT</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.metabroadcast.common.webapp</groupId>
             <artifactId>common-webapp</artifactId>
             <version>${common.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.metabroadcast.common.health</groupId>
             <artifactId>common-health</artifactId>
             <version>2.0-SNAPSHOT</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.metabroadcast.common.ingest</groupId>
             <artifactId>common-ingest</artifactId>
             <version>${common.version}</version>
             <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>com.metabroadcast.columbus.telescope</groupId>
                     <artifactId>telescope-client</artifactId>
@@ -658,6 +702,12 @@
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-webapp</artifactId>
             <version>${jetty.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jmock</groupId>
@@ -689,6 +739,12 @@
             <groupId>com.metabroadcast.atlas.glycerin</groupId>
             <artifactId>glycerin</artifactId>
             <version>2.1.3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.http-client</groupId>
@@ -709,6 +765,12 @@
             <groupId>com.google.gdata</groupId>
             <artifactId>core</artifactId>
             <version>1.47.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.apis</groupId>
@@ -729,6 +791,12 @@
             <groupId>net.sourceforge</groupId>
             <artifactId>jwbf</artifactId>
             <version>2.0.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.sweble.wikitext</groupId>
@@ -810,7 +878,7 @@
         <atlas.version>${project.version}</atlas.version>
         <common.version>1.0-SNAPSHOT</common.version>
         <netbeans.hint.deploy.server>Tomcat60</netbeans.hint.deploy.server>
-        <jetty.version>9.4.1.v20170120</jetty.version>
+        <jetty.version>9.4.32.v20200930</jetty.version>
         <jacoco.version>0.7.5.201505241946</jacoco.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 

--- a/pom.xml
+++ b/pom.xml
@@ -838,7 +838,7 @@
         <dependency>
             <groupId>com.metabroadcast.sherlock</groupId>
             <artifactId>client-shaded</artifactId>
-            <version>1.1-SNAPSHOT</version>
+            <version>1.0-SNAPSHOT</version>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -851,7 +851,7 @@
         </dependency>
         <dependency>
             <groupId>com.metabroadcast.sherlock</groupId>
-            <artifactId>client</artifactId>
+            <artifactId>client-shaded</artifactId>
             <version>1.0-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
@@ -869,18 +869,6 @@
                 <exclusion>
                     <groupId>io.dropwizard</groupId>
                     <artifactId>dropwizard-jackson</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.metabroadcast.common</groupId>
-                    <artifactId>common</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.metabroadcast.common.health</groupId>
-                    <artifactId>common-health</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.metabroadcast.common.queue</groupId>
-                    <artifactId>common-queue</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -871,6 +871,10 @@
                     <artifactId>guava</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-core</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>io.dropwizard</groupId>
                     <artifactId>dropwizard-core</artifactId>
                 </exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -875,6 +875,10 @@
                     <artifactId>log4j-core</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>io.dropwizard</groupId>
                     <artifactId>dropwizard-core</artifactId>
                 </exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -839,40 +839,6 @@
             <groupId>com.metabroadcast.sherlock</groupId>
             <artifactId>client-shaded</artifactId>
             <version>1.1-SNAPSHOT</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.metabroadcast.common</groupId>
-                    <artifactId>common</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.metabroadcast.common.health</groupId>
-                    <artifactId>common-health</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.metabroadcast.common.queue</groupId>
-                    <artifactId>common-queue</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.dropwizard</groupId>
-                    <artifactId>dropwizard-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.dropwizard</groupId>
-                    <artifactId>dropwizard-jackson</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -855,6 +855,18 @@
             <version>1.0-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
+                    <groupId>com.metabroadcast.common</groupId>
+                    <artifactId>common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.metabroadcast.common.health</groupId>
+                    <artifactId>common-health</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.metabroadcast.common.queue</groupId>
+                    <artifactId>common-queue</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>com.google.guava</groupId>
                     <artifactId>guava</artifactId>
                 </exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -871,10 +871,6 @@
                     <artifactId>guava</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-core</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>io.dropwizard</groupId>
                     <artifactId>dropwizard-core</artifactId>
                 </exclusion>


### PR DESCRIPTION
* Bump jetty to the version being used before it was lowered in a recent commit.

* Isolate guava dependency to help avoid incorrect version being used.

* Upgraded log4j dependency