### PR TITLE
Ingest pa season id as alias under series.

### DIFF
--- a/src/main/java/org/atlasapi/remotesite/pa/PaHelper.java
+++ b/src/main/java/org/atlasapi/remotesite/pa/PaHelper.java
@@ -62,6 +62,10 @@ public class PaHelper {
     public static Alias getSeriesAlias(String id, String seriesNumber) {
         return new Alias(PA_BASE_ALIAS + "series", id + "-" + seriesNumber);
     }
+
+    public static Alias getSeriesAlias(String id) {
+        return new Alias(PA_BASE_ALIAS + "series", id);
+    }
     
     public static String getEpisodeCurie(String id) {
         return "pa:e-" + id;

--- a/src/main/java/org/atlasapi/remotesite/pa/PaProgrammeProcessor.java
+++ b/src/main/java/org/atlasapi/remotesite/pa/PaProgrammeProcessor.java
@@ -546,10 +546,18 @@ public class PaProgrammeProcessor implements PaProgDataProcessor, PaProgDataUpda
                 progData.getSeriesId(),
                 progData.getSeriesNumber()
         );
-        Alias seriesAlias = PaHelper.getSeriesAlias(
-                progData.getSeriesId(),
-                progData.getSeriesNumber()
-        );
+
+        Alias seriesAlias;
+        // pa series <=> to atlas brand, so we need season.id NOT series.id. Related to ENG-979
+        if (progData.getSeason() != null && !Strings.isNullOrEmpty(progData.getSeason().getId())) {
+            seriesAlias = PaHelper.getSeriesAlias(progData.getSeason().getId());
+        }
+        else {
+            seriesAlias = PaHelper.getSeriesAlias(
+                    progData.getSeriesId(),     // this is actually the brand id?
+                    progData.getSeriesNumber()
+            );
+        }
 
         Maybe<Identified> possiblePrevious = contentResolver.findByCanonicalUris(
                 ImmutableList.of(seriesUri)


### PR DESCRIPTION
We want the new pa api data to equiv to the file-based pa
data based on pa id, but for some reason we were never
ingesting pa season ids. Relates to eng-979.