### PR TITLE
Eng 988

### DIFF
--- a/src/main/java/org/atlasapi/query/content/merge/BroadcastMerger.java
+++ b/src/main/java/org/atlasapi/query/content/merge/BroadcastMerger.java
@@ -179,7 +179,7 @@ public class BroadcastMerger {
 
             checkNotNull(from);
             checkNotNull(to);
-            checkArgument(from.isBefore(to));
+            checkArgument(from.isBefore(to) || from.isEqual(to));
 
             this.interval = new Interval(from, to);
         }

--- a/src/main/java/org/atlasapi/query/content/merge/BroadcastMerger.java
+++ b/src/main/java/org/atlasapi/query/content/merge/BroadcastMerger.java
@@ -179,7 +179,7 @@ public class BroadcastMerger {
 
             checkNotNull(from);
             checkNotNull(to);
-            checkArgument(from.isBefore(to) || from.isEqual(to));
+            checkArgument(!from.isAfter(to));
 
             this.interval = new Interval(from, to);
         }

--- a/src/test/java/org/atlasapi/query/content/merge/BroadcastMergerTest.java
+++ b/src/test/java/org/atlasapi/query/content/merge/BroadcastMergerTest.java
@@ -30,12 +30,6 @@ public class BroadcastMergerTest {
     }
 
     @Test
-    public void fromDateSameAsToFailsParsing() throws Exception {
-        exception.expect(IllegalArgumentException.class);
-        BroadcastMerger.parse("\"cbkM\"|\"2016-01-01T00:00:00Z\"|\"2016-01-01T00:00:00Z\"");
-    }
-
-    @Test
     public void invalidDateFailsParsing() throws Exception {
         exception.expect(IllegalArgumentException.class);
         BroadcastMerger.parse("\"cbkM\"|\"2016-01-01T00:00:00Z\"|\"2016-01-01T99:00:00Z\"");


### PR DESCRIPTION
Allows ingest thru owl client/API of zero duration broadcasts.
This relates to new PA API data, which is just like old PA
except ingested thru client, and the BroadcastAssertions
prevented broadcasts where startTime == endTime (for
no particular reason; the inner overlap checks are safe
for this kind of cases)