### PR TITLE
Fixes content images transformer + consolidates image transformer usage

### DIFF
--- a/src/main/java/org/atlasapi/input/BrandModelTransformer.java
+++ b/src/main/java/org/atlasapi/input/BrandModelTransformer.java
@@ -21,8 +21,10 @@ public class BrandModelTransformer extends ContentModelTransformer<Playlist, Bra
 
 	public BrandModelTransformer(LookupEntryStore lookupStore, 
 			TopicStore topicStore, NumberToShortStringCodec idCodec, 
-			ClipModelTransformer clipsModelTransformer, Clock clock) {
-		super(lookupStore, topicStore, idCodec, clipsModelTransformer, clock);
+			ClipModelTransformer clipsModelTransformer, Clock clock,
+			ImageModelTransformer imageModelTransformer) {
+
+		super(lookupStore, topicStore, idCodec, clipsModelTransformer, clock, imageModelTransformer);
 		this.encodingTransformer = EncodingModelTransformer.create();
 		this.restrictionTransformer = RestrictionModelTransformer.create();
 	}

--- a/src/main/java/org/atlasapi/input/ChannelModelTransformer.java
+++ b/src/main/java/org/atlasapi/input/ChannelModelTransformer.java
@@ -29,11 +29,11 @@ import static com.google.gdata.util.common.base.Preconditions.checkNotNull;
 public class ChannelModelTransformer implements ModelTransformer<Channel, org.atlasapi.media.channel.Channel> {
 
     private final NumberToShortStringCodec v4Codec;
-    private final ImageModelTranslator imageTranslator;
+    private final ImageModelTransformer imageTranslator;
 
     private ChannelModelTransformer(
             NumberToShortStringCodec v4Codec,
-            ImageModelTranslator imageTranslator
+            ImageModelTransformer imageTranslator
     ) {
         this.v4Codec = checkNotNull(v4Codec);
         this.imageTranslator = checkNotNull(imageTranslator);
@@ -41,7 +41,7 @@ public class ChannelModelTransformer implements ModelTransformer<Channel, org.at
 
     public static ChannelModelTransformer create(
             NumberToShortStringCodec v4Codec,
-            ImageModelTranslator imageTranslator
+            ImageModelTransformer imageTranslator
     ) {
         return new ChannelModelTransformer(v4Codec, imageTranslator);
     }

--- a/src/main/java/org/atlasapi/input/ClipModelTransformer.java
+++ b/src/main/java/org/atlasapi/input/ClipModelTransformer.java
@@ -11,8 +11,10 @@ import org.joda.time.DateTime;
 
 public class ClipModelTransformer extends ItemModelTransformer  {
     public ClipModelTransformer(LookupEntryStore lookupStore, TopicStore topicStore, 
-            ChannelResolver channelResolver, NumberToShortStringCodec idCodec, Clock clock, SegmentModelTransformer segmentModelTransformer) {
-        super(lookupStore, topicStore, channelResolver, idCodec, null, clock, segmentModelTransformer);
+            ChannelResolver channelResolver, NumberToShortStringCodec idCodec, Clock clock,
+            SegmentModelTransformer segmentModelTransformer, ImageModelTransformer imageModelTransformer) {
+
+        super(lookupStore, topicStore, channelResolver, idCodec, null, clock, segmentModelTransformer, imageModelTransformer);
     }
 
     @Override

--- a/src/main/java/org/atlasapi/input/ContentModelTransformer.java
+++ b/src/main/java/org/atlasapi/input/ContentModelTransformer.java
@@ -85,8 +85,10 @@ public abstract class ContentModelTransformer<F extends Description,T extends Co
     };
 
     public ContentModelTransformer(LookupEntryStore lookupStore, TopicStore topicStore, 
-            NumberToShortStringCodec idCodec, ClipModelTransformer clipsModelTransformer, Clock clock) {
-        super(clock);
+            NumberToShortStringCodec idCodec, ClipModelTransformer clipsModelTransformer,
+            Clock clock, ImageModelTransformer imageModelTransformer) {
+
+        super(clock, imageModelTransformer);
         this.lookupStore = lookupStore;
         this.topicStore = topicStore;
         this.clipsModelTransformer = clipsModelTransformer;

--- a/src/main/java/org/atlasapi/input/ImageModelTransformer.java
+++ b/src/main/java/org/atlasapi/input/ImageModelTransformer.java
@@ -5,12 +5,14 @@ import org.atlasapi.media.entity.Image;
 import org.atlasapi.media.entity.ImageAspectRatio;
 import org.atlasapi.media.entity.ImageColor;
 import org.atlasapi.media.entity.ImageTheme;
+import org.atlasapi.media.entity.ImageType;
+
 import org.joda.time.DateTime;
 
-public class ImageModelTranslator implements ModelTransformer<org.atlasapi.media.entity.simple.Image, Image> {
+public class ImageModelTransformer implements ModelTransformer<org.atlasapi.media.entity.simple.Image, Image> {
 
-    public static ImageModelTranslator create() {
-        return new ImageModelTranslator();
+    public static ImageModelTransformer create() {
+        return new ImageModelTransformer();
     }
 
     @Override
@@ -38,6 +40,9 @@ public class ImageModelTranslator implements ModelTransformer<org.atlasapi.media
         }
         if (simple.getMimeType() != null) {
             complex.withMimeType(MimeType.fromString(simple.getMimeType()));
+        }
+        if (simple.getType() != null) {
+            complex.withType(ImageType.valueOf(simple.getImageType().toUpperCase()));
         }
         if (simple.getAvailabilityStart() != null) {
             complex.withAvailabilityStart(new DateTime(simple.getAvailabilityStart()));

--- a/src/main/java/org/atlasapi/input/ItemModelTransformer.java
+++ b/src/main/java/org/atlasapi/input/ItemModelTransformer.java
@@ -40,8 +40,11 @@ public class ItemModelTransformer extends ContentModelTransformer<org.atlasapi.m
 
     public ItemModelTransformer(LookupEntryStore lookupStore, TopicStore topicStore,
             ChannelResolver channelResolver, NumberToShortStringCodec idCodec,
-            ClipModelTransformer clipsModelTransformer, Clock clock, SegmentModelTransformer segmentModelTransformer) {
-        super(lookupStore, topicStore, idCodec, clipsModelTransformer, clock);
+            ClipModelTransformer clipsModelTransformer, Clock clock,
+            SegmentModelTransformer segmentModelTransformer,
+            ImageModelTransformer imageModelTransformer) {
+
+        super(lookupStore, topicStore, idCodec, clipsModelTransformer, clock, imageModelTransformer);
         this.broadcastTransformer = BroadcastModelTransformer.create(channelResolver);
         this.encodingTransformer = EncodingModelTransformer.create();
         this.restrictionTransformer = RestrictionModelTransformer.create();

--- a/src/main/java/org/atlasapi/input/PersonModelTransformer.java
+++ b/src/main/java/org/atlasapi/input/PersonModelTransformer.java
@@ -1,23 +1,29 @@
 package org.atlasapi.input;
 
-import com.google.common.base.Function;
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.metabroadcast.common.time.Clock;
+import java.util.Set;
+
 import org.atlasapi.media.entity.LookupRef;
 import org.atlasapi.media.entity.simple.Person;
 import org.atlasapi.media.entity.simple.SameAs;
 import org.atlasapi.persistence.content.PeopleResolver;
 
-import java.util.Set;
+import com.metabroadcast.common.time.Clock;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 
 public class PersonModelTransformer extends DescribedModelTransformer<Person, org.atlasapi.media.entity.Person> {
 
     private PeopleResolver resolver;
 
-    public PersonModelTransformer(Clock clock, PeopleResolver resolver) {
-        super(clock);
+    public PersonModelTransformer(
+            Clock clock,
+            ImageModelTransformer imageModelTransformer,
+            PeopleResolver resolver)
+    {
+        super(clock, imageModelTransformer);
         this.resolver = resolver;
     }
     

--- a/src/main/java/org/atlasapi/input/SeriesModelTransformer.java
+++ b/src/main/java/org/atlasapi/input/SeriesModelTransformer.java
@@ -26,8 +26,11 @@ public class SeriesModelTransformer extends ContentModelTransformer<Playlist, Se
     public SeriesModelTransformer(LookupEntryStore lookupStore,
             TopicStore topicStore,
             NumberToShortStringCodec idCodec,
-            ClipModelTransformer clipsModelTransformer, Clock clock) {
-        super(lookupStore, topicStore, idCodec, clipsModelTransformer, clock);
+            ClipModelTransformer clipsModelTransformer,
+            Clock clock,
+            ImageModelTransformer imageModelTransformer) {
+
+        super(lookupStore, topicStore, idCodec, clipsModelTransformer, clock, imageModelTransformer);
         this.encodingTransformer = EncodingModelTransformer.create();
         this.restrictionTransformer = RestrictionModelTransformer.create();
     }

--- a/src/main/java/org/atlasapi/query/QueryExecutorModule.java
+++ b/src/main/java/org/atlasapi/query/QueryExecutorModule.java
@@ -10,6 +10,7 @@ import org.atlasapi.input.BrandModelTransformer;
 import org.atlasapi.input.ClipModelTransformer;
 import org.atlasapi.input.DefaultJacksonModelReader;
 import org.atlasapi.input.DelegatingModelTransformer;
+import org.atlasapi.input.ImageModelTransformer;
 import org.atlasapi.input.ItemModelTransformer;
 import org.atlasapi.input.SegmentModelTransformer;
 import org.atlasapi.input.SeriesModelTransformer;
@@ -178,7 +179,8 @@ public class QueryExecutorModule {
                 topicStore,
                 idCodec(),
                 clipTransformer(),
-                new SystemClock()
+                new SystemClock(),
+                ImageModelTransformer.create()
         );
     }
 
@@ -190,7 +192,8 @@ public class QueryExecutorModule {
                 idCodec(),
                 clipTransformer(),
                 new SystemClock(),
-                segmentModelTransformer()
+                segmentModelTransformer(),
+                ImageModelTransformer.create()
         );
     }
 
@@ -200,7 +203,8 @@ public class QueryExecutorModule {
                 topicStore,
                 idCodec(),
                 clipTransformer(),
-                new SystemClock()
+                new SystemClock(),
+                ImageModelTransformer.create()
         );
     }
 
@@ -211,7 +215,8 @@ public class QueryExecutorModule {
                 channelResolver,
                 idCodec(),
                 new SystemClock(),
-                segmentModelTransformer()
+                segmentModelTransformer(),
+                ImageModelTransformer.create()
         );
     }
 

--- a/src/main/java/org/atlasapi/query/QueryWebModule.java
+++ b/src/main/java/org/atlasapi/query/QueryWebModule.java
@@ -24,7 +24,7 @@ import org.atlasapi.feeds.youview.statistics.FeedStatisticsResolver;
 import org.atlasapi.input.ChannelGroupTransformer;
 import org.atlasapi.input.ChannelModelTransformer;
 import org.atlasapi.input.DefaultJacksonModelReader;
-import org.atlasapi.input.ImageModelTranslator;
+import org.atlasapi.input.ImageModelTransformer;
 import org.atlasapi.input.PersonModelTransformer;
 import org.atlasapi.input.TopicModelTransformer;
 import org.atlasapi.media.channel.CachingChannelGroupStore;
@@ -240,7 +240,7 @@ public class QueryWebModule {
                 .withChannelTransformer(
                         ChannelModelTransformer.create(
                                 v4ChannelCodec(),
-                                ImageModelTranslator.create()
+                                ImageModelTransformer.create()
                         )
                 )
                 .withOutputter(channelModelWriter())
@@ -479,7 +479,7 @@ public class QueryWebModule {
                 applicationFetcher,
                 personStore,
                 new DefaultJacksonModelReader(),
-                new PersonModelTransformer(new SystemClock(), personStore),
+                new PersonModelTransformer(new SystemClock(), ImageModelTransformer.create(), personStore),
                 personModelOutputter()
         );
     }

--- a/src/main/java/org/atlasapi/remotesite/barb/channels/BarbChannelsModule.java
+++ b/src/main/java/org/atlasapi/remotesite/barb/channels/BarbChannelsModule.java
@@ -2,27 +2,19 @@ package org.atlasapi.remotesite.barb.channels;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.google.common.base.Throwables;
+
 import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
 import com.metabroadcast.common.scheduling.RepetitionRule;
 import com.metabroadcast.common.scheduling.RepetitionRules;
-import com.metabroadcast.common.scheduling.ScheduledTask;
-import com.metabroadcast.common.scheduling.SimpleScheduler;
-import org.apache.commons.net.ftp.FTPClient;
-import org.apache.commons.net.ftp.FTPClientConfig;
+
 import org.atlasapi.input.ChannelModelTransformer;
-import org.atlasapi.input.ImageModelTranslator;
+import org.atlasapi.input.ImageModelTransformer;
 import org.atlasapi.media.channel.ChannelWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import sun.net.ftp.FtpClient;
-
-import javax.annotation.PostConstruct;
-import java.io.IOException;
 
 @Configuration
 public class BarbChannelsModule {
@@ -49,7 +41,7 @@ public class BarbChannelsModule {
     public BarbChannelsModule() {
         modelTransformer = ChannelModelTransformer.create(
                 SubstitutionTableNumberCodec.lowerCaseOnly(),
-                ImageModelTranslator.create()
+                ImageModelTransformer.create()
         );
     }
 

--- a/src/test/java/org/atlasapi/input/ChannelModelTransformerTest.java
+++ b/src/test/java/org/atlasapi/input/ChannelModelTransformerTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.when;
 public class ChannelModelTransformerTest {
 
     private NumberToShortStringCodec v4Codec = mock(NumberToShortStringCodec.class);
-    private ImageModelTranslator imageTranslator = mock(ImageModelTranslator.class);
+    private ImageModelTransformer imageTranslator = mock(ImageModelTransformer.class);
     private ChannelModelTransformer channelTransformer;
 
     @Before

--- a/src/test/java/org/atlasapi/input/ImageModelTransformerTest.java
+++ b/src/test/java/org/atlasapi/input/ImageModelTransformerTest.java
@@ -17,13 +17,13 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-public class ImageModelTranslatorTest {
+public class ImageModelTransformerTest {
 
-    private ImageModelTranslator translator;
+    private ImageModelTransformer translator;
 
     @Before
     public void setUp() throws Exception {
-        this.translator = new ImageModelTranslator();
+        this.translator = new ImageModelTransformer();
     }
 
     @Test

--- a/src/test/java/org/atlasapi/input/ItemModelTransformerTest.java
+++ b/src/test/java/org/atlasapi/input/ItemModelTransformerTest.java
@@ -63,7 +63,8 @@ public class ItemModelTransformerTest {
                 idCodec,
                 clipModelTransformer,
                 clock,
-                segmentModelTransformer
+                segmentModelTransformer,
+                ImageModelTransformer.create()
         );
 
         simpleRestriction = getSimpleRestriction();

--- a/src/test/java/org/atlasapi/remotesite/barb/channels/BarbStringToChannelTransformerTest.java
+++ b/src/test/java/org/atlasapi/remotesite/barb/channels/BarbStringToChannelTransformerTest.java
@@ -3,7 +3,7 @@ package org.atlasapi.remotesite.barb.channels;
 import java.util.Set;
 
 import org.atlasapi.input.ChannelModelTransformer;
-import org.atlasapi.input.ImageModelTranslator;
+import org.atlasapi.input.ImageModelTransformer;
 import org.atlasapi.media.channel.Channel;
 import org.atlasapi.media.entity.Alias;
 
@@ -27,7 +27,7 @@ public class BarbStringToChannelTransformerTest {
 
         modelTransformer = ChannelModelTransformer.create(
                 SubstitutionTableNumberCodec.lowerCaseOnly(),
-                mock(ImageModelTranslator.class)
+                mock(ImageModelTransformer.class)
         );
         barbTransformer = BarbStringToChannelTransformer.create(modelTransformer);
     }


### PR DESCRIPTION
For some unknown reason, the described model used its own (poor)
transformer logic, instead of using the more feature complete
ImageModelTransformer. This seeks to both consolidate all transformers
to use the ImageModelTransformer to complexify images, and also make
the ImageModelTransformer also complexify the Type field of Image.

This relates the new ingest-pa project (eng-989)